### PR TITLE
feat: refine follow-up question selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **One‑hop extraction**: Parse PDFs/DOCX/URLs into 20+ fields
 - **Structured output**: function calling/JSON mode ensures valid responses
 - **API helper**: `call_chat_api` supports OpenAI function calls for reliable extraction
-- **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG, shown inline in relevant steps
+- **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance, shown inline in relevant steps
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **No system OCR deps**: uses **OpenAI Vision** (set `OCR_BACKEND=none` to disable)


### PR DESCRIPTION
## Summary
- tune follow-up generation to weigh critical vs optional fields and split qualifications into education & experience
- document dynamic follow-up behaviour

## Testing
- `ruff check question_logic.py tests/test_question_logic.py`
- `mypy question_logic.py tests/test_question_logic.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b8cd9f05083208427415b56355175