### PR TITLE
fix: ignore unlabeled follow-up answers

### DIFF
--- a/tests/test_wizard_followups.py
+++ b/tests/test_wizard_followups.py
@@ -1,0 +1,27 @@
+"""Tests for follow-up question session state handling in wizard."""
+
+import streamlit as st
+
+from wizard import followup_questions_page
+
+
+def test_followup_questions_skip_blank_field(monkeypatch) -> None:
+    """Ensure questions without a field do not write to session state."""
+    st.session_state.clear()
+    st.session_state["lang"] = "en"
+    st.session_state["followup_questions"] = [
+        {"field": "", "question": "General note?"},
+        {"field": "salary", "question": "Salary?"},
+    ]
+
+    def fake_text_input(label: str, value: str = "", key: str | None = None) -> str:
+        return "some answer"
+
+    monkeypatch.setattr(st, "text_input", fake_text_input)
+    monkeypatch.setattr(st, "header", lambda *a, **k: None)
+    monkeypatch.setattr(st, "info", lambda *a, **k: None)
+
+    followup_questions_page()
+
+    assert "" not in st.session_state
+    assert st.session_state["salary"] == "some answer"

--- a/wizard.py
+++ b/wizard.py
@@ -156,9 +156,12 @@ def followup_questions_page():
         field = item.get("field", "")
         question = item.get("question", "")
         key = field or question
-        st.session_state[field] = st.text_input(
-            question, st.session_state.get(field, ""), key=key
-        )
+        if field:
+            st.session_state[field] = st.text_input(
+                question, st.session_state.get(field, ""), key=key
+            )
+        else:
+            _ = st.text_input(question, "", key=key)
 
 
 def company_information_page():


### PR DESCRIPTION
## Summary
- avoid writing answers for follow-up questions without a field name
- add test to ensure unlabeled follow-ups aren't saved

## Testing
- `ruff check --fix .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a5635035c83208d8b09346d51905c