### PR TITLE
test: expand parsing and follow-up coverage

### DIFF
--- a/tests/test_e2e_extraction.py
+++ b/tests/test_e2e_extraction.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.ss_bridge import to_session_state
+from llm.client import extract_and_parse
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '{"job_title": "Dev"}',
+        "```json\n{\"job_title\": \"Dev\"}\n```",
+        "Noise {\"job_title\": \"Dev\"} tail",
+    ],
+)
+def test_e2e_to_session_state(monkeypatch, raw: str) -> None:
+    """End-to-end extraction should populate session state."""
+
+    def fake_extract_json(text, title=None, url=None, minimal=False):
+        return raw
+
+    monkeypatch.setattr("llm.client.extract_json", fake_extract_json)
+    jd = extract_and_parse("input")
+    ss: dict = {}
+    to_session_state(jd, ss)
+    assert ss["job_title"] == "Dev"

--- a/tests/test_esco.py
+++ b/tests/test_esco.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from esco.normalize import normalize_skills
+from questions.augment import missing_esco_skills
+
+
+def test_normalize_skills(monkeypatch) -> None:
+    def fake_lookup(skill, lang="en"):
+        return {"preferredLabel": skill.strip().title()}
+
+    monkeypatch.setattr("esco.normalize.lookup_esco_skill", fake_lookup)
+    out = normalize_skills(["python", "Python ", "docker", ""])
+    assert out == ["Python", "Docker"]
+
+
+def test_missing_esco_skills(monkeypatch) -> None:
+    def fake_get(uri, lang="en"):
+        return ["Git", "Python", "Docker"]
+
+    monkeypatch.setattr("questions.augment.get_essential_skills", fake_get)
+    missing = missing_esco_skills("uri", ["Python"], ["Docker"])
+    assert missing == ["Git"]

--- a/tests/test_followups.py
+++ b/tests/test_followups.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.schema import VacalyserJD
+from questions.generate import generate_followup_questions
+
+
+def test_missing_detector_categories(monkeypatch) -> None:
+    captured = {}
+
+    def fake_call_chat_api(messages, temperature=0.0, max_tokens=0):
+        captured["prompt"] = messages[1]["content"]
+        return "[]"
+
+    monkeypatch.setattr("questions.generate.call_chat_api", fake_call_chat_api)
+    monkeypatch.setattr("questions.generate.classify_occupation", lambda *args, **kwargs: {})
+    monkeypatch.setattr("questions.generate.get_essential_skills", lambda *args, **kwargs: [])
+
+    jd = VacalyserJD(job_title="Dev", responsibilities=["Code"])
+    generate_followup_questions(jd)
+
+    prompt = captured["prompt"]
+    missing = prompt.split("fields: ", 1)[1].split(". Return", 1)[0]
+    assert "responsibilities" not in missing
+    assert "hard_skills" in missing
+    assert "company_name" in missing

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,31 @@
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from utils.json_parse import parse_extraction
+
+
+def test_parse_pure_json() -> None:
+    jd = parse_extraction('{"job_title": "Dev"}')
+    assert jd.job_title == "Dev"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "```json\n{\"job_title\": \"Dev\"}\n```",
+        "Here is the data: {\"job_title\": \"Dev\"} Thanks",
+    ],
+)
+def test_parse_with_sanitization(raw: str) -> None:
+    jd = parse_extraction(raw)
+    assert jd.job_title == "Dev"
+
+
+def test_parse_mismatched_quotes() -> None:
+    with pytest.raises(json.JSONDecodeError):
+        parse_extraction('{"job_title": "Dev}')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,4 +1,10 @@
-from core.schema import ALL_FIELDS, LIST_FIELDS, VacalyserJD, coerce_and_fill
+from core.schema import (
+    ALL_FIELDS,
+    LIST_FIELDS,
+    STRING_FIELDS,
+    VacalyserJD,
+    coerce_and_fill,
+)
 
 
 def test_constants() -> None:
@@ -33,3 +39,28 @@ def test_coerce_and_fill_partial_and_aliases() -> None:
     assert jd.benefits == ["Gym"]
     # missing field filled with default
     assert jd.company_name == ""
+
+
+def test_default_insertion() -> None:
+    """All missing fields are populated with default empty values."""
+
+    jd = coerce_and_fill({})
+    for field in STRING_FIELDS:
+        assert getattr(jd, field) == ""
+    for field in LIST_FIELDS:
+        assert getattr(jd, field) == []
+
+
+def test_alias_priority() -> None:
+    """Canonical fields are not overridden by aliases."""
+
+    data = {"requirements": "BSc", "qualifications": "MSc"}
+    jd = coerce_and_fill(data)
+    assert jd.qualifications == "MSc"
+
+
+def test_list_coercion_split_and_dedupe() -> None:
+    """String list fields are split on newlines/commas and deduplicated."""
+
+    jd = coerce_and_fill({"hard_skills": "Python, Java\nPython"})
+    assert jd.hard_skills == ["Python", "Java"]


### PR DESCRIPTION
## Summary
- exercise schema coercion defaults, alias priority, and list splitting
- add parser, integration, follow-up, and ESCO stub tests

## Testing
- `ruff check --fix .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898efebe7f8832091bb297ac99a2258