### PR TITLE
feat: prefill follow-ups with hints

### DIFF
--- a/tests/test_followup_inline.py
+++ b/tests/test_followup_inline.py
@@ -18,3 +18,22 @@ def test_render_followups_updates_state(monkeypatch) -> None:
 
     assert st.session_state["salary"] == "100k"
     assert st.session_state["followup_questions"] == []
+
+
+def test_render_followups_prefill(monkeypatch) -> None:
+    """Prefill values should appear as default text."""
+    st.session_state.clear()
+    st.session_state["lang"] = "en"
+    st.session_state["followup_questions"] = [
+        {"field": "location", "question": "Location?", "prefill": "Berlin"}
+    ]
+
+    def fake_input(label, value="", key=None):
+        assert value == "Berlin"
+        return value
+
+    monkeypatch.setattr(st, "text_input", fake_input)
+    render_followups_for(["location"])
+
+    assert st.session_state["location"] == "Berlin"
+    assert st.session_state["followup_questions"] == []

--- a/wizard.py
+++ b/wizard.py
@@ -103,9 +103,8 @@ def render_followups_for(fields: list[str] | None = None) -> None:
         question = item.get("question", "")
         key = field or question
         if field:
-            st.session_state[field] = st.text_input(
-                question, st.session_state.get(field, ""), key=key
-            )
+            default_val = st.session_state.get(field) or item.get("prefill", "")
+            st.session_state[field] = st.text_input(question, default_val, key=key)
         else:
             _ = st.text_input(question, "", key=key)
 


### PR DESCRIPTION
## Summary
- suggest default answers for yes/no follow-up questions
- prefill follow-up fields from vector-store hints
- display prefill text in wizard inputs

## Testing
- `ruff check question_logic.py tests/test_followup_inline.py tests/test_question_logic.py wizard.py`
- `black question_logic.py tests/test_followup_inline.py tests/test_question_logic.py wizard.py`
- `timeout 30s mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b909e34dc8320a35438d3ab14f4e0