### PR TITLE
feat: add export download buttons

### DIFF
--- a/tests/test_export_utils.py
+++ b/tests/test_export_utils.py
@@ -1,0 +1,38 @@
+import json
+from io import BytesIO
+
+import docx
+import fitz
+
+from utils.export import (
+    prepare_download_data,
+    text_to_docx,
+    text_to_pdf,
+    text_to_json,
+)
+
+
+def test_text_to_docx() -> None:
+    data = text_to_docx("Hello")
+    document = docx.Document(BytesIO(data))
+    assert document.paragraphs[0].text == "Hello"
+
+
+def test_text_to_pdf() -> None:
+    data = text_to_pdf("Hello")
+    doc = fitz.open(stream=data, filetype="pdf")
+    assert doc.page_count == 1
+
+
+def test_text_to_json() -> None:
+    data = text_to_json("Hello", key="test", title="Title")
+    obj = json.loads(data.decode("utf-8"))
+    assert obj == {"type": "test", "content": "Hello", "title": "Title"}
+
+
+def test_prepare_download_data_docx() -> None:
+    data, mime, ext = prepare_download_data("Hello", "docx", key="test")
+    assert ext == "docx"
+    assert mime.startswith("application/vnd")
+    document = docx.Document(BytesIO(data))
+    assert document.paragraphs[0].text == "Hello"

--- a/utils/export.py
+++ b/utils/export.py
@@ -1,0 +1,56 @@
+"""Utilities to export generated text into various file formats."""
+
+from __future__ import annotations
+
+from io import BytesIO
+import json
+
+import docx
+import fitz  # PyMuPDF
+
+
+def text_to_docx(text: str) -> bytes:
+    """Convert plain text into a DOCX binary."""
+    doc = docx.Document()
+    for line in text.splitlines():
+        doc.add_paragraph(line)
+    buffer = BytesIO()
+    doc.save(buffer)
+    return buffer.getvalue()
+
+
+def text_to_pdf(text: str) -> bytes:
+    """Convert plain text into a simple single-page PDF binary."""
+    doc = fitz.open()
+    page = doc.new_page()
+    rect = fitz.Rect(72, 72, page.rect.width - 72, page.rect.height - 72)
+    page.insert_textbox(rect, text, fontsize=12)
+    buffer = BytesIO()
+    doc.save(buffer)
+    return buffer.getvalue()
+
+
+def text_to_json(text: str, *, key: str, title: str | None = None) -> bytes:
+    """Wrap text in a structured JSON object and return as bytes."""
+    data: dict[str, str] = {"type": key, "content": text}
+    if title:
+        data["title"] = title
+    return json.dumps(data, ensure_ascii=False, indent=2).encode("utf-8")
+
+
+def prepare_download_data(
+    text: str, fmt: str, *, key: str, title: str | None = None
+) -> tuple[bytes, str, str]:
+    """Prepare data, mime type and extension for download."""
+    fmt = fmt.lower()
+    if fmt == "docx":
+        return (
+            text_to_docx(text),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "docx",
+        )
+    if fmt == "pdf":
+        return text_to_pdf(text), "application/pdf", "pdf"
+    if fmt == "json":
+        return text_to_json(text, key=key, title=title), "application/json", "json"
+    return text.encode("utf-8"), "text/markdown", "md"

--- a/wizard.py
+++ b/wizard.py
@@ -10,6 +10,7 @@ from utils import (
     seo_optimize,
     ensure_logs_dir,
 )
+from utils.export import prepare_download_data
 from openai_utils import (
     call_chat_api,
     suggest_additional_skills,
@@ -703,6 +704,29 @@ def summary_outputs_page():
                     st.markdown(f"**SEO Keywords:** `{', '.join(seo['keywords'])}`")
                 if seo["meta_description"]:
                     st.markdown(f"**Meta Description:** {seo['meta_description']}")
+                fmt_label = "Download format" if lang != "de" else "Download-Format"
+                job_fmt = st.selectbox(
+                    fmt_label,
+                    ["markdown", "docx", "pdf", "json"],
+                    key="job_ad_format",
+                )
+                data, mime, ext = prepare_download_data(
+                    job_ad_text,
+                    job_fmt,
+                    key="job_ad",
+                    title=st.session_state.get("job_title"),
+                )
+                dl_label = (
+                    "💾 Download Job Ad"
+                    if lang != "de"
+                    else "💾 Stellenanzeige herunterladen"
+                )
+                st.download_button(
+                    dl_label,
+                    data=data,
+                    file_name=f"job_ad.{ext}",
+                    mime=mime,
+                )
                 log_event(f"JOB_AD by {st.session_state.get('user', 'anonymous')}")
     with colB:
         if st.button("📝 Generate Interview Guide"):
@@ -737,6 +761,29 @@ def summary_outputs_page():
                     ),
                 )
                 st.write(guide)
+                fmt_label = "Download format" if lang != "de" else "Download-Format"
+                guide_fmt = st.selectbox(
+                    fmt_label,
+                    ["markdown", "docx", "pdf", "json"],
+                    key="guide_format",
+                )
+                data, mime, ext = prepare_download_data(
+                    guide,
+                    guide_fmt,
+                    key="interview_guide",
+                    title=st.session_state.get("job_title"),
+                )
+                dl_label = (
+                    "💾 Download Interview Guide"
+                    if lang != "de"
+                    else "💾 Leitfaden herunterladen"
+                )
+                st.download_button(
+                    dl_label,
+                    data=data,
+                    file_name=f"interview_guide.{ext}",
+                    mime=mime,
+                )
                 log_event(
                     f"INTERVIEW_GUIDE by {st.session_state.get('user', 'anonymous')}"
                 )


### PR DESCRIPTION
## Summary
- add Streamlit download options for job ads and interview guides in multiple formats
- create utility helpers for DOCX, PDF and JSON export
- cover export utilities with tests

## Testing
- `ruff check .`
- `black .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba8dd6c008320bc2f0b8aa8ad2442