### PR TITLE
feat: prefer structured outputs for extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## Highlights
 - **Dynamic Wizard**: multi‑step, bilingual (EN/DE), low‑friction inputs
 - **One‑hop extraction**: Parse PDFs/DOCX/URLs into 20+ fields
+- **Structured output**: function calling/JSON mode ensures valid responses
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **No system OCR deps**: **OpenAI Vision** by default (override via `OCR_BACKEND`)


### PR DESCRIPTION
## Summary
- try OpenAI structured outputs (JSON schema or function call) before plain text to reduce parsing errors
- document structured output feature in README highlights

## Testing
- `ruff check .`
- `black llm/client.py`
- `mypy llm/client.py --follow-imports=skip --no-warn-unused-ignores`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b1908693c8320a45fefd24c3f7fcf