### PR TITLE
feat: classify job roles with ESCO to tailor questions

### DIFF
--- a/esco_utils.py
+++ b/esco_utils.py
@@ -1,6 +1,12 @@
+"""Utilities for interacting with the ESCO API."""
+
+from typing import Dict
+
 import requests
 
-_esco_cache = {}
+_esco_cache: Dict[tuple[str, str], Dict] = {}
+_occupation_cache: Dict[tuple[str, str], Dict[str, str]] = {}
+
 
 def lookup_esco_skill(skill_name: str, lang: str = "en") -> dict:
     if not skill_name:
@@ -19,13 +25,18 @@ def lookup_esco_skill(skill_name: str, lang: str = "en") -> dict:
                 preferred = skill.get("preferredLabel", {})
                 label = preferred.get(lang) or preferred.get("en") or skill_name
                 desc = skill.get("description", {}).get(lang) or ""
-                result = {"preferredLabel": label, "type": skill.get("type",""), "description": desc}
+                result = {
+                    "preferredLabel": label,
+                    "type": skill.get("type", ""),
+                    "description": desc,
+                }
                 _esco_cache[key] = result
                 return result
     except Exception:
         pass
     _esco_cache[key] = {}
     return {}
+
 
 def enrich_skills_with_esco(skill_list: list[str], lang: str = "en") -> list[str]:
     enriched = []
@@ -35,3 +46,54 @@ def enrich_skills_with_esco(skill_list: list[str], lang: str = "en") -> list[str
         res = lookup_esco_skill(skill, lang=lang)
         enriched.append(res.get("preferredLabel") or skill)
     return enriched
+
+
+def classify_occupation(job_title: str, lang: str = "en") -> Dict[str, str]:
+    """Return the closest ESCO occupation for a job title.
+
+    The function queries the ESCO search API to find the best matching
+    occupation for ``job_title``. It also resolves the broader ISCO group to
+    provide a general category, which can later be used to tailor
+    questionnaire flows.
+
+    Args:
+        job_title: Raw job title string provided by the user.
+        lang: Preferred language code for labels.
+
+    Returns:
+        A dictionary containing ``preferredLabel`` and ``group`` keys. Empty
+        if no match was found or the API call failed.
+    """
+
+    if not job_title:
+        return {}
+    cache_key = (job_title.lower(), lang)
+    if cache_key in _occupation_cache:
+        return _occupation_cache[cache_key]
+    try:
+        search_url = "https://ec.europa.eu/esco/api/search"
+        params = {"type": "occupation", "text": job_title, "language": lang, "limit": 1}
+        resp = requests.get(search_url, params=params, timeout=5)
+        if resp.status_code == 200:
+            data = resp.json()
+            results = data.get("_embedded", {}).get("results", [])
+            if results:
+                occ = results[0]
+                label = occ.get("preferredLabel", {}).get(lang) or occ.get("title", "")
+                group_uri = (occ.get("broaderIscoGroup") or [None])[0]
+                group_label = ""
+                if group_uri:
+                    group_resp = requests.get(
+                        "https://ec.europa.eu/esco/api/resource",
+                        params={"uri": group_uri},
+                        timeout=5,
+                    )
+                    if group_resp.status_code == 200:
+                        group_label = group_resp.json().get("title", "")
+                result = {"preferredLabel": label, "group": group_label}
+                _occupation_cache[cache_key] = result
+                return result
+    except Exception:
+        pass
+    _occupation_cache[cache_key] = {}
+    return {}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/tests/test_esco_utils.py
+++ b/tests/test_esco_utils.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from esco_utils import classify_occupation  # noqa: E402
+
+
+def test_classify_occupation(monkeypatch):
+    """Classification should return label and group from ESCO."""
+
+    def fake_get(url, params=None, timeout=5):
+        class Resp:
+            status_code = 200
+
+            def __init__(self, data):
+                self._data = data
+
+            def json(self):
+                return self._data
+
+        if "search" in url:
+            data = {
+                "_embedded": {
+                    "results": [
+                        {
+                            "preferredLabel": {"en": "software developer"},
+                            "broaderIscoGroup": [
+                                "http://data.europa.eu/esco/isco/C2512"
+                            ],
+                        }
+                    ]
+                }
+            }
+            return Resp(data)
+        data = {"title": "Software developers"}
+        return Resp(data)
+
+    monkeypatch.setattr("esco_utils.requests.get", fake_get)
+    res = classify_occupation("Software engineer")
+    assert res == {
+        "preferredLabel": "software developer",
+        "group": "Software developers",
+    }

--- a/tests/test_question_logic.py
+++ b/tests/test_question_logic.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
@@ -9,16 +10,39 @@ from question_logic import generate_followup_questions  # noqa: E402
 def test_generate_followup_questions(monkeypatch):
     """Ensure follow-up questions are parsed from model output."""
 
-    def fake_call_chat_api(messages, temperature=0.0, max_tokens=0, model=None) -> str:  # noqa: E501
-        return (
-            "[{\"field\": \"salary_range\", \"question\": "
-            "\"What is the salary range?\"}]"
-        )
+    def fake_call_chat_api(
+        messages, temperature=0.0, max_tokens=0, model=None
+    ) -> str:  # noqa: E501
+        return '[{"field": "salary_range", "question": ' '"What is the salary range?"}]'
 
-    monkeypatch.setattr(
-        "question_logic.call_chat_api", fake_call_chat_api
-    )
+    monkeypatch.setattr("question_logic.call_chat_api", fake_call_chat_api)
     questions = generate_followup_questions({"company_name": "ACME"})
     assert questions == [
         {"field": "salary_range", "question": "What is the salary range?"}
     ]
+
+
+def test_role_specific_payload(monkeypatch):
+    """Classification should add role-specific fields to the payload."""
+
+    captured = {}
+
+    def fake_call_chat_api(
+        messages, temperature=0.0, max_tokens=0, model=None
+    ) -> str:  # noqa: E501
+        captured["payload"] = messages[1]["content"]
+        return "[]"
+
+    def fake_classify(job_title, lang="en"):
+        return {"preferredLabel": "Software developer", "group": "Software developers"}
+
+    monkeypatch.setattr("question_logic.call_chat_api", fake_call_chat_api)
+    monkeypatch.setattr("question_logic.classify_occupation", fake_classify)
+
+    generate_followup_questions({"job_title": "Software engineer"})
+
+    payload_json = captured["payload"].split("Current data:\n", 1)[1]
+    data = json.loads(payload_json)
+    assert "programming_languages" in data
+    assert data["esco_group"] == "Software developers"
+    assert data["esco_occupation"] == "Software developer"


### PR DESCRIPTION
## Summary
- classify job titles using ESCO and cache occupation data
- tailor follow-up fields based on ESCO group (e.g. developers, sales)
- add tests for ESCO classification and role-specific payload enrichment

## Testing
- `ruff check --fix .`
- `black esco_utils.py question_logic.py tests/test_question_logic.py tests/test_esco_utils.py`
- `mypy .` *(fails: missing import stubs for fitz, pytesseract, requests, readability; duplicate module for tailwind_injector)*
- `flake8 esco_utils.py question_logic.py tests/test_question_logic.py tests/test_esco_utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a37325008320be7390dd0d5c359c