### PR TITLE
feat: add schema helpers

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -5,6 +5,55 @@ from __future__ import annotations
 from pydantic import BaseModel, Field
 
 
+# --- Constants -----------------------------------------------------------------
+
+# Field names in :class:`VacalyserJD` order.
+ALL_FIELDS: list[str] = [
+    "schema_version",
+    "job_title",
+    "company_name",
+    "location",
+    "industry",
+    "job_type",
+    "remote_policy",
+    "travel_required",
+    "role_summary",
+    "qualifications",
+    "salary_range",
+    "reporting_line",
+    "target_start_date",
+    "team_structure",
+    "application_deadline",
+    "seniority_level",
+    "responsibilities",
+    "hard_skills",
+    "soft_skills",
+    "certifications",
+    "benefits",
+    "languages_required",
+    "tools_and_technologies",
+]
+
+# Set of list-type fields in :class:`VacalyserJD`.
+LIST_FIELDS: set[str] = {
+    "responsibilities",
+    "hard_skills",
+    "soft_skills",
+    "certifications",
+    "benefits",
+    "languages_required",
+    "tools_and_technologies",
+}
+
+
+# Aliases for backward compatibility of field names.
+ALIASES = {
+    "requirements": "qualifications",
+    "contract_type": "job_type",
+    "tasks": "responsibilities",
+}
+
+
 class VacalyserJD(BaseModel):
     """Schema for extracted job description data.
 
@@ -58,3 +107,49 @@ class VacalyserJD(BaseModel):
     benefits: list[str] = Field(default_factory=list)
     languages_required: list[str] = Field(default_factory=list)
     tools_and_technologies: list[str] = Field(default_factory=list)
+
+
+def coerce_and_fill(d: dict) -> VacalyserJD:
+    """Normalize raw dictionaries to :class:`VacalyserJD`.
+
+    Missing keys are filled with defaults (empty string or list). Values for
+    list-type fields are coerced into lists, trimmed for surrounding
+    whitespace and deduplicated.
+
+    Args:
+        d: Partial job description data.
+
+    Returns:
+        A fully populated :class:`VacalyserJD` instance.
+    """
+
+    payload: dict[str, object] = dict(d)
+
+    for alias, target in ALIASES.items():
+        if alias in payload and target not in payload:
+            payload[target] = payload[alias]
+
+    result: dict[str, object] = {}
+    for field in ALL_FIELDS:
+        value = payload.get(field, [] if field in LIST_FIELDS else "")
+
+        if field in LIST_FIELDS:
+            if value is None:
+                value = []
+            if not isinstance(value, list):
+                value = [value]
+
+            cleaned: list[str] = []
+            seen: set[str] = set()
+            for item in value:
+                item = str(item).strip()
+                if item and item not in seen:
+                    cleaned.append(item)
+                    seen.add(item)
+            result[field] = cleaned
+        else:
+            if value is None:
+                value = ""
+            result[field] = str(value).strip()
+
+    return VacalyserJD(**result)

--- a/core/ss_bridge.py
+++ b/core/ss_bridge.py
@@ -1,0 +1,45 @@
+"""Helpers for mapping between session state and schema objects."""
+
+from __future__ import annotations
+
+from .schema import ALL_FIELDS, LIST_FIELDS, VacalyserJD, coerce_and_fill
+
+
+def to_session_state(jd: VacalyserJD, ss: dict) -> None:
+    """Populate session state with values from a job description.
+
+    List fields are joined by newlines so they can be displayed in Streamlit
+    text areas.
+
+    Args:
+        jd: The job description to serialise.
+        ss: Session state dictionary to update in-place.
+    """
+
+    for field in ALL_FIELDS:
+        value = getattr(jd, field)
+        if field in LIST_FIELDS:
+            ss[field] = "\n".join(value)
+        else:
+            ss[field] = value
+
+
+def from_session_state(ss: dict) -> VacalyserJD:
+    """Build a :class:`VacalyserJD` from session state values.
+
+    Text area fields are split on newlines to re-create lists.
+
+    Args:
+        ss: Session state dictionary.
+
+    Returns:
+        A normalised :class:`VacalyserJD` instance.
+    """
+
+    data: dict[str, object] = {}
+    for field in ALL_FIELDS:
+        value = ss.get(field, [] if field in LIST_FIELDS else "")
+        if field in LIST_FIELDS and isinstance(value, str):
+            value = [line for line in value.splitlines() if line.strip()]
+        data[field] = value
+    return coerce_and_fill(data)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,35 @@
+from core.schema import ALL_FIELDS, LIST_FIELDS, VacalyserJD, coerce_and_fill
+
+
+def test_constants() -> None:
+    assert len(ALL_FIELDS) == 23
+    assert LIST_FIELDS == {
+        "responsibilities",
+        "hard_skills",
+        "soft_skills",
+        "certifications",
+        "benefits",
+        "languages_required",
+        "tools_and_technologies",
+    }
+
+
+def test_coerce_and_fill_partial_and_aliases() -> None:
+    data = {
+        "job_title": " Engineer ",
+        "hard_skills": "Python",
+        "requirements": "BSc",
+        "contract_type": "full-time",
+        "tasks": "Code apps",
+        "benefits": ["Gym", "", "Gym"],
+    }
+    jd = coerce_and_fill(data)
+    assert isinstance(jd, VacalyserJD)
+    assert jd.job_title == "Engineer"
+    assert jd.hard_skills == ["Python"]
+    assert jd.qualifications == "BSc"
+    assert jd.job_type == "full-time"
+    assert jd.responsibilities == ["Code apps"]
+    assert jd.benefits == ["Gym"]
+    # missing field filled with default
+    assert jd.company_name == ""

--- a/tests/test_ss_bridge.py
+++ b/tests/test_ss_bridge.py
@@ -1,0 +1,17 @@
+from core.schema import coerce_and_fill
+from core.ss_bridge import from_session_state, to_session_state
+
+
+def test_round_trip_session_state():
+    jd = coerce_and_fill(
+        {
+            "job_title": "Dev",
+            "responsibilities": ["Code", "Review"],
+            "languages_required": ["EN", "DE"],
+        }
+    )
+    ss = {}
+    to_session_state(jd, ss)
+    jd2 = from_session_state(ss)
+    assert jd2 == jd
+    assert ss["responsibilities"] == "Code\nReview"


### PR DESCRIPTION
## Summary
- add constants, alias map and normalization helper for job schema
- bridge Vacalyser job data to session state and back
- cover schema utilities with unit tests

## Testing
- `ruff check --fix .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b69c06c48320bc84f5bd9520b3e1