### PR TITLE
feat: add adaptive vacancy follow-up logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Vacalyser — AI-Powered Recruitment Need Analysis
 
-A modern Streamlit Cloud app that parses job ads, autofills key fields, and asks only the minimum follow-ups to complete a vacancy profile. Generates SEO-ready job ads, Boolean search strings, and interview guides. Styled with Tailwind (CDN) via a tiny component.
+A modern Streamlit Cloud app that parses job ads, autofills key fields, and now adapts its follow-up questions to gather a complete vacancy profile. Generates SEO-ready job ads, Boolean search strings, and interview guides. Styled with Tailwind (CDN) via a tiny component.
 
 ## Features
 - PDF/DOCX/TXT/URL ingestion
 - ESCO skill enrichment (preferred labels)
 - OpenAI prompts for extraction, suggestions, and content generation
 - Dynamic, low-friction wizard (EN/DE)
+- Adaptive follow-up questioning for comprehensive vacancy data
 
 ## Setup
 ```bash

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from wizard import (
     show_progress_bar,
     show_navigation,
     start_discovery_page,
+    followup_questions_page,
     company_information_page,
     role_description_page,
     task_scope_page,
@@ -27,9 +28,7 @@ inject_tailwind(theme="dark")
 if "current_section" not in st.session_state:
     st.session_state["current_section"] = 0
 if "lang" not in st.session_state:
-    st.session_state["lang"] = (
-        "de" if DEFAULT_LANGUAGE.startswith("de") else "en"
-    )
+    st.session_state["lang"] = "de" if DEFAULT_LANGUAGE.startswith("de") else "en"  # noqa: E501
 if "llm_model" not in st.session_state:
     st.session_state["llm_model"] = None
 
@@ -47,6 +46,7 @@ st.session_state["lang"] = "de" if lang_choice == "Deutsch" else "en"
 # Wizard steps
 sections = [
     {"name": "Start", "func": start_discovery_page},
+    {"name": "Follow-Ups", "func": followup_questions_page},
     {"name": "Company Info", "func": company_information_page},
     {"name": "Role Description", "func": role_description_page},
     {"name": "Tasks", "func": task_scope_page},

--- a/question_logic.py
+++ b/question_logic.py
@@ -1,0 +1,108 @@
+"""Logic for adaptive vacancy follow-up questions."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+import json
+
+from openai_utils import call_chat_api
+
+# Extended vacancy fields to ensure a comprehensive profile
+EXTENDED_FIELDS: List[str] = [
+    "company_name",
+    "location",
+    "company_website",
+    "industry",
+    "company_size",
+    "company_mission",
+    "department",
+    "team_structure",
+    "reporting_line",
+    "company_culture",
+    "diversity_inclusion",
+    "role_summary",
+    "tasks",
+    "responsibilities",
+    "requirements",
+    "experience_level",
+    "education_requirements",
+    "tools_technologies",
+    "certifications",
+    "languages_required",
+    "salary_range",
+    "bonus_compensation",
+    "benefits",
+    "health_benefits",
+    "retirement_benefits",
+    "learning_opportunities",
+    "equity_options",
+    "relocation_assistance",
+    "visa_sponsorship",
+    "remote_policy",
+    "onsite_requirements",
+    "travel_required",
+    "working_hours",
+    "contract_type",
+    "start_date",
+    "application_deadline",
+    "performance_metrics",
+]
+
+
+def generate_followup_questions(
+    extracted: Dict[str, Any],
+    num_questions: int = 8,
+    lang: str = "en",
+) -> List[Dict[str, str]]:
+    """Generate targeted follow-up questions for missing vacancy fields.
+
+    The function performs a lightweight chain-of-thought reasoning step via
+    the OpenAI API. It analyses the currently extracted vacancy data and
+    determines which of the :data:`EXTENDED_FIELDS` are missing or unclear.
+    It then asks the model to propose additional questions to fill those gaps.
+
+    Args:
+        extracted: Mapping of vacancy fields already known.
+        num_questions: Maximum number of follow-up questions to return.
+        lang: Language for the generated questions (``"en"`` or ``"de"``).
+
+    Returns:
+        A list of dictionaries with ``field`` and ``question`` keys.
+    """
+
+    payload = {field: extracted.get(field, "") for field in EXTENDED_FIELDS}
+    prompt = (
+        "You analyse vacancy data and ensure every field is complete. "
+        "First think step-by-step about missing or vague information. "
+        "Then respond with a JSON array of objects, each having 'field' and "
+        f"'question'. Provide at most {num_questions} questions in {lang}. "
+        "If nothing is missing, return an empty JSON array."
+    )
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a meticulous recruitment analyst.",
+        },
+        {
+            "role": "user",
+            "content": prompt
+            + "\nCurrent data:\n"
+            + json.dumps(payload, ensure_ascii=False),
+        },
+    ]
+    response = call_chat_api(messages, temperature=0.1, max_tokens=400)
+    try:
+        parsed = json.loads(response)
+    except json.JSONDecodeError:
+        parsed = []
+        for line in response.splitlines():
+            if "?" in line:
+                question = line.strip("-*0123456789. \t")
+                parsed.append({"field": "", "question": question})
+    result: List[Dict[str, str]] = []
+    for item in parsed:
+        field = item.get("field", "")
+        question = item.get("question", "")
+        if field or question:
+            result.append({"field": field, "question": question})
+    return result

--- a/tests/test_question_logic.py
+++ b/tests/test_question_logic.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from question_logic import generate_followup_questions  # noqa: E402
+
+
+def test_generate_followup_questions(monkeypatch):
+    """Ensure follow-up questions are parsed from model output."""
+
+    def fake_call_chat_api(messages, temperature=0.0, max_tokens=0, model=None) -> str:  # noqa: E501
+        return (
+            "[{\"field\": \"salary_range\", \"question\": "
+            "\"What is the salary range?\"}]"
+        )
+
+    monkeypatch.setattr(
+        "question_logic.call_chat_api", fake_call_chat_api
+    )
+    questions = generate_followup_questions({"company_name": "ACME"})
+    assert questions == [
+        {"field": "salary_range", "question": "What is the salary range?"}
+    ]

--- a/wizard.py
+++ b/wizard.py
@@ -1,9 +1,22 @@
 import streamlit as st
-from utils import extract_text_from_file, highlight_keywords, build_boolean_query, seo_optimize, ensure_logs_dir
-from openai_utils import suggest_additional_skills, suggest_role_tasks, generate_interview_guide, generate_job_ad
+from utils import (
+    extract_text_from_file,
+    build_boolean_query,
+    seo_optimize,
+    ensure_logs_dir,
+)
+from openai_utils import (
+    suggest_additional_skills,
+    suggest_role_tasks,
+    generate_interview_guide,
+    generate_job_ad,
+)
+from question_logic import generate_followup_questions, EXTENDED_FIELDS
+
 
 def apply_global_styling():
-    st.markdown("""
+    st.markdown(
+        """
     <style>
     @import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;400;700&display=swap');
     body, .stApp { background-color: #0b0f14; color: #e5e7eb; font-family: 'Comfortaa', sans-serif; }
@@ -11,14 +24,18 @@ def apply_global_styling():
     .card { background-color: #111827; padding: 1rem; border-radius: 12px; margin-bottom: 1.25rem; }
     .stButton > button { border-radius: 10px; }
     </style>
-    """, unsafe_allow_html=True)
+    """,
+        unsafe_allow_html=True,
+    )
+
 
 def show_progress_bar(current_step: int, total_steps: int):
     progress = (current_step + 1) / total_steps
     st.progress(progress, text=f"{int(progress*100)}% complete")
 
+
 def show_navigation(current_step: int, total_steps: int):
-    col1, col2, col3 = st.columns([1,2,1])
+    col1, col2, col3 = st.columns([1, 2, 1])
     with col1:
         if current_step > 0:
             if st.button("⬅ Previous"):
@@ -30,24 +47,45 @@ def show_navigation(current_step: int, total_steps: int):
                 st.session_state["current_section"] += 1
                 st.rerun()
 
+
 def start_discovery_page():
     lang = st.session_state.get("lang", "en")
-    st.header("🔍 Start Your Analysis with Vacalyser" if lang!="de" else "🔍 Starten Sie Ihre Analyse mit Vacalyser")
-    st.caption("Upload a job ad or paste a URL. We’ll extract everything we can — then ask only what’s missing.")
+    st.header(
+        "🔍 Start Your Analysis with Vacalyser"
+        if lang != "de"
+        else "🔍 Starten Sie Ihre Analyse mit Vacalyser"
+    )
+    st.caption(
+        "Upload a job ad or paste a URL. We’ll extract everything we can — then ask only what’s missing."
+    )
 
     colA, colB = st.columns(2)
     with colA:
-        job_title = st.text_input("Job Title" if lang!="de" else "Stellenbezeichnung",
-                                  st.session_state.get("job_title",""))
+        job_title = st.text_input(
+            "Job Title" if lang != "de" else "Stellenbezeichnung",
+            st.session_state.get("job_title", ""),
+        )
         if job_title:
             st.session_state["job_title"] = job_title
-        input_url = st.text_input("Job Ad URL (optional)" if lang!="de" else "Stellenanzeigen-URL (optional)",
-                                  st.session_state.get("input_url",""))
+        input_url = st.text_input(
+            (
+                "Job Ad URL (optional)"
+                if lang != "de"
+                else "Stellenanzeigen-URL (optional)"
+            ),
+            st.session_state.get("input_url", ""),
+        )
         if input_url:
             st.session_state["input_url"] = input_url
     with colB:
-        uploaded_file = st.file_uploader("Upload Job Ad (PDF, DOCX, TXT)" if lang!="de" else "Stellenanzeige hochladen (PDF, DOCX, TXT)",
-                                         type=["pdf","docx","txt"])
+        uploaded_file = st.file_uploader(
+            (
+                "Upload Job Ad (PDF, DOCX, TXT)"
+                if lang != "de"
+                else "Stellenanzeige hochladen (PDF, DOCX, TXT)"
+            ),
+            type=["pdf", "docx", "txt"],
+        )
         if uploaded_file is not None:
             file_bytes = uploaded_file.read()
             text = extract_text_from_file(file_bytes, uploaded_file.name)
@@ -63,11 +101,13 @@ def start_discovery_page():
             try:
                 from readability import Document
                 import requests
+
                 r = requests.get(st.session_state["input_url"], timeout=8)
                 if r.status_code == 200:
                     doc = Document(r.text)
                     # Keep text only — a quick heuristic
                     from bs4 import BeautifulSoup
+
                     soup = BeautifulSoup(doc.summary(), "lxml")
                     combined_text += soup.get_text("\n")
             except Exception:
@@ -81,10 +121,7 @@ def start_discovery_page():
             st.warning("⚠️ No text available to analyze.")
             return
 
-        fields = ["company_name","location","company_website","industry","role_summary",
-                  "tasks","requirements","salary_range","benefits",
-                  "health_benefits","learning_opportunities","remote_policy","travel_required"]
-        field_list = "".join([f"- {f}\n" for f in fields])
+        field_list = "".join([f"- {f}\n" for f in EXTENDED_FIELDS])
         extract_prompt = (
             "Extract the following fields from the job ad text. Return ONLY a JSON object with these keys:\n"
             f"{field_list}\n"
@@ -92,46 +129,100 @@ def start_discovery_page():
             f"Text:\n{combined_text}"
         )
         from openai_utils import call_chat_api
-        messages = [{"role":"user","content":extract_prompt}]
+
+        messages = [{"role": "user", "content": extract_prompt}]
         resp = call_chat_api(messages, model=st.session_state.get("llm_model"))
         import json
+
         try:
             parsed = json.loads(resp)
-            for k,v in parsed.items():
-                st.session_state[k] = "\n".join(v) if isinstance(v,list) else str(v)
+            for k, v in parsed.items():
+                st.session_state[k] = "\n".join(v) if isinstance(v, list) else str(v)
+            followups = generate_followup_questions(st.session_state, lang=lang)
+            st.session_state["followup_questions"] = followups
             st.success("✅ Key information extracted successfully!")
-            log_event(f"ANALYZE by {st.session_state.get('user','anonymous')} title='{st.session_state.get('job_title','')}'")
+            log_event(
+                f"ANALYZE by {st.session_state.get('user', 'anonymous')} "
+                f"title='{st.session_state.get('job_title', '')}'"
+            )
         except json.JSONDecodeError:
             st.error("❌ Could not parse AI response as JSON.")
 
+
+def followup_questions_page():
+    """Display dynamically generated follow-up questions to the user."""
+    lang = st.session_state.get("lang", "en")
+    st.header("❓ Additional Questions" if lang != "de" else "❓ Zusätzliche Fragen")
+    followups = st.session_state.get("followup_questions", [])
+    if not followups:
+        st.info(
+            "No further questions – vacancy profile looks complete."
+            if lang != "de"
+            else "Keine weiteren Fragen – Profil vollständig."
+        )
+        return
+    for item in followups:
+        field = item.get("field", "")
+        question = item.get("question", "")
+        key = field or question
+        st.session_state[field] = st.text_input(
+            question, st.session_state.get(field, ""), key=key
+        )
+
+
 def company_information_page():
-    lang = st.session_state.get("lang","en")
-    st.header("🏢 Company Information" if lang!="de" else "🏢 Firmeninformationen")
-    st.session_state["company_name"] = st.text_input("Company Name" if lang!="de" else "Unternehmensname",
-                                                     st.session_state.get("company_name",""))
-    st.session_state["industry"] = st.text_input("Industry" if lang!="de" else "Branche",
-                                                 st.session_state.get("industry",""))
-    st.session_state["location"] = st.text_input("Location" if lang!="de" else "Standort",
-                                                 st.session_state.get("location",""))
-    st.session_state["company_website"] = st.text_input("Company Website" if lang!="de" else "Webseite",
-                                                        st.session_state.get("company_website",""))
+    lang = st.session_state.get("lang", "en")
+    st.header("🏢 Company Information" if lang != "de" else "🏢 Firmeninformationen")
+    st.session_state["company_name"] = st.text_input(
+        "Company Name" if lang != "de" else "Unternehmensname",
+        st.session_state.get("company_name", ""),
+    )
+    st.session_state["industry"] = st.text_input(
+        "Industry" if lang != "de" else "Branche", st.session_state.get("industry", "")
+    )
+    st.session_state["location"] = st.text_input(
+        "Location" if lang != "de" else "Standort", st.session_state.get("location", "")
+    )
+    st.session_state["company_website"] = st.text_input(
+        "Company Website" if lang != "de" else "Webseite",
+        st.session_state.get("company_website", ""),
+    )
+
 
 def role_description_page():
-    lang = st.session_state.get("lang","en")
-    st.header("📋 Role Description" if lang!="de" else "📋 Stellenbeschreibung")
-    st.session_state["role_summary"] = st.text_area("Role Summary" if lang!="de" else "Rollenbeschreibung",
-                                                    st.session_state.get("role_summary",""), height=100)
-    st.session_state["requirements"] = st.text_area("Requirements/Qualifications" if lang!="de" else "Anforderungen/Qualifikationen",
-                                                    st.session_state.get("requirements",""), height=100)
+    lang = st.session_state.get("lang", "en")
+    st.header("📋 Role Description" if lang != "de" else "📋 Stellenbeschreibung")
+    st.session_state["role_summary"] = st.text_area(
+        "Role Summary" if lang != "de" else "Rollenbeschreibung",
+        st.session_state.get("role_summary", ""),
+        height=100,
+    )
+    st.session_state["requirements"] = st.text_area(
+        (
+            "Requirements/Qualifications"
+            if lang != "de"
+            else "Anforderungen/Qualifikationen"
+        ),
+        st.session_state.get("requirements", ""),
+        height=100,
+    )
+
 
 def task_scope_page():
-    lang = st.session_state.get("lang","en")
-    st.header("📝 Key Tasks & Responsibilities" if lang!="de" else "📝 Wichtige Aufgaben & Verantwortlichkeiten")
-    tasks_text = st.text_area("Tasks (one per line)" if lang!="de" else "Aufgaben (eine pro Zeile)",
-                              st.session_state.get("tasks",""), height=150)
+    lang = st.session_state.get("lang", "en")
+    st.header(
+        "📝 Key Tasks & Responsibilities"
+        if lang != "de"
+        else "📝 Wichtige Aufgaben & Verantwortlichkeiten"
+    )
+    tasks_text = st.text_area(
+        "Tasks (one per line)" if lang != "de" else "Aufgaben (eine pro Zeile)",
+        st.session_state.get("tasks", ""),
+        height=150,
+    )
     st.session_state["tasks"] = tasks_text
     if st.button("💡 Suggest Tasks"):
-        title = st.session_state.get("job_title","")
+        title = st.session_state.get("job_title", "")
         suggestions = suggest_role_tasks(title, num_tasks=5)
         if suggestions:
             current = tasks_text.splitlines() if tasks_text else []
@@ -144,28 +235,43 @@ def task_scope_page():
         else:
             st.warning("No suggestions available.")
 
+
 def skills_competencies_page():
-    lang = st.session_state.get("lang","en")
-    st.header("🛠️ Required Skills & Competencies" if lang!="de" else "🛠️ Erforderliche Fähigkeiten & Kompetenzen")
-    hard_skills = st.text_area("Hard/Technical Skills" if lang!="de" else "Fachliche (Hard) Skills",
-                               st.session_state.get("hard_skills", st.session_state.get("requirements","")),
-                               height=100)
+    lang = st.session_state.get("lang", "en")
+    st.header(
+        "🛠️ Required Skills & Competencies"
+        if lang != "de"
+        else "🛠️ Erforderliche Fähigkeiten & Kompetenzen"
+    )
+    hard_skills = st.text_area(
+        "Hard/Technical Skills" if lang != "de" else "Fachliche (Hard) Skills",
+        st.session_state.get("hard_skills", st.session_state.get("requirements", "")),
+        height=100,
+    )
     st.session_state["hard_skills"] = hard_skills
-    soft_skills = st.text_area("Soft Skills" if lang!="de" else "Soft Skills",
-                               st.session_state.get("soft_skills",""), height=100)
+    soft_skills = st.text_area(
+        "Soft Skills" if lang != "de" else "Soft Skills",
+        st.session_state.get("soft_skills", ""),
+        height=100,
+    )
     st.session_state["soft_skills"] = soft_skills
     if st.button("💡 Suggest Additional Skills"):
-        title = st.session_state.get("job_title","")
-        tasks = st.session_state.get("tasks","")
+        title = st.session_state.get("job_title", "")
+        tasks = st.session_state.get("tasks", "")
         existing = []
         if hard_skills:
             existing += [s.strip() for s in hard_skills.splitlines() if s.strip()]
         if soft_skills:
             existing += [s.strip() for s in soft_skills.splitlines() if s.strip()]
-        suggestions = suggest_additional_skills(title, tasks, existing, num_suggestions=10,
-                                                lang=("de" if lang=="de" else "en"))
-        tech = suggestions.get("technical",[])
-        soft = suggestions.get("soft",[])
+        suggestions = suggest_additional_skills(
+            title,
+            tasks,
+            existing,
+            num_suggestions=10,
+            lang=("de" if lang == "de" else "en"),
+        )
+        tech = suggestions.get("technical", [])
+        soft = suggestions.get("soft", [])
         updated_hard = existing + [s for s in tech if s and s not in existing]
         updated_soft = [s for s in soft if s and s not in existing]
         st.session_state["hard_skills"] = "\n".join(updated_hard)
@@ -173,46 +279,70 @@ def skills_competencies_page():
         st.success("✔️ Added skill suggestions.")
         st.rerun()
 
+
 def benefits_compensation_page():
-    lang = st.session_state.get("lang","en")
-    st.header("💰 Benefits & Compensation" if lang!="de" else "💰 Vergütung & Vorteile")
-    st.session_state["salary_range"] = st.text_input("Salary Range",
-                                                     st.session_state.get("salary_range",""))
-    st.session_state["benefits"] = st.text_area("Benefits/Perks",
-                                                st.session_state.get("benefits",""), height=100)
-    st.session_state["health_benefits"] = st.text_area("Healthcare Benefits",
-                                                       st.session_state.get("health_benefits",""), height=70)
-    st.session_state["learning_opportunities"] = st.text_area("Learning & Development Opportunities",
-                                                              st.session_state.get("learning_opportunities",""), height=70)
-    st.session_state["remote_policy"] = st.text_input("Remote Work Policy",
-                                                      st.session_state.get("remote_policy",""))
-    st.session_state["travel_required"] = st.text_input("Travel Requirements",
-                                                        st.session_state.get("travel_required",""))
+    lang = st.session_state.get("lang", "en")
+    st.header(
+        "💰 Benefits & Compensation" if lang != "de" else "💰 Vergütung & Vorteile"
+    )
+    st.session_state["salary_range"] = st.text_input(
+        "Salary Range", st.session_state.get("salary_range", "")
+    )
+    st.session_state["benefits"] = st.text_area(
+        "Benefits/Perks", st.session_state.get("benefits", ""), height=100
+    )
+    st.session_state["health_benefits"] = st.text_area(
+        "Healthcare Benefits", st.session_state.get("health_benefits", ""), height=70
+    )
+    st.session_state["learning_opportunities"] = st.text_area(
+        "Learning & Development Opportunities",
+        st.session_state.get("learning_opportunities", ""),
+        height=70,
+    )
+    st.session_state["remote_policy"] = st.text_input(
+        "Remote Work Policy", st.session_state.get("remote_policy", "")
+    )
+    st.session_state["travel_required"] = st.text_input(
+        "Travel Requirements", st.session_state.get("travel_required", "")
+    )
+
 
 def recruitment_process_page():
-    lang = st.session_state.get("lang","en")
-    st.header("🏁 Recruitment Process" if lang!="de" else "🏁 Einstellungsprozess")
-    st.session_state["interview_stages"] = int(st.number_input(
-        "Number of Interview Rounds" if lang!="de" else "Anzahl der Interviewrunden",
-        min_value=0, step=1, value=int(st.session_state.get("interview_stages",0))
-    ))
-    st.session_state["process_notes"] = st.text_area("Additional Hiring Process Notes" if lang!="de" else "Weitere Hinweise zum Prozess",
-                                                     st.session_state.get("process_notes",""), height=80)
+    lang = st.session_state.get("lang", "en")
+    st.header("🏁 Recruitment Process" if lang != "de" else "🏁 Einstellungsprozess")
+    st.session_state["interview_stages"] = int(
+        st.number_input(
+            (
+                "Number of Interview Rounds"
+                if lang != "de"
+                else "Anzahl der Interviewrunden"
+            ),
+            min_value=0,
+            step=1,
+            value=int(st.session_state.get("interview_stages", 0)),
+        )
+    )
+    st.session_state["process_notes"] = st.text_area(
+        (
+            "Additional Hiring Process Notes"
+            if lang != "de"
+            else "Weitere Hinweise zum Prozess"
+        ),
+        st.session_state.get("process_notes", ""),
+        height=80,
+    )
+
 
 def summary_outputs_page():
-    lang = st.session_state.get("lang","en")
-    st.header("📊 Summary & Outputs" if lang!="de" else "📊 Zusammenfassung & Ergebnisse")
-
-    st.write(f"**Job Title:** {st.session_state.get('job_title','')}")
-    st.write(f"**Company:** {st.session_state.get('company_name','')}")
-    st.write(f"**Location:** {st.session_state.get('location','')}")
-    st.write(f"**Industry:** {st.session_state.get('industry','')}")
-    st.write(f"**Role Summary:** {st.session_state.get('role_summary','')}")
-    st.write(f"**Key Tasks:** {st.session_state.get('tasks','').replace('\\n','; ')}")
-    st.write(f"**Hard Skills:** {st.session_state.get('hard_skills','').replace('\\n','; ')}")
-    st.write(f"**Soft Skills:** {st.session_state.get('soft_skills','').replace('\\n','; ')}")
-    st.write(f"**Benefits:** {st.session_state.get('benefits','').replace('\\n','; ')}")
-    st.write(f"**Salary Range:** {st.session_state.get('salary_range','')}")
+    lang = st.session_state.get("lang", "en")
+    st.header(
+        "📊 Summary & Outputs" if lang != "de" else "📊 Zusammenfassung & Ergebnisse"
+    )
+    for field in ["job_title"] + EXTENDED_FIELDS + ["hard_skills", "soft_skills"]:
+        value = st.session_state.get(field)
+        if value:
+            display = str(value).replace("\n", "; ")
+            st.write(f"**{field.replace('_', ' ').title()}:** {display}")
 
     colA, colB = st.columns(2)
     with colA:
@@ -225,26 +355,34 @@ def summary_outputs_page():
                 st.markdown(f"**SEO Keywords:** `{', '.join(seo['keywords'])}`")
             if seo["meta_description"]:
                 st.markdown(f"**Meta Description:** {seo['meta_description']}")
-            log_event(f"JOB_AD by {st.session_state.get('user','anonymous')}")
+            log_event(f"JOB_AD by {st.session_state.get('user', 'anonymous')}")
     with colB:
         if st.button("📝 Generate Interview Guide"):
-            title = st.session_state.get("job_title","")
-            tasks = st.session_state.get("tasks","")
-            guide = generate_interview_guide(title, tasks, audience="hiring managers", num_questions=5)
+            title = st.session_state.get("job_title", "")
+            tasks = st.session_state.get("tasks", "")
+            guide = generate_interview_guide(
+                title, tasks, audience="hiring managers", num_questions=5
+            )
             st.subheader("Interview Guide & Scoring Rubrics")
             st.write(guide)
-            log_event(f"INTERVIEW_GUIDE by {st.session_state.get('user','anonymous')}")
+            log_event(f"INTERVIEW_GUIDE by {st.session_state.get('user', 'anonymous')}")
 
     if st.session_state.get("job_title") or st.session_state.get("hard_skills"):
         bool_query = build_boolean_query(
-            st.session_state.get("job_title",""),
-            (st.session_state.get("hard_skills","") + "\n" + st.session_state.get("soft_skills","")).splitlines()
+            st.session_state.get("job_title", ""),
+            (
+                st.session_state.get("hard_skills", "")
+                + "\n"
+                + st.session_state.get("soft_skills", "")
+            ).splitlines(),
         )
         if bool_query:
             st.info(f"**Boolean Search Query:** `{bool_query}`")
 
+
 def log_event(event_text: str):
     import datetime
+
     ensure_logs_dir()
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     entry = f"[{timestamp}] {event_text}\n"


### PR DESCRIPTION
## Summary
- introduce `question_logic` module with extended vacancy fields and dynamic follow-up question generation
- wire new logic into wizard and app, adding adaptive follow-up page and comprehensive summary output
- add unit test for question logic and update README for adaptive questioning

## Testing
- `ruff check --fix question_logic.py app.py wizard.py tests/test_question_logic.py`
- `flake8 .` *(fails: many pre-existing E501/E302 issues across repo)*
- `pytest -q`
- `mypy question_logic.py app.py wizard.py tests/test_question_logic.py` *(fails: missing stubs and type annotations in existing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68989cbb14e083209e13ea7ad28f56d8