### PR TITLE
feat: add VacalyserJD schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A modern Streamlit Cloud app that parses job ads, autofills key fields, and now 
 - OpenAI prompts for extraction, suggestions, and content generation
 - Dynamic, low-friction wizard (EN/DE)
 - Adaptive follow-up questioning for comprehensive vacancy data
+- Typed vacancy schema via Pydantic for consistent job outputs
 
 ## Setup
 ```bash

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core package for Vacalyser models and utilities."""

--- a/core/schema.py
+++ b/core/schema.py
@@ -1,0 +1,60 @@
+"""Pydantic schema definitions for Vacalyser job descriptions."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class VacalyserJD(BaseModel):
+    """Schema for extracted job description data.
+
+    Attributes:
+        schema_version: Version of this schema.
+        job_title: Title of the job role.
+        company_name: Name of the hiring company.
+        location: Job location.
+        industry: Industry classification of the job.
+        job_type: Employment type (e.g., full-time).
+        remote_policy: Remote work policy.
+        travel_required: Travel requirements for the role.
+        role_summary: Brief summary of the role.
+        qualifications: Required qualifications.
+        salary_range: Offered salary range.
+        reporting_line: Reporting structure for the role.
+        target_start_date: Desired start date.
+        team_structure: Description of the team structure.
+        application_deadline: Deadline for applications.
+        seniority_level: Seniority level of the position.
+        responsibilities: List of role responsibilities.
+        hard_skills: List of hard skills required.
+        soft_skills: List of soft skills required.
+        certifications: Relevant certifications.
+        benefits: Offered benefits.
+        languages_required: Languages required for the role.
+        tools_and_technologies: Tools and technologies used.
+    """
+
+    schema_version: str = Field(default="v1.0")
+    job_title: str = ""
+    company_name: str = ""
+    location: str = ""
+    industry: str = ""
+    job_type: str = ""
+    remote_policy: str = ""
+    travel_required: str = ""
+    role_summary: str = ""
+    qualifications: str = ""
+    salary_range: str = ""
+    reporting_line: str = ""
+    target_start_date: str = ""
+    team_structure: str = ""
+    application_deadline: str = ""
+    seniority_level: str = ""
+
+    responsibilities: list[str] = Field(default_factory=list)
+    hard_skills: list[str] = Field(default_factory=list)
+    soft_skills: list[str] = Field(default_factory=list)
+    certifications: list[str] = Field(default_factory=list)
+    benefits: list[str] = Field(default_factory=list)
+    languages_required: list[str] = Field(default_factory=list)
+    tools_and_technologies: list[str] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- define `VacalyserJD` Pydantic model as single job description schema
- document new typed schema in README

## Testing
- `ruff check --fix .`
- `black .`
- `flake8 .`
- `mypy .` *(fails: missing stubs for requests and duplicate module name for tailwind_injector)*
- `mypy core/schema.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898b2e2bfac83208ace4e532cd52701