### PR TITLE
feat: add config loader, CLI extraction, CI, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Ruff
+        run: ruff check .
+      - name: Black
+        run: black --check .
+      - name: Mypy
+        run: mypy .
+      - name: Tests
+        env:
+          VACAYSER_OFFLINE: '1'
+        run: pytest -q

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command line interfaces for Vacalyser."""

--- a/cli/extract.py
+++ b/cli/extract.py
@@ -1,0 +1,52 @@
+"""CLI for running the extraction pipeline locally."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+
+def main() -> None:
+    """Parse arguments and print validated JSON to stdout.
+
+    The command reads a local job description file, extracts text, and runs the
+    LLM pipeline without requiring Streamlit. Example::
+
+        python -m cli.extract --file jd.pdf --title "..." --url "..." --mode json
+    """
+
+    parser = argparse.ArgumentParser(description="Vacalyser JSON extractor")
+    parser.add_argument(
+        "--file", required=True, help="Path to the job description file"
+    )
+    parser.add_argument("--title", help="Optional job title for context")
+    parser.add_argument("--url", help="Optional source URL for context")
+    parser.add_argument(
+        "--mode",
+        choices=["plain", "json", "function"],
+        default=os.getenv("LLM_MODE", "plain"),
+        help="LLM mode: plain, json, or function",
+    )
+    args = parser.parse_args()
+
+    # Ensure mode is respected by the client module
+    os.environ["LLM_MODE"] = args.mode
+
+    from utils import extract_text_from_file
+    from llm.client import extract_and_parse
+
+    file_path = Path(args.file)
+    if not file_path.exists():
+        raise SystemExit(f"File not found: {file_path}")
+
+    text = extract_text_from_file(file_path.read_bytes(), file_path.name)
+    if not text:
+        raise SystemExit("No text could be extracted from the file.")
+
+    jd = extract_and_parse(text, title=args.title, url=args.url)
+    print(jd.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,80 @@
+"""Configuration loader for OpenAI access and debug flags.
+
+Reads environment variables or Streamlit secrets and exposes
+settings used across the project. A clear runtime error is raised
+if the OpenAI API key is missing.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+try:  # pragma: no cover - streamlit not always available
+    import streamlit as st
+except Exception:  # pragma: no cover
+    st = None  # type: ignore
+
+
+@dataclass(slots=True)
+class Settings:
+    """Runtime configuration values.
+
+    Attributes:
+        openai_api_key: Secret key for the OpenAI API.
+        openai_org: Optional OpenAI organization identifier.
+        json_mode: Whether to request JSON responses from the model.
+        function_calling: Whether to enable function-calling mode.
+        debug_logs: Toggle verbose debug logging.
+    """
+
+    openai_api_key: str
+    openai_org: Optional[str]
+    json_mode: bool
+    function_calling: bool
+    debug_logs: bool
+
+
+def _as_bool(value: Optional[str]) -> bool:
+    """Interpret truthy string values as boolean True."""
+
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def load_settings() -> Settings:
+    """Load settings from env vars or Streamlit secrets.
+
+    Raises:
+        RuntimeError: If ``OPENAI_API_KEY`` is missing.
+    """
+
+    secrets: dict[str, str] = {}
+    if st is not None:
+        try:
+            secrets = dict(st.secrets)
+        except Exception:  # pragma: no cover - defensive
+            secrets = {}
+
+    def _get(key: str) -> Optional[str]:
+        return secrets.get(key) or os.getenv(key)
+
+    api_key = _get("OPENAI_API_KEY")
+    org = _get("OPENAI_ORG")
+    if not api_key:
+        raise RuntimeError(
+            "OPENAI_API_KEY is missing. Set the variable or define it in st.secrets."
+        )
+
+    return Settings(
+        openai_api_key=api_key,
+        openai_org=org,
+        json_mode=_as_bool(_get("JSON_MODE")),
+        function_calling=_as_bool(_get("FUNCTION_CALLING")),
+        debug_logs=_as_bool(_get("DEBUG_LOGS")),
+    )
+
+
+__all__ = ["Settings", "load_settings"]

--- a/docs/json_pipeline.md
+++ b/docs/json_pipeline.md
@@ -1,0 +1,110 @@
+# JSON Extraction Pipeline
+
+Vacalyser extracts job information into a strict schema so downstream tools can rely on stable keys.
+The canonical schema lives in `core/schema.py` and defines the `VacalyserJD` model.
+
+## Schema
+The schema contains 22 fields ordered for prompting:
+
+- job_title
+- company_name
+- location
+- industry
+- job_type
+- remote_policy
+- travel_required
+- role_summary
+- responsibilities
+- hard_skills
+- soft_skills
+- qualifications
+- certifications
+- salary_range
+- benefits
+- reporting_line
+- target_start_date
+- team_structure
+- application_deadline
+- seniority_level
+- languages_required
+- tools_and_technologies
+
+Example JSON produced by the pipeline:
+
+```json
+{
+  "schema_version": "v1.0",
+  "job_title": "Software Engineer",
+  "company_name": "",
+  "location": "",
+  "industry": "",
+  "job_type": "",
+  "remote_policy": "",
+  "travel_required": "",
+  "role_summary": "",
+  "responsibilities": [],
+  "hard_skills": [],
+  "soft_skills": [],
+  "qualifications": "",
+  "certifications": [],
+  "salary_range": "",
+  "benefits": [],
+  "reporting_line": "",
+  "target_start_date": "",
+  "team_structure": "",
+  "application_deadline": "",
+  "seniority_level": "",
+  "languages_required": [],
+  "tools_and_technologies": []
+}
+```
+
+## Prompts
+`llm/prompts.py` renders two messages:
+
+- **System** – `You are an extractor. Return ONLY a JSON object with the exact keys provided. Use empty strings for missing values and empty lists for missing arrays. No prose.`
+- **User** – lists the fields above and injects the job text plus optional `title` and `url`.
+
+Copy‑paste prompt for manual runs:
+
+```
+You are an extractor. Return ONLY a JSON object with the exact keys provided. Use empty strings for missing values and empty lists for missing arrays. No prose.
+
+Extract the following fields and respond with a JSON object containing these keys. If data for a key is missing, use an empty string or empty list.
+Fields:
+- job_title
+- company_name
+- location
+- industry
+- job_type
+- remote_policy
+- travel_required
+- role_summary
+- responsibilities
+- hard_skills
+- soft_skills
+- qualifications
+- certifications
+- salary_range
+- benefits
+- reporting_line
+- target_start_date
+- team_structure
+- application_deadline
+- seniority_level
+- languages_required
+- tools_and_technologies
+
+Text:
+{{JOB_TEXT}}
+```
+
+## Fallback Strategy
+`llm.client.extract_and_parse` calls the model once with the full prompt. If the response cannot be parsed as JSON it retries with a minimal prompt asking for raw JSON. A failure on the second attempt raises `ExtractionError`.
+
+## Extending
+To add new fields:
+
+1. Update `ALL_FIELDS` (and `LIST_FIELDS` if it is a list) in `core/schema.py`.
+2. Add any prompt handling in `llm/prompts.py`.
+3. Re-run tests to ensure the schema and prompts stay in sync.

--- a/tests/test_e2e_extraction.py
+++ b/tests/test_e2e_extraction.py
@@ -1,20 +1,19 @@
 import os
 import sys
 
-import pytest
-
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from core.ss_bridge import to_session_state
-from llm.client import extract_and_parse
+import pytest  # noqa: E402
+from core.ss_bridge import to_session_state  # noqa: E402
+from llm.client import extract_and_parse  # noqa: E402
 
 
 @pytest.mark.parametrize(
     "raw",
     [
         '{"job_title": "Dev"}',
-        "```json\n{\"job_title\": \"Dev\"}\n```",
-        "Noise {\"job_title\": \"Dev\"} tail",
+        '```json\n{"job_title": "Dev"}\n```',
+        'Noise {"job_title": "Dev"} tail',
     ],
 )
 def test_e2e_to_session_state(monkeypatch, raw: str) -> None:

--- a/tests/test_esco.py
+++ b/tests/test_esco.py
@@ -3,8 +3,8 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from esco.normalize import normalize_skills
-from questions.augment import missing_esco_skills
+from esco.normalize import normalize_skills  # noqa: E402
+from questions.augment import missing_esco_skills  # noqa: E402
 
 
 def test_normalize_skills(monkeypatch) -> None:

--- a/tests/test_followups.py
+++ b/tests/test_followups.py
@@ -3,8 +3,8 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from core.schema import VacalyserJD
-from questions.generate import generate_followup_questions
+from core.schema import VacalyserJD  # noqa: E402
+from questions.generate import generate_followup_questions  # noqa: E402
 
 
 def test_missing_detector_categories(monkeypatch) -> None:
@@ -15,8 +15,12 @@ def test_missing_detector_categories(monkeypatch) -> None:
         return "[]"
 
     monkeypatch.setattr("questions.generate.call_chat_api", fake_call_chat_api)
-    monkeypatch.setattr("questions.generate.classify_occupation", lambda *args, **kwargs: {})
-    monkeypatch.setattr("questions.generate.get_essential_skills", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        "questions.generate.classify_occupation", lambda *args, **kwargs: {}
+    )
+    monkeypatch.setattr(
+        "questions.generate.get_essential_skills", lambda *args, **kwargs: []
+    )
 
     jd = VacalyserJD(job_title="Dev", responsibilities=["Code"])
     generate_followup_questions(jd)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,11 +2,10 @@ import json
 import os
 import sys
 
-import pytest
-
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from utils.json_parse import parse_extraction
+import pytest  # noqa: E402
+from utils.json_parse import parse_extraction  # noqa: E402
 
 
 def test_parse_pure_json() -> None:
@@ -17,8 +16,8 @@ def test_parse_pure_json() -> None:
 @pytest.mark.parametrize(
     "raw",
     [
-        "```json\n{\"job_title\": \"Dev\"}\n```",
-        "Here is the data: {\"job_title\": \"Dev\"} Thanks",
+        '```json\n{"job_title": "Dev"}\n```',
+        'Here is the data: {"job_title": "Dev"} Thanks',
     ],
 )
 def test_parse_with_sanitization(raw: str) -> None:


### PR DESCRIPTION
## Summary
- add configuration loader for OpenAI keys and debug flags
- introduce CLI for local JSON extraction runs
- document JSON pipeline and wire up CI workflow

## Testing
- `ruff check --fix .`
- `flake8 .`
- `pytest -q`
- `mypy .` *(fails: missing library stubs for external deps)*

------
https://chatgpt.com/codex/tasks/task_e_6898f28c6d5083208f6b103cff799de4