### PR TITLE
feat: customize boolean search fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - **Cost‑aware**: hybrid models (4o‑mini default), minimal re‑asks
 - **Robust error handling**: user-facing alerts for API or network issues
 - **Cross-field deduplication**: avoids repeating the same information across multiple fields
+- **Boolean Builder 2.0**: interactive search string with selectable skills and title synonyms
 - **Export**: clean JSON profile, job‑ad markdown, interview guide
 
 ---

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,3 +66,22 @@ def test_extract_text_from_url(monkeypatch):
 
     text = utils.extract_text_from_url("http://example.com")
     assert "Hello URL" in text and "nope" not in text
+
+
+def test_build_boolean_query_basic():
+    query = utils.build_boolean_query("Data Scientist", ["Python", "SQL"])
+    assert query == '("Data Scientist") AND ("Python" OR "SQL")'
+
+
+def test_build_boolean_query_exclude_title():
+    query = utils.build_boolean_query("Data Scientist", ["Python"], include_title=False)
+    assert query == '"Python"'
+
+
+def test_build_boolean_query_with_synonyms():
+    query = utils.build_boolean_query(
+        "Developer",
+        ["Python"],
+        title_synonyms=["Engineer", "Programmer"],
+    )
+    assert query == '("Developer" OR "Engineer" OR "Programmer") AND ("Python")'


### PR DESCRIPTION
## Summary
- allow users to include/exclude job title and skills when building boolean search queries
- support job title synonyms in boolean query generation
- document boolean builder customization and add unit tests

## Testing
- `black utils/__init__.py wizard.py tests/test_utils.py`
- `ruff check utils/__init__.py wizard.py tests/test_utils.py`
- `mypy utils/__init__.py wizard.py tests/test_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba767b3708320a99db399b359e86c