### PR TITLE
fix: migrate to OpenAI client v1

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -1,9 +1,10 @@
-from config import OPENAI_API_KEY, OPENAI_MODEL
-import openai
+from typing import Any, cast
 
-# Set API key for OpenAI if available
-if OPENAI_API_KEY:
-    openai.api_key = OPENAI_API_KEY
+from openai import OpenAI
+
+from config import OPENAI_API_KEY, OPENAI_MODEL
+
+client = OpenAI(api_key=OPENAI_API_KEY) if OPENAI_API_KEY else None
 
 
 def call_chat_api(
@@ -19,18 +20,18 @@ def call_chat_api(
     """
     if model is None:
         model = OPENAI_MODEL
-    if not OPENAI_API_KEY:
+    if client is None:
         raise RuntimeError(
             "OpenAI API key is not set. Set the OPENAI_API_KEY environment variable or add it to Streamlit secrets."
         )
     try:
-        response = openai.ChatCompletion.create(  # type: ignore[attr-defined]
+        response = client.chat.completions.create(
             model=model,
-            messages=messages,
+            messages=cast(list[Any], messages),
             temperature=temperature,
             max_tokens=max_tokens,
         )
-        return (response["choices"][0]["message"]["content"] or "").strip()
+        return (response.choices[0].message.content or "").strip()
     except Exception as e:
         raise RuntimeError(f"OpenAI API error: {e}") from e
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,19 +1,55 @@
+"""Tests for the OpenAI LLM client helper."""
+
 import json
 
 import llm.client as client
 
 
-def fake_create(**kwargs):
+class _FakeFunctionCall:
+    """Minimal stand-in for OpenAI function call payload."""
+
+    def __init__(self, arguments: str | None = None) -> None:
+        self.arguments = arguments
+
+
+class _FakeMessage:
+    """Minimal message object returned by the OpenAI client."""
+
+    def __init__(
+        self, content: str = "", function_call: _FakeFunctionCall | None = None
+    ) -> None:
+        self.content = content
+        self.function_call = function_call
+
+
+class _FakeChoice:
+    """Container mimicking a chat completion choice."""
+
+    def __init__(self, message: _FakeMessage) -> None:
+        self.message = message
+
+
+class _FakeResponse:
+    """Simplified response holding a single choice."""
+
+    def __init__(self, message: _FakeMessage) -> None:
+        self.choices = [_FakeChoice(message)]
+
+
+def fake_create(**kwargs):  # noqa: D401
+    """Return a fake OpenAI response object."""
+
     if client.MODE == "function":
-        return {
-            "choices": [
-                {"message": {"function_call": {"arguments": json.dumps({"job_title": "x"})}}}
-            ]
-        }
-    return {"choices": [{"message": {"content": "{}"}}]}
+        msg = _FakeMessage(
+            function_call=_FakeFunctionCall(arguments=json.dumps({"job_title": "x"}))
+        )
+        return _FakeResponse(msg)
+    return _FakeResponse(_FakeMessage(content="{}"))
 
 
 def test_extract_json_smoke(monkeypatch):
-    monkeypatch.setattr(client.openai.ChatCompletion, "create", fake_create)
+    """Smoke test for the extraction helper."""
+
+    monkeypatch.setattr(client.OPENAI_CLIENT.chat.completions, "create", fake_create)
     out = client.extract_json("text")
     assert isinstance(out, str) and out != ""

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -6,7 +6,7 @@ from openai_utils import call_chat_api
 def test_call_chat_api_raises_when_no_api_key(monkeypatch):
     """call_chat_api should raise if OpenAI API key is missing."""
     monkeypatch.setattr("openai_utils.OPENAI_API_KEY", "")
-    monkeypatch.setattr("openai_utils.openai.api_key", None, raising=False)
+    monkeypatch.setattr("openai_utils.client", None, raising=False)
 
     with pytest.raises(RuntimeError):
         call_chat_api([{"role": "user", "content": "hi"}])


### PR DESCRIPTION
## Summary
- refactor OpenAI utilities to use the `OpenAI` client and v1 chat completions
- update LLM client and tests for new API surface

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b493fb05c832091eafc6097e54945