### PR TITLE
feat: add missing field detector and follow-ups

### DIFF
--- a/questions/__init__.py
+++ b/questions/__init__.py
@@ -1,0 +1,6 @@
+"""Question utilities for vacancy completeness."""
+
+from .missing import missing_fields
+from .generate import generate_followup_questions
+
+__all__ = ["missing_fields", "generate_followup_questions"]

--- a/questions/generate.py
+++ b/questions/generate.py
@@ -1,0 +1,79 @@
+"""Generate follow-up questions for incomplete job descriptions."""
+
+from __future__ import annotations
+
+import json
+from typing import List
+
+from core.schema import ALL_FIELDS, VacalyserJD
+from esco_utils import classify_occupation, get_essential_skills
+from openai_utils import call_chat_api
+
+from .missing import missing_fields
+
+
+def generate_followup_questions(jd: VacalyserJD, lang: str = "en") -> List[str]:
+    """Return targeted questions for missing fields in ``jd``.
+
+    The function inspects the job description and asks the LLM for
+    clarifications only for fields that are currently empty. Between three
+    and seven questions are requested. If no fields are missing, an empty
+    list is returned. Additionally, if ``responsibilities`` or ``hard_skills``
+    are empty but ESCO lists essential skills for the role, one probing
+    question for each category is appended.
+
+    Args:
+        jd: Parsed job description data.
+        lang: Language for generated questions.
+
+    Returns:
+        List of follow-up question strings.
+    """
+
+    missing = missing_fields(jd)
+    if not missing:
+        return []
+
+    extras: List[str] = []
+    if jd.job_title and {"responsibilities", "hard_skills"} & set(missing):
+        occ = classify_occupation(jd.job_title, lang=lang)
+        uri = occ.get("uri", "")
+        essential = get_essential_skills(uri, lang=lang) if uri else []
+        if "responsibilities" in missing and essential:
+            extras.append("What are the main responsibilities for this role?")
+            missing.remove("responsibilities")
+        if "hard_skills" in missing and essential:
+            sample = ", ".join(essential[:3])
+            extras.append(
+                f"Does the role require any of the following skills: {sample}?"
+            )
+            missing.remove("hard_skills")
+
+    if not missing:
+        return extras
+
+    num_questions = min(max(len(missing), 3), 7)
+    payload = {field: getattr(jd, field) for field in ALL_FIELDS}
+    prompt = (
+        "You ensure vacancy data is complete. "
+        f"Ask {num_questions} concise questions in {lang} to fill the missing "
+        f"fields: {', '.join(missing)}. Return a JSON array of strings."
+    )
+    messages = [
+        {"role": "system", "content": "You are a meticulous recruitment analyst."},
+        {
+            "role": "user",
+            "content": prompt + "\nData:\n" + json.dumps(payload, ensure_ascii=False),
+        },
+    ]
+    response = call_chat_api(messages, temperature=0.1, max_tokens=400)
+    try:
+        questions = json.loads(response)
+    except json.JSONDecodeError:
+        questions = [
+            line.strip("-*0123456789. \t")
+            for line in response.splitlines()
+            if line.strip()
+        ]
+    result = [str(q).strip() for q in questions if str(q).strip()]
+    return result + extras

--- a/questions/missing.py
+++ b/questions/missing.py
@@ -1,0 +1,28 @@
+"""Utilities to detect missing fields in job descriptions."""
+
+from __future__ import annotations
+
+from core.schema import ALL_FIELDS, LIST_FIELDS, VacalyserJD
+
+
+def missing_fields(jd: VacalyserJD) -> list[str]:
+    """Return schema fields that are still empty in ``jd``.
+
+    Args:
+        jd: Parsed job description data.
+
+    Returns:
+        List of field names whose value is an empty string or list. The
+        order matches :data:`core.schema.ALL_FIELDS` to ensure determinism.
+    """
+
+    missing: list[str] = []
+    for field in ALL_FIELDS:
+        value = getattr(jd, field)
+        if field in LIST_FIELDS:
+            if not value:
+                missing.append(field)
+        else:
+            if not value:
+                missing.append(field)
+    return missing

--- a/tests/test_generate_followups.py
+++ b/tests/test_generate_followups.py
@@ -1,0 +1,54 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.schema import VacalyserJD, ALL_FIELDS, LIST_FIELDS  # noqa: E402
+from questions.generate import generate_followup_questions  # noqa: E402
+
+
+def test_generate_followups(monkeypatch):
+    def fake_call_chat_api(messages, temperature=0.0, max_tokens=0):
+        return '["Company name?", "Location?", "Salary?"]'
+
+    def fake_classify(job_title, lang="en"):
+        return {"preferredLabel": "Developer", "group": "Software", "uri": "u"}
+
+    def fake_skills(uri, lang="en"):
+        return ["Python", "Teamwork"]
+
+    monkeypatch.setattr(
+        "questions.generate.call_chat_api", fake_call_chat_api
+    )
+    monkeypatch.setattr(
+        "questions.generate.classify_occupation", fake_classify
+    )
+    monkeypatch.setattr(
+        "questions.generate.get_essential_skills", fake_skills
+    )
+
+    jd = VacalyserJD(job_title="Dev")
+    questions = generate_followup_questions(jd)
+    assert questions == [
+        "Company name?",
+        "Location?",
+        "Salary?",
+        "What are the main responsibilities for this role?",
+        "Does the role require any of the following skills: Python, Teamwork?",
+    ]
+
+
+def test_generate_followups_complete(monkeypatch):
+    data = {}
+    for field in ALL_FIELDS:
+        if field in LIST_FIELDS:
+            data[field] = ["x"]
+        else:
+            data[field] = "x"
+    jd = VacalyserJD(**data)
+
+    def fail_call(*args, **kwargs):  # pragma: no cover
+        raise AssertionError("should not call")
+
+    monkeypatch.setattr("questions.generate.call_chat_api", fail_call)
+    assert generate_followup_questions(jd) == []

--- a/tests/test_missing_fields.py
+++ b/tests/test_missing_fields.py
@@ -1,0 +1,13 @@
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.schema import VacalyserJD, ALL_FIELDS  # noqa: E402
+from questions.missing import missing_fields  # noqa: E402
+
+
+def test_missing_fields_order():
+    jd = VacalyserJD(job_title="dev")
+    expected = [f for f in ALL_FIELDS if f not in {"schema_version", "job_title"}]
+    assert missing_fields(jd) == expected


### PR DESCRIPTION
## Summary
- detect missing job description fields via schema-based helper
- generate follow-up questions for gaps, including ESCO-based hints
- cover new logic with unit tests

## Testing
- `ruff check --fix .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898ea33a5fc83208ab08a295d0ffae0