### PR TITLE
feat: support function calls for extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - **Dynamic Wizard**: multi‑step, bilingual (EN/DE), low‑friction inputs
 - **One‑hop extraction**: Parse PDFs/DOCX/URLs into 20+ fields
 - **Structured output**: function calling/JSON mode ensures valid responses
+- **API helper**: `call_chat_api` supports OpenAI function calls for reliable extraction
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG, shown inline in relevant steps
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **RAG‑Assist**: use your vector store to fill/contextualize

--- a/llm/client.py
+++ b/llm/client.py
@@ -19,7 +19,9 @@ MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 OPENAI_CLIENT = OpenAI(api_key=os.getenv("OPENAI_API_KEY", ""))
 
 
-def _function_schema() -> dict[str, Any]:
+def build_extraction_function() -> dict[str, Any]:
+    """Return an OpenAI function schema for the vacancy profile."""
+
     properties: dict[str, Any] = {}
     for field in FIELDS_ORDER:
         if field in LIST_FIELDS:
@@ -95,7 +97,7 @@ def extract_json(
             if mode == "function":
                 response = OPENAI_CLIENT.chat.completions.create(  # type: ignore[call-overload]
                     **common,
-                    functions=[_function_schema()],
+                    functions=[build_extraction_function()],
                     function_call={"name": "return_extraction"},
                 )
                 call = response.choices[0].message.function_call

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -10,3 +10,32 @@ def test_call_chat_api_raises_when_no_api_key(monkeypatch):
 
     with pytest.raises(RuntimeError):
         call_chat_api([{"role": "user", "content": "hi"}])
+
+
+def test_call_chat_api_function_call(monkeypatch):
+    """Function call arguments should be returned when provided."""
+
+    class _FakeFunctionCall:
+        def __init__(self, arguments: str | None = None) -> None:
+            self.arguments = arguments
+
+    class _FakeMessage:
+        def __init__(self) -> None:
+            self.content = None
+            self.function_call = _FakeFunctionCall('{"job_title": "x"}')
+
+    class _FakeResponse:
+        def __init__(self) -> None:
+            self.choices = [type("Choice", (), {"message": _FakeMessage()})()]
+
+    class _FakeCompletions:
+        @staticmethod
+        def create(**kwargs):
+            return _FakeResponse()
+
+    class _FakeClient:
+        chat = type("Chat", (), {"completions": _FakeCompletions()})()
+
+    monkeypatch.setattr("openai_utils.client", _FakeClient(), raising=False)
+    out = call_chat_api([], functions=[{}], function_call={"name": "fn"})
+    assert out == '{"job_title": "x"}'


### PR DESCRIPTION
## Summary
- expand `call_chat_api` with OpenAI function-calling support
- expose function schema builder and wire extraction to use function calls
- test function-call path and document helper in README

## Testing
- `black openai_utils.py llm/client.py wizard.py tests/test_openai_utils.py`
- `ruff check openai_utils.py llm/client.py wizard.py tests/test_openai_utils.py`
- `mypy openai_utils.py llm/client.py wizard.py tests/test_openai_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b87303970832090985e1d34d7f091