### PR TITLE
feat: improve input ingestion with OCR and URL parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A modern Streamlit Cloud app that parses job ads, autofills key fields, and now adapts its follow-up questions to gather a complete vacancy profile. Generates SEO-ready job ads, Boolean search strings, and interview guides. Styled with Tailwind (CDN) via a tiny component.
 
 ## Features
-- PDF/DOCX/TXT/URL ingestion
+- Robust PDF/DOCX/TXT/URL ingestion with OCR for scanned PDFs
 - ESCO skill enrichment (preferred labels)
 - OpenAI prompts for extraction, suggestions, and content generation
 - Dynamic, low-friction wizard (EN/DE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ readability-lxml>=0.8.1
 lxml>=5.2.1
 beautifulsoup4>=4.12.3
 python-dotenv>=1.0.1
+pytesseract>=0.3.10
+Pillow>=10.3.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,69 @@
+import fitz
+from io import BytesIO
+import docx
+
+import utils
+
+
+def test_extract_text_from_file_pdf():
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Hello PDF")
+    pdf_bytes = doc.tobytes()
+    text = utils.extract_text_from_file(pdf_bytes, "sample.pdf")
+    assert "Hello PDF" in text
+
+
+def test_extract_text_from_file_docx():
+    document = docx.Document()
+    document.add_paragraph("Hello DOCX")
+    buffer = BytesIO()
+    document.save(buffer)
+    text = utils.extract_text_from_file(buffer.getvalue(), "sample.docx")
+    assert "Hello DOCX" in text
+
+
+def test_extract_text_from_file_pdf_ocr(monkeypatch):
+    doc = fitz.open()
+    doc.new_page()
+    pdf_bytes = doc.tobytes()
+
+    import pytesseract
+
+    def fake_ocr(_img):
+        return "SCANNED TEXT"
+
+    monkeypatch.setattr(pytesseract, "image_to_string", fake_ocr)
+    text = utils.extract_text_from_file(pdf_bytes, "scan.pdf")
+    assert "SCANNED TEXT" in text
+
+
+def test_extract_text_from_url(monkeypatch):
+    html = (
+        "<html><body><h1>Title</h1><p>Hello URL</p>"
+        "<script>nope</script></body></html>"
+    )
+
+    class Resp:
+        status_code = 200
+        text = html
+
+    def fake_get(_url, timeout):
+        return Resp()
+
+    import requests
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    import readability
+
+    class DummyDoc:
+        def __init__(self, text):
+            self.text = text
+
+        def summary(self):
+            return self.text
+
+    monkeypatch.setattr(readability, "Document", lambda html: DummyDoc(html))
+
+    text = utils.extract_text_from_url("http://example.com")
+    assert "Hello URL" in text and "nope" not in text

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,26 @@
+"""Utility helpers for the Vacalyser app."""
+
 import os
-import fitz  # PyMuPDF
-from io import BytesIO
 import re
+from io import BytesIO
+
+import fitz  # PyMuPDF
+
 
 def extract_text_from_file(file_bytes: bytes, file_name: str) -> str:
+    """Extract text content from an uploaded file.
+
+    Supports PDFs (with optional OCR for scanned pages), DOCX/DOC documents
+    and plain text files.
+
+    Args:
+        file_bytes: Raw file data.
+        file_name: Original filename used to infer the type.
+
+    Returns:
+        Extracted text content, stripped of leading/trailing whitespace.
+    """
+
     if not file_bytes:
         return ""
     file_name = file_name.lower()
@@ -12,9 +29,22 @@ def extract_text_from_file(file_bytes: bytes, file_name: str) -> str:
         if file_name.endswith(".pdf"):
             with fitz.open(stream=file_bytes, filetype="pdf") as doc:
                 for page in doc:
-                    text += page.get_text()
+                    page_text = page.get_text().strip()
+                    if page_text:
+                        text += page_text + "\n"
+                    else:  # fallback to OCR for scanned pages
+                        try:
+                            import pytesseract
+                            from PIL import Image
+
+                            pix = page.get_pixmap()
+                            img = Image.open(BytesIO(pix.tobytes("png")))
+                            text += pytesseract.image_to_string(img) + "\n"
+                        except Exception:
+                            pass
         elif file_name.endswith(".docx") or file_name.endswith(".doc"):
             import docx
+
             doc = docx.Document(BytesIO(file_bytes))
             full_text = [para.text for para in doc.paragraphs]
             text = "\n".join(full_text)
@@ -22,13 +52,64 @@ def extract_text_from_file(file_bytes: bytes, file_name: str) -> str:
             text = file_bytes.decode("utf-8", errors="ignore")
     except Exception:
         text = ""
-    return text.strip()
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return "\n".join(lines)
+
+
+def extract_text_from_url(url: str) -> str:
+    """Fetch and clean the main textual content from a web page.
+
+    Args:
+        url: Web page URL.
+
+    Returns:
+        Cleaned textual content or an empty string if retrieval fails.
+    """
+
+    try:
+        from readability import Document
+        import requests
+        from bs4 import BeautifulSoup
+
+        response = requests.get(url, timeout=8)
+        if response.status_code != 200:
+            return ""
+        doc = Document(response.text)
+        soup = BeautifulSoup(doc.summary(), "lxml")
+        for tag in soup(["script", "style"]):
+            tag.decompose()
+        text = soup.get_text("\n")
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        return "\n".join(lines)
+    except Exception:
+        return ""
+
+
+def merge_texts(*parts: str) -> str:
+    """Combine multiple text fragments into one string.
+
+    Empty or whitespace-only parts are ignored. Remaining fragments are
+    joined using newline separators.
+
+    Args:
+        *parts: Arbitrary text snippets.
+
+    Returns:
+        Merged text.
+    """
+
+    cleaned = [p.strip() for p in parts if p and p.strip()]
+    return "\n".join(cleaned)
+
 
 def highlight_keywords(text: str, keywords: list[str]) -> str:
     if not text or not keywords:
         return text
-    pattern = re.compile("|".join([re.escape(k) for k in keywords]), re.IGNORECASE)
+    pattern = re.compile(
+        "|".join([re.escape(k) for k in keywords]), re.IGNORECASE
+    )
     return pattern.sub(lambda m: f"**{m.group(0)}**", text)
+
 
 def build_boolean_query(job_title: str, skills: list[str]) -> str:
     job_title_part = f"\"{job_title}\"" if job_title else ""
@@ -40,6 +121,7 @@ def build_boolean_query(job_title: str, skills: list[str]) -> str:
         return job_title_part
     else:
         return " OR ".join(skill_terms)
+
 
 def seo_optimize(text: str, max_keywords: int = 5) -> dict:
     result = {"keywords": [], "meta_description": ""}
@@ -60,6 +142,7 @@ def seo_optimize(text: str, max_keywords: int = 5) -> dict:
         first_sentence = first_sentence[:157] + "..."
     result["meta_description"] = first_sentence.strip()
     return result
+
 
 def ensure_logs_dir():
     try:

--- a/wizard.py
+++ b/wizard.py
@@ -1,6 +1,8 @@
 import streamlit as st
 from utils import (
     extract_text_from_file,
+    extract_text_from_url,
+    merge_texts,
     build_boolean_query,
     seo_optimize,
     ensure_logs_dir,
@@ -96,28 +98,17 @@ def start_discovery_page():
                 st.error("❌ Failed to extract text from the file.")
 
     if st.button("🔎 Analyze"):
-        combined_text = ""
+        url_text = ""
         if st.session_state.get("input_url"):
-            try:
-                from readability import Document
-                import requests
-
-                r = requests.get(st.session_state["input_url"], timeout=8)
-                if r.status_code == 200:
-                    doc = Document(r.text)
-                    # Keep text only — a quick heuristic
-                    from bs4 import BeautifulSoup
-
-                    soup = BeautifulSoup(doc.summary(), "lxml")
-                    combined_text += soup.get_text("\n")
-            except Exception:
+            url_text = extract_text_from_url(st.session_state["input_url"])
+            if not url_text:
                 st.warning("Unable to fetch/parse URL content.")
-        if st.session_state.get("uploaded_text"):
-            combined_text += "\n" + st.session_state["uploaded_text"]
-        if st.session_state.get("job_title") and not combined_text.strip():
+        file_text = st.session_state.get("uploaded_text", "")
+        combined_text = merge_texts(url_text, file_text)
+        if st.session_state.get("job_title") and not combined_text:
             combined_text = st.session_state["job_title"]
 
-        if not combined_text.strip():
+        if not combined_text:
             st.warning("⚠️ No text available to analyze.")
             return
 


### PR DESCRIPTION
## Summary
- add OCR-enabled PDF extraction, URL text cleaner, and text merge helper
- wire new helpers into discovery step for seamless multi-source ingestion
- cover file and URL extraction utilities with tests

## Testing
- `ruff check --fix utils.py tests/test_utils.py wizard.py`
- `flake8 utils.py tests/test_utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a14b93208320a45d9d056cb5d4c2