### PR TITLE
fix: remove invalid pydantic arg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ beautifulsoup4>=4.12.3
 python-dotenv>=1.0.1
 pytesseract>=0.3.10
 Pillow>=10.3.0
-pydantic>=1.10.7
+pydantic>=2.0.0

--- a/wizard.py
+++ b/wizard.py
@@ -1,3 +1,4 @@
+import json
 import streamlit as st
 from core.ss_bridge import from_session_state, to_session_state
 from core.schema import ALIASES
@@ -29,7 +30,9 @@ def normalise_state(reapply_aliases: bool = True):
         st.session_state["requirements"] = st.session_state.get("qualifications", "")
         st.session_state["tasks"] = st.session_state.get("responsibilities", "")
         st.session_state["contract_type"] = st.session_state.get("job_type", "")
-    st.session_state["validated_json"] = jd.model_dump_json(indent=2, ensure_ascii=False)
+    st.session_state["validated_json"] = json.dumps(
+        jd.model_dump(mode="json"), indent=2, ensure_ascii=False
+    )
     return jd
 
 def apply_global_styling():


### PR DESCRIPTION
## Summary
- convert validated JSON handling to manual dump without deprecated ensure_ascii arg
- bump Pydantic requirement to v2

## Testing
- `ruff check --fix .`
- `flake8 .` *(fails: E302 expected 2 blank lines, E501 line too long, ...)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a6ba9f8f88320a63604d7584a1031