### PR TITLE
fix: prompt when OpenAI API key missing

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,8 +1,11 @@
 import os
+import warnings
+
 import streamlit as st
 
 try:
     from dotenv import load_dotenv
+
     load_dotenv()
 except ImportError:
     pass
@@ -24,9 +27,15 @@ except Exception:
 if OPENAI_API_KEY:
     try:
         import openai
+
         openai.api_key = OPENAI_API_KEY
     except ImportError:
         pass
+else:
+    warnings.warn(
+        "OpenAI API key is not set. Set the OPENAI_API_KEY environment variable or add it to Streamlit secrets.",
+        RuntimeWarning,
+    )
 
 DATABASE_URL = os.getenv("DATABASE_URL", "")
 SECRET_KEY = os.getenv("SECRET_KEY", "replace-me")

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -1,7 +1,7 @@
-from config import OPENAI_MODEL, OPENAI_API_KEY
+from config import OPENAI_API_KEY, OPENAI_MODEL
 import openai
 
-# Set API key for OpenAI
+# Set API key for OpenAI if available
 if OPENAI_API_KEY:
     openai.api_key = OPENAI_API_KEY
 
@@ -12,9 +12,17 @@ def call_chat_api(
     max_tokens: int = 500,
     temperature: float = 0.5,
 ) -> str:
-    """Generic helper to call OpenAI ChatCompletion API and return the response text."""
+    """Generic helper to call OpenAI ChatCompletion API and return the response text.
+
+    Raises:
+        RuntimeError: If the OpenAI API key is missing or the API request fails.
+    """
     if model is None:
         model = OPENAI_MODEL
+    if not OPENAI_API_KEY:
+        raise RuntimeError(
+            "OpenAI API key is not set. Set the OPENAI_API_KEY environment variable or add it to Streamlit secrets."
+        )
     try:
         response = openai.ChatCompletion.create(  # type: ignore[attr-defined]
             model=model,
@@ -24,8 +32,7 @@ def call_chat_api(
         )
         return (response["choices"][0]["message"]["content"] or "").strip()
     except Exception as e:
-        print(f"OpenAI API error: {e}")
-        return ""
+        raise RuntimeError(f"OpenAI API error: {e}") from e
 
 
 def suggest_additional_skills(

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -1,0 +1,12 @@
+import pytest
+
+from openai_utils import call_chat_api
+
+
+def test_call_chat_api_raises_when_no_api_key(monkeypatch):
+    """call_chat_api should raise if OpenAI API key is missing."""
+    monkeypatch.setattr("openai_utils.OPENAI_API_KEY", "")
+    monkeypatch.setattr("openai_utils.openai.api_key", None, raising=False)
+
+    with pytest.raises(RuntimeError):
+        call_chat_api([{"role": "user", "content": "hi"}])

--- a/tests/test_question_logic.py
+++ b/tests/test_question_logic.py
@@ -16,6 +16,7 @@ def test_generate_followup_questions(monkeypatch):
         return '[{"field": "salary_range", "question": ' '"What is the salary range?"}]'
 
     monkeypatch.setattr("question_logic.call_chat_api", fake_call_chat_api)
+    monkeypatch.setattr("question_logic.OPENAI_API_KEY", "")
     questions = generate_followup_questions({"company_name": "ACME"})
     assert questions == [
         {
@@ -51,6 +52,7 @@ def test_role_specific_payload(monkeypatch):
     monkeypatch.setattr("question_logic.call_chat_api", fake_call_chat_api)
     monkeypatch.setattr("question_logic.classify_occupation", fake_classify)
     monkeypatch.setattr("question_logic.get_essential_skills", fake_get_skills)
+    monkeypatch.setattr("question_logic.OPENAI_API_KEY", "")
 
     generate_followup_questions({"job_title": "Software engineer"})
 


### PR DESCRIPTION
## Summary
- warn at startup when OPENAI_API_KEY is not configured
- raise a clear error from OpenAI chat helper when key is missing or request fails
- add safeguards and tests around missing API key

## Testing
- `ruff check config.py openai_utils.py question_logic.py tests/test_openai_utils.py tests/test_question_logic.py`
- `mypy config.py openai_utils.py question_logic.py tests/test_question_logic.py tests/test_openai_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b0d23915083208726899412084b9d