### PR TITLE
fix: surface openai errors to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **No system OCR deps**: **OpenAI Vision** by default (override via `OCR_BACKEND`)
 - **Cost‑aware**: hybrid models (4o‑mini default), minimal re‑asks
+- **Robust error handling**: user-facing alerts for API or network issues
 - **Export**: clean JSON profile, job‑ad markdown, interview guide
 
 ---

--- a/question_logic.py
+++ b/question_logic.py
@@ -363,17 +363,20 @@ def generate_followup_questions(
     else:
         # Chat fallback
         chat_prompt = f"{instruction}\nN={num_questions}\n\nContext:\n{json.dumps(payload, ensure_ascii=False)}"
-        raw = call_chat_api(
-            messages=[
-                {
-                    "role": "system",
-                    "content": "You are a meticulous recruitment analyst.",
-                },
-                {"role": "user", "content": chat_prompt},
-            ],
-            temperature=0.1,
-            max_tokens=600,
-        )
+        try:
+            raw = call_chat_api(
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "You are a meticulous recruitment analyst.",
+                    },
+                    {"role": "user", "content": chat_prompt},
+                ],
+                temperature=0.1,
+                max_tokens=600,
+            )
+        except Exception as e:  # pragma: no cover - network failure
+            raise RuntimeError(f"OpenAI API error: {e}") from e
         try:
             items = json.loads(raw)
         except Exception:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -124,10 +124,10 @@ def seo_optimize(text: str, max_keywords: int = 5) -> dict:
     if not text:
         return result
     words = re.findall(r"\b[a-zA-Z]{4,}\b", text.lower())
-    freq = {}
+    freq: dict[str, int] = {}
     for w in words:
         freq[w] = freq.get(w, 0) + 1
-    top_words = sorted(freq, key=freq.get, reverse=True)
+    top_words = sorted(freq, key=lambda k: freq[k], reverse=True)
     result["keywords"] = [w for w in top_words[:max_keywords]]
     first_sentence_end = re.search(r"[.!?]", text)
     if first_sentence_end:


### PR DESCRIPTION
## Summary
- improve wizard error handling for OpenAI calls and suggestions
- guard chat fallbacks in question_logic against OpenAI failures
- add type hints for SEO helper to satisfy mypy

## Testing
- `ruff check wizard.py question_logic.py utils/__init__.py --fix`
- `black wizard.py question_logic.py utils/__init__.py`
- `mypy wizard.py question_logic.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b2b18c10c8320ba14c0e3adfa3e3e