### PR TITLE
feat: auto-fill job title after extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A modern Streamlit Cloud app that parses job ads, autofills key fields, and now 
 - OpenAI prompts for extraction, suggestions, and content generation
 - Dynamic, low-friction wizard (EN/DE)
 - Adaptive follow-up questioning for comprehensive vacancy data
+- Auto-fills the job title on upload for a quicker start
 - Typed vacancy schema via Pydantic for consistent job outputs
 
 ## Setup

--- a/question_logic.py
+++ b/question_logic.py
@@ -10,6 +10,7 @@ from esco_utils import classify_occupation, get_essential_skills
 
 # Extended vacancy fields to ensure a comprehensive profile
 EXTENDED_FIELDS: List[str] = [
+    "job_title",
     "company_name",
     "location",
     "company_website",

--- a/wizard.py
+++ b/wizard.py
@@ -80,6 +80,10 @@ def start_discovery_page():
         if lang != "de" else "Laden Sie eine Stellenanzeige hoch oder fügen Sie eine URL ein. Wir extrahieren alle verfügbaren Informationen und fragen nur noch fehlende Details ab."
     )
 
+    if st.session_state.get("extraction_success"):
+        st.success("✅ Key information extracted successfully!")
+        st.session_state.pop("extraction_success")
+
     # Job title and source inputs
     colA, colB = st.columns(2)
     with colA:
@@ -148,10 +152,11 @@ def start_discovery_page():
             # Generate follow-up questions for missing info
             followups = generate_followup_questions(st.session_state, lang=lang)
             st.session_state["followup_questions"] = followups
-            st.success("✅ Key information extracted successfully!")
+            st.session_state["extraction_success"] = True
             log_event(
                 f"ANALYZE by {st.session_state.get('user', 'anonymous')} title='{st.session_state.get('job_title', '')}'"
             )
+            st.rerun()
         except json.JSONDecodeError:
             st.error("❌ Could not parse AI response as JSON. Please try again or rephrase the input.")
 


### PR DESCRIPTION
## Summary
- extract the job title along with other vacancy fields
- auto-fill the Job Title field after successful analysis
- document automatic job-title detection in README

## Testing
- `ruff check --fix .`
- `flake8 wizard.py question_logic.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a6fc7391c8320922a5d8e43c7a070