### PR TITLE
feat: add unified job text ingestion with OCR

### DIFF
--- a/ingest/__init__.py
+++ b/ingest/__init__.py
@@ -1,0 +1,3 @@
+"""Utilities for ingesting job description text."""
+
+__all__ = ["read_job_text", "ocr_pdf"]

--- a/ingest/ocr.py
+++ b/ingest/ocr.py
@@ -1,0 +1,28 @@
+"""OCR utilities for PDF processing."""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import fitz  # type: ignore[import-not-found]
+from PIL import Image
+import pytesseract
+
+
+def ocr_pdf(pdf_path: str) -> str:
+    """Extract text from a PDF using Tesseract OCR.
+
+    Args:
+        pdf_path: Path to the PDF file.
+
+    Returns:
+        Text recognised from the PDF.
+    """
+
+    text_parts: list[str] = []
+    with fitz.open(pdf_path) as doc:
+        for page in doc:
+            pix = page.get_pixmap()
+            img = Image.open(BytesIO(pix.tobytes("png")))
+            text_parts.append(pytesseract.image_to_string(img))
+    return "\n".join(text_parts).strip()

--- a/ingest/reader.py
+++ b/ingest/reader.py
@@ -1,0 +1,86 @@
+"""Read job text from multiple sources."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import fitz  # type: ignore[import-not-found]
+from bs4 import BeautifulSoup
+from docx import Document
+import requests
+
+from .ocr import ocr_pdf
+
+
+def _clean(text: str) -> str:
+    """Collapse whitespace and strip surrounding spaces."""
+
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _read_txt(path: Path) -> str:
+    with path.open("r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _read_docx(path: Path) -> str:
+    doc = Document(path)
+    return "\n".join(p.text for p in doc.paragraphs)
+
+
+def _read_pdf(path: Path) -> str:
+    with fitz.open(path) as doc:
+        return "".join(page.get_text() for page in doc)
+
+
+def _read_url(url: str) -> str:
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+    return soup.get_text(" ")
+
+
+def read_job_text(
+    files: list[str],
+    url: str | None = None,
+    pasted: str | None = None,
+    *,
+    use_ocr: bool = False,
+) -> str:
+    """Merge text from files, URL and pasted snippets.
+
+    Args:
+        files: Paths to local files (PDF, DOCX, TXT).
+        url: Optional web URL to fetch.
+        pasted: Additional pasted text.
+        use_ocr: Whether to OCR PDFs lacking extractable text.
+
+    Returns:
+        Cleaned and de-duplicated text.
+    """
+
+    texts: list[str] = []
+    for name in files:
+        path = Path(name)
+        suffix = path.suffix.lower()
+        content = ""
+        if suffix == ".pdf":
+            content = _read_pdf(path)
+            if use_ocr and not content.strip():
+                content = ocr_pdf(str(path))
+        elif suffix == ".docx":
+            content = _read_docx(path)
+        elif suffix == ".txt":
+            content = _read_txt(path)
+        if content:
+            texts.append(content)
+
+    if url:
+        texts.append(_read_url(url))
+    if pasted:
+        texts.append(pasted)
+
+    cleaned = [_clean(t) for t in texts if t]
+    unique = list(dict.fromkeys(cleaned))
+    return "\n".join(unique)

--- a/tests/test_ingest_reader.py
+++ b/tests/test_ingest_reader.py
@@ -1,0 +1,25 @@
+import fitz
+
+from ingest.reader import read_job_text
+
+
+def test_read_job_text_merges_and_cleans(tmp_path):
+    txt = tmp_path / "a.txt"
+    txt.write_text("Hello   world\n")
+    result = read_job_text([str(txt)], pasted="Hello world")
+    assert result == "Hello world"
+
+
+def test_read_job_text_triggers_ocr(tmp_path, monkeypatch):
+    pdf_path = tmp_path / "blank.pdf"
+    doc = fitz.open()
+    doc.new_page()
+    doc.save(pdf_path)
+    doc.close()
+
+    def fake_ocr(path: str) -> str:  # noqa: ARG001
+        return "scanned text"
+
+    monkeypatch.setattr("ingest.reader.ocr_pdf", fake_ocr)
+    result = read_job_text([str(pdf_path)], use_ocr=True)
+    assert result == "scanned text"


### PR DESCRIPTION
## Summary
- add `read_job_text` to merge PDF/DOCX/TXT/URL and clean duplicate content
- provide `ocr_pdf` helper to OCR scanned PDFs when enabled
- cover ingestion and OCR path with unit tests

## Testing
- `ruff check --fix .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d2405a048320a61b3af747820369