### PR TITLE
chore: remove legacy OCR references

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **RAG‑Assist**: use your vector store to fill/contextualize
-- **No system OCR deps**: **OpenAI Vision** by default (override via `OCR_BACKEND`)
+- **No system OCR deps**: uses **OpenAI Vision** (set `OCR_BACKEND=none` to disable)
 - **Cost‑aware**: hybrid models (4o‑mini default), minimal re‑asks
 - **Robust error handling**: user-facing alerts for API or network issues
 - **Export**: clean JSON profile, job‑ad markdown, interview guide

--- a/core/ocr_backends.py
+++ b/core/ocr_backends.py
@@ -12,18 +12,19 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 def extract_text(image_bytes: bytes, backend: str | None = None) -> str:
-    """Extract text from image bytes using the configured OCR backend.
+    """Extract text from image bytes using OpenAI Vision or a no-op.
 
     Args:
         image_bytes: Raw image data.
-        backend: Optional backend name overriding ``OCR_BACKEND`` env var.
+        backend: Optional backend name (``"openai"`` or ``"none"``)
+            overriding ``OCR_BACKEND`` env var.
 
     Returns:
         Recognised text. Returns an empty string if the backend is ``"none"``.
 
     Raises:
-        ValueError: If an unsupported backend is specified.
-        ImportError: If the OpenAI backend is selected but the package is missing.
+        ValueError: If ``backend`` is not ``"openai"`` or ``"none"``.
+        ImportError: If the OpenAI package is required but missing.
     """
     backend_name = (backend or os.getenv("OCR_BACKEND", "openai")).lower()
 

--- a/ingest/ocr.py
+++ b/ingest/ocr.py
@@ -8,7 +8,7 @@ from core.ocr_backends import extract_text as ocr_extract_text
 
 
 def ocr_pdf(pdf_path: str) -> str:
-    """Extract text from a PDF using the configured OCR backend.
+    """Extract text from a PDF using OpenAI Vision.
 
     Args:
         pdf_path: Path to the PDF file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,3 @@ requests>=2.31
 tenacity>=8.2
 typing-extensions>=4.8
 
-# Optional extras
-# OCR
-# pdf
-# Environment
-# python-dotenv>=1.0.1
-


### PR DESCRIPTION
## Summary
- clarify OCR docs around OpenAI Vision only
- drop unused OCR extras from requirements

## Testing
- `ruff check .`
- `black core/ocr_backends.py ingest/ocr.py`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b3612674483209265474e38a3c018