### PR TITLE
feat: relocate ESCO utils and cache lookups

### DIFF
--- a/esco/normalize.py
+++ b/esco/normalize.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List
 
-from esco_utils import lookup_esco_skill
+from core.esco_utils import lookup_esco_skill
 
 
 def normalize_skills(skills: List[str], lang: str = "en") -> List[str]:

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -6,21 +6,36 @@ import json
 if OPENAI_API_KEY:
     openai.api_key = OPENAI_API_KEY
 
-def call_chat_api(messages: list[dict], model: str = None, max_tokens: int = 500, temperature: float = 0.5) -> str:
+
+def call_chat_api(
+    messages: list[dict],
+    model: str = None,
+    max_tokens: int = 500,
+    temperature: float = 0.5,
+) -> str:
     """Generic helper to call OpenAI ChatCompletion API and return the response text."""
     if model is None:
         model = OPENAI_MODEL
     try:
         response = openai.ChatCompletion.create(
-            model=model, messages=messages, temperature=temperature, max_tokens=max_tokens
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
         )
         return (response["choices"][0]["message"]["content"] or "").strip()
     except Exception as e:
         print(f"OpenAI API error: {e}")
         return ""
 
-def suggest_additional_skills(job_title: str, tasks: str = "", existing_skills: list[str] = None,
-                              num_suggestions: int = 10, lang: str = "en") -> dict:
+
+def suggest_additional_skills(
+    job_title: str,
+    tasks: str = "",
+    existing_skills: list[str] = None,
+    num_suggestions: int = 10,
+    lang: str = "en",
+) -> dict:
     """Suggest a mix of technical and soft skills for the given role, avoiding duplicates."""
     if existing_skills is None:
         existing_skills = []
@@ -61,14 +76,18 @@ def suggest_additional_skills(job_title: str, tasks: str = "", existing_skills: 
     soft_skills = [s for s in soft_skills if s.lower() not in existing_lower]
     # Optionally enrich skill names to ESCO preferred labels
     try:
-        from esco_utils import enrich_skills_with_esco
+        from core.esco_utils import enrich_skills_with_esco
+
         tech_skills = enrich_skills_with_esco(tech_skills, lang=lang)
         soft_skills = enrich_skills_with_esco(soft_skills, lang=lang)
     except Exception:
         pass
     return {"technical": tech_skills, "soft": soft_skills}
 
-def suggest_benefits(job_title: str, industry: str = "", existing_benefits: str = "") -> list[str]:
+
+def suggest_benefits(
+    job_title: str, industry: str = "", existing_benefits: str = ""
+) -> list[str]:
     """Suggest common benefits/perks for the given role (and industry), avoiding those already listed."""
     job_title = job_title.strip()
     # If no specific role given, we cannot suggest targeted benefits
@@ -92,6 +111,7 @@ def suggest_benefits(job_title: str, industry: str = "", existing_benefits: str 
     benefits = [b for b in benefits if b.strip().lower() not in existing_set]
     return benefits
 
+
 def suggest_role_tasks(job_title: str, num_tasks: int = 5) -> list[str]:
     """Suggest a list of key responsibilities/tasks for a given job title."""
     job_title = job_title.strip()
@@ -107,7 +127,10 @@ def suggest_role_tasks(job_title: str, num_tasks: int = 5) -> list[str]:
             tasks.append(task)
     return tasks[:num_tasks]
 
-def generate_interview_guide(job_title: str, tasks: str = "", audience: str = "general", num_questions: int = 5) -> str:
+
+def generate_interview_guide(
+    job_title: str, tasks: str = "", audience: str = "general", num_questions: int = 5
+) -> str:
     """Generate an interview guide (questions + scoring rubrics) for the role."""
     job_title = job_title.strip() or "this position"
     prompt = (
@@ -117,6 +140,7 @@ def generate_interview_guide(job_title: str, tasks: str = "", audience: str = "g
     )
     messages = [{"role": "user", "content": prompt}]
     return call_chat_api(messages, temperature=0.7, max_tokens=1000)
+
 
 def generate_job_ad(session_data: dict) -> str:
     """Generate a compelling job advertisement using the collected session data."""
@@ -135,6 +159,7 @@ def generate_job_ad(session_data: dict) -> str:
     messages = [{"role": "user", "content": prompt}]
     return call_chat_api(messages, temperature=0.7, max_tokens=600)
 
+
 def extract_company_info(text: str) -> dict:
     """Extract company information (name, mission/values, culture, location) from given website text."""
     if not text or text.strip() == "":
@@ -146,8 +171,7 @@ def extract_company_info(text: str) -> dict:
         "Identify the company name, the main location (city or country), any statement of the company's mission or core values, "
         "and any description of the company culture or work environment from the text below. "
         "Provide the answer as a JSON object with keys: company_name, location, company_mission, company_culture. "
-        "If a field is not mentioned, use an empty string for it.\nText:\n"
-        + snippet
+        "If a field is not mentioned, use an empty string for it.\nText:\n" + snippet
     )
     messages = [{"role": "user", "content": prompt}]
     result = call_chat_api(messages, temperature=0.2, max_tokens=300)

--- a/question_logic.py
+++ b/question_logic.py
@@ -24,52 +24,109 @@ import os
 from typing import Any, Dict, List, Optional, Set
 
 # ESCO helpers (must exist in core/esco_utils.py)
-from core.esco_utils import classify_occupation, get_essential_skills, enrich_skills_with_esco
+from core.esco_utils import (
+    classify_occupation,
+    get_essential_skills,
+    enrich_skills_with_esco,
+)
 
-# Generic chat helper (fallback) — must exist in core/openai_utils.py
-from core.openai_utils import call_chat_api
+# Generic chat helper (fallback)
+from openai_utils import call_chat_api
 
 # Try modern OpenAI SDK (Responses API)
 try:
     from openai import OpenAI  # >=1.30
+
     _HAS_RESPONSES = True
 except Exception:  # pragma: no cover
     OpenAI = None
     _HAS_RESPONSES = False
 
 DEFAULT_LOW_COST_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
-RAG_VECTOR_STORE_ID = os.getenv("VECTOR_STORE_ID", "vs_67e40071e7608191a62ab06cacdcdd10")
+RAG_VECTOR_STORE_ID = os.getenv(
+    "VECTOR_STORE_ID", "vs_67e40071e7608191a62ab06cacdcdd10"
+)
 
 # Extended coverage: combine legacy and new fields (kept flat for prompts).
 EXTENDED_FIELDS: List[str] = [
     # company / context
-    "company_name", "company_website", "industry", "location", "company_mission",
-    "company_culture", "department", "team_structure", "reporting_line",
+    "company_name",
+    "company_website",
+    "industry",
+    "location",
+    "company_mission",
+    "company_culture",
+    "department",
+    "team_structure",
+    "reporting_line",
     # role core
-    "job_title", "role_summary", "responsibilities", "qualifications",
-    "hard_skills", "soft_skills", "tools_and_technologies", "certifications",
-    "languages_required", "seniority_level",
+    "job_title",
+    "role_summary",
+    "responsibilities",
+    "qualifications",
+    "hard_skills",
+    "soft_skills",
+    "tools_and_technologies",
+    "certifications",
+    "languages_required",
+    "seniority_level",
     # employment
-    "job_type", "remote_policy", "onsite_requirements", "travel_required",
-    "working_hours", "salary_range", "bonus_compensation", "benefits",
-    "health_benefits", "retirement_benefits", "learning_opportunities",
-    "equity_options", "relocation_assistance", "visa_sponsorship",
-    "target_start_date", "application_deadline", "performance_metrics",
+    "job_type",
+    "remote_policy",
+    "onsite_requirements",
+    "travel_required",
+    "working_hours",
+    "salary_range",
+    "bonus_compensation",
+    "benefits",
+    "health_benefits",
+    "retirement_benefits",
+    "learning_opportunities",
+    "equity_options",
+    "relocation_assistance",
+    "visa_sponsorship",
+    "target_start_date",
+    "application_deadline",
+    "performance_metrics",
 ]
 
 # Role-specific extras keyed by ESCO group (lowercased)
 ROLE_FIELD_MAP: Dict[str, List[str]] = {
-    "software developers": ["programming_languages", "frameworks", "tech_stack", "code_quality_practices"],
-    "sales, marketing and public relations professionals": ["target_markets", "sales_quota", "crm_tools"],
-    "nursing and midwifery professionals": ["required_certifications", "shift_schedule", "patient_ratio"],
+    "software developers": [
+        "programming_languages",
+        "frameworks",
+        "tech_stack",
+        "code_quality_practices",
+    ],
+    "sales, marketing and public relations professionals": [
+        "target_markets",
+        "sales_quota",
+        "crm_tools",
+    ],
+    "nursing and midwifery professionals": [
+        "required_certifications",
+        "shift_schedule",
+        "patient_ratio",
+    ],
 }
 
 CRITICAL_FIELDS: Set[str] = {
-    "job_title", "company_name", "location",
-    "role_summary", "responsibilities", "qualifications",
-    "salary_range", "job_type", "remote_policy",
-    "languages_required", "certifications", "tools_and_technologies",
+    "job_title",
+    "company_name",
+    "location",
+    "role_summary",
+    "responsibilities",
+    "qualifications",
+    "salary_range",
+    "job_type",
+    "remote_policy",
+    "languages_required",
+    "certifications",
+    "tools_and_technologies",
 }
+
+SKILL_FIELDS: Set[str] = {"hard_skills", "soft_skills", "tools_and_technologies"}
+
 
 def _is_empty(val: Any) -> bool:
     if val is None:
@@ -80,6 +137,7 @@ def _is_empty(val: Any) -> bool:
         return len(val) == 0
     return False
 
+
 def _priority_for(field: str, is_missing_esco_skill: bool = False) -> str:
     if is_missing_esco_skill:
         return "critical"
@@ -88,12 +146,14 @@ def _priority_for(field: str, is_missing_esco_skill: bool = False) -> str:
     # Favor role-relevant extras as normal
     return "normal"
 
+
 def _collect_missing_fields(extracted: Dict[str, Any], fields: List[str]) -> List[str]:
     missing = []
     for f in fields:
         if _is_empty(extracted.get(f)):
             missing.append(f)
     return missing
+
 
 def _rag_suggestions(
     job_title: str,
@@ -127,7 +187,7 @@ def _rag_suggestions(
         "industry": industry,
         "language": lang,
         "fields": missing_fields,
-        "N": max_items_per_field
+        "N": max_items_per_field,
     }
     try:
         resp = client.responses.create(
@@ -156,11 +216,14 @@ def _rag_suggestions(
         out: Dict[str, List[str]] = {}
         for f in missing_fields:
             vals = data.get(f) or data.get(f.replace("_", " ")) or []
-            # sanitize to strings
-            out[f] = [str(x).strip() for x in vals if str(x).strip()]
+            sanitized = [str(x).strip() for x in vals if str(x).strip()]
+            if f in SKILL_FIELDS and sanitized:
+                sanitized = enrich_skills_with_esco(sanitized, lang=lang)
+            out[f] = sanitized
         return out
     except Exception:
         return {}
+
 
 def generate_followup_questions(
     extracted: Dict[str, Any],
@@ -191,17 +254,21 @@ def generate_followup_questions(
     if occ_uri:
         essential_skills = get_essential_skills(occ_uri, lang=lang) or []
         # text presence check
-        haystack = " ".join([
-            str(extracted.get("responsibilities") or ""),
-            str(extracted.get("qualifications") or ""),
-            str(extracted.get("hard_skills") or ""),
-            str(extracted.get("soft_skills") or ""),
-            str(extracted.get("tools_and_technologies") or ""),
-        ]).lower()
+        haystack = " ".join(
+            [
+                str(extracted.get("responsibilities") or ""),
+                str(extracted.get("qualifications") or ""),
+                str(extracted.get("hard_skills") or ""),
+                str(extracted.get("soft_skills") or ""),
+                str(extracted.get("tools_and_technologies") or ""),
+            ]
+        ).lower()
         missing_esco_skills = [s for s in essential_skills if s.lower() not in haystack]
 
     # 2) Missing fields
-    fields_to_check = list(dict.fromkeys(EXTENDED_FIELDS + role_fields))  # dedupe keep order
+    fields_to_check = list(
+        dict.fromkeys(EXTENDED_FIELDS + role_fields)
+    )  # dedupe keep order
     missing_fields = _collect_missing_fields(extracted, fields_to_check)
 
     # 3) RAG suggestions (chips)
@@ -215,9 +282,9 @@ def generate_followup_questions(
         "language": lang,
         "missing_fields": missing_fields,
         "occupation": occupation,
-        "essential_skills": essential_skills[:24],         # budget cap
-        "missing_esco_skills": missing_esco_skills[:12],   # budget cap
-        "rag_suggestions": rag_map,                        # may be empty
+        "essential_skills": essential_skills[:24],  # budget cap
+        "missing_esco_skills": missing_esco_skills[:12],  # budget cap
+        "rag_suggestions": rag_map,  # may be empty
         "rules": {
             "max_questions": num_questions,
             "priorities": {
@@ -226,7 +293,12 @@ def generate_followup_questions(
             },
             "format": {
                 "type": "array",
-                "item": {"field": "str", "question": "str", "priority": "critical|normal|optional", "suggestions?": "list[str]"}
+                "item": {
+                    "field": "str",
+                    "question": "str",
+                    "priority": "critical|normal|optional",
+                    "suggestions?": "list[str]",
+                },
             },
             "language": lang,
         },
@@ -263,25 +335,36 @@ def generate_followup_questions(
             resp = client.responses.create(
                 model=DEFAULT_LOW_COST_MODEL,
                 input=[
-                    {"role": "system", "content": "You are a meticulous recruitment analyst."},
-                    {"role": "user", "content": json.dumps(user_msg, ensure_ascii=False)},
+                    {
+                        "role": "system",
+                        "content": "You are a meticulous recruitment analyst.",
+                    },
+                    {
+                        "role": "user",
+                        "content": json.dumps(user_msg, ensure_ascii=False),
+                    },
                 ],
                 response_format={"type": "json_object"},
                 temperature=0.1,
             )
             text = getattr(resp, "output_text", None) or "{}"
             data = json.loads(text)
-            items = data if isinstance(data, list) else data.get("items") or data.get("questions") or []
+            items = (
+                data
+                if isinstance(data, list)
+                else data.get("items") or data.get("questions") or []
+            )
         except Exception:
             items = []
     else:
         # Chat fallback
-        chat_prompt = (
-            f"{instruction}\nN={num_questions}\n\nContext:\n{json.dumps(payload, ensure_ascii=False)}"
-        )
+        chat_prompt = f"{instruction}\nN={num_questions}\n\nContext:\n{json.dumps(payload, ensure_ascii=False)}"
         raw = call_chat_api(
             messages=[
-                {"role": "system", "content": "You are a meticulous recruitment analyst."},
+                {
+                    "role": "system",
+                    "content": "You are a meticulous recruitment analyst.",
+                },
                 {"role": "user", "content": chat_prompt},
             ],
             temperature=0.1,
@@ -294,7 +377,13 @@ def generate_followup_questions(
             items = []
             for line in raw.splitlines():
                 if "?" in line:
-                    items.append({"field": "", "question": line.strip("-*• 0123456789.\t "), "priority": "normal"})
+                    items.append(
+                        {
+                            "field": "",
+                            "question": line.strip("-*• 0123456789.\t "),
+                            "priority": "normal",
+                        }
+                    )
 
     # 5) Post-process: default priorities, attach suggestions, cap length
     out: List[Dict[str, Any]] = []
@@ -307,14 +396,21 @@ def generate_followup_questions(
 
         # Default / fixup priority
         if pr not in {"critical", "normal", "optional"}:
-            pr = _priority_for(field, is_missing_esco_skill=(q.lower() in esco_set or field in {"hard_skills", "qualifications"}))
+            pr = _priority_for(
+                field,
+                is_missing_esco_skill=(
+                    q.lower() in esco_set or field in {"hard_skills", "qualifications"}
+                ),
+            )
 
         # Merge RAG suggestions if field present and none attached
         if field and not sugg and rag_map.get(field):
             sugg = rag_map[field][:6]
 
         if field or q:
-            out.append({"field": field, "question": q, "priority": pr, "suggestions": sugg})
+            out.append(
+                {"field": field, "question": q, "priority": pr, "suggestions": sugg}
+            )
 
     # Sort: critical → normal → optional, keep original order within tier; cap N
     rank = {"critical": 0, "normal": 1, "optional": 2}

--- a/questions/augment.py
+++ b/questions/augment.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List
 
-from esco_utils import get_essential_skills
+from core.esco_utils import get_essential_skills
 
 
 def missing_esco_skills(

--- a/questions/generate.py
+++ b/questions/generate.py
@@ -6,7 +6,7 @@ import json
 from typing import List
 
 from core.schema import ALL_FIELDS, VacalyserJD
-from esco_utils import classify_occupation, get_essential_skills
+from core.esco_utils import classify_occupation, get_essential_skills
 from openai_utils import call_chat_api
 
 from .missing import missing_fields

--- a/tests/test_esco_utils.py
+++ b/tests/test_esco_utils.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from esco_utils import classify_occupation, get_essential_skills  # noqa: E402
+from core.esco_utils import classify_occupation, get_essential_skills  # noqa: E402
 
 
 def test_classify_occupation(monkeypatch):
@@ -37,7 +37,7 @@ def test_classify_occupation(monkeypatch):
         data = {"title": "Software developers"}
         return Resp(data)
 
-    monkeypatch.setattr("esco_utils.requests.get", fake_get)
+    monkeypatch.setattr("core.esco_utils.requests.get", fake_get)
     res = classify_occupation("Software engineer")
     assert res == {
         "preferredLabel": "software developer",
@@ -65,6 +65,6 @@ def test_get_essential_skills(monkeypatch):
 
         return Resp()
 
-    monkeypatch.setattr("esco_utils.requests.get", fake_get)
+    monkeypatch.setattr("core.esco_utils.requests.get", fake_get)
     skills = get_essential_skills("http://example.com/occ")
     assert skills == ["Project management", "Python"]

--- a/tests/test_question_logic.py
+++ b/tests/test_question_logic.py
@@ -18,7 +18,12 @@ def test_generate_followup_questions(monkeypatch):
     monkeypatch.setattr("question_logic.call_chat_api", fake_call_chat_api)
     questions = generate_followup_questions({"company_name": "ACME"})
     assert questions == [
-        {"field": "salary_range", "question": "What is the salary range?"}
+        {
+            "field": "salary_range",
+            "question": "What is the salary range?",
+            "priority": "critical",
+            "suggestions": [],
+        }
     ]
 
 
@@ -49,9 +54,9 @@ def test_role_specific_payload(monkeypatch):
 
     generate_followup_questions({"job_title": "Software engineer"})
 
-    payload_json = captured["payload"].split("Current data:\n", 1)[1]
+    payload_json = captured["payload"].split("Context:\n", 1)[1]
     data = json.loads(payload_json)
-    assert "programming_languages" in data
-    assert data["esco_group"] == "Software developers"
-    assert data["esco_occupation"] == "Software developer"
+    assert "programming_languages" in data["current"]
+    assert data["occupation"]["group"] == "Software developers"
+    assert data["occupation"]["preferredLabel"] == "Software developer"
     assert data["missing_esco_skills"] == ["Project management"]


### PR DESCRIPTION
## Summary
- move ESCO utilities into core module and add LRU caching to ESCO API calls
- normalize RAG skill suggestions via `enrich_skills_with_esco`
- update imports and tests to new `core.esco_utils` path

## Testing
- `ruff check core/esco_utils.py questions/generate.py questions/augment.py openai_utils.py esco/normalize.py question_logic.py tests/test_esco_utils.py tests/test_question_logic.py`
- `mypy --config-file=/tmp/mypy.ini core/esco_utils.py questions/generate.py questions/augment.py openai_utils.py esco/normalize.py question_logic.py tests/test_esco_utils.py tests/test_question_logic.py`
- `pytest -c /tmp/pytest.ini /workspace/cognitivestaffing/tests/test_esco_utils.py /workspace/cognitivestaffing/tests/test_question_logic.py`


------
https://chatgpt.com/codex/tasks/task_e_689a7812f9188320993514b2010f776a