### PR TITLE
fix: make vector store configurable for rag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,8 @@ Normalize role context and surface **missing essential skills** by ESCO; standar
 
 ## 3) RAG Completion Agent
 
-**Purpose**  
-Fill or propose values for missing fields using your **OpenAI vector store** (id: `vs_67e40071e7608191a62ab06cacdcdd10`).
+**Purpose**
+Fill or propose values for missing fields using your **OpenAI vector store** (set via the `VECTOR_STORE_ID` env var; omit to disable).
 
 **Inputs**  
 - job context (title + industry + current JSON)  

--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ git clone https://github.com/KleinerBaum/cognitivestaffing
 cd cognitivestaffing
 pip install -r requirements.txt  # or: pip install -e .
 streamlit run app.py
+```
+
+### Optional: RAG vector store
+
+To enable retrieval-augmented suggestions, create an OpenAI vector store and
+set the environment variable `VECTOR_STORE_ID` to its ID:
+
+```bash
+export VECTOR_STORE_ID=vs_XXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+If `VECTOR_STORE_ID` is unset or empty, Vacalyser runs without RAG.


### PR DESCRIPTION
## Summary
- read `VECTOR_STORE_ID` from environment without hard-coded default and skip RAG when absent
- document optional vector-store setup and RAG disablement in README and agent docs

## Testing
- `ruff check .`
- `black --check question_logic.py`
- `mypy question_logic.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b41ef420883208558dab7602a6fba