### PR TITLE
feat: add introductory wizard page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - **Cross-field deduplication**: avoids repeating the same information across multiple fields
 - **Boolean Builder 2.0**: interactive search string with selectable skills and title synonyms
 - **Export**: clean JSON profile, job‑ad markdown, interview guide
+- **Onboarding Intro**: welcome step explains required inputs and allows skipping for returning users
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from wizard import (
     apply_global_styling,
     show_progress_bar,
     show_navigation,
+    intro_page,
     start_discovery_page,
     company_information_page,
     role_description_page,
@@ -24,8 +25,12 @@ st.set_page_config(
 inject_tailwind(theme="dark")
 
 # Initialize session state defaults
+if "skip_intro" not in st.session_state:
+    st.session_state["skip_intro"] = False
 if "current_section" not in st.session_state:
     st.session_state["current_section"] = 0
+if st.session_state.get("skip_intro") and st.session_state["current_section"] == 0:
+    st.session_state["current_section"] = 1
 if "lang" not in st.session_state:
     st.session_state["lang"] = "de" if DEFAULT_LANGUAGE.startswith("de") else "en"
 if "llm_model" not in st.session_state:
@@ -44,6 +49,7 @@ st.session_state["lang"] = "de" if lang_choice == "Deutsch" else "en"
 
 # Define wizard sections and their corresponding page functions
 sections = [
+    {"name": "Intro", "func": intro_page},
     {"name": "Start", "func": start_discovery_page},
     {"name": "Company Info", "func": company_information_page},
     {"name": "Role Description", "func": role_description_page},
@@ -57,6 +63,7 @@ sections = [
 # Render current section
 idx = st.session_state["current_section"]
 total = len(sections)
-show_progress_bar(idx, total)
+offset = 1 if st.session_state.get("skip_intro") else 0
+show_progress_bar(max(idx - offset, 0), total - offset)
 sections[idx]["func"]()
 show_navigation(idx, total)

--- a/wizard.py
+++ b/wizard.py
@@ -128,6 +128,41 @@ def render_followups_for(fields: list[str] | None = None) -> None:
     ]
 
 
+def intro_page() -> None:
+    """Display an introductory page explaining the wizard flow."""
+    lang = st.session_state.get("lang", "en")
+    if lang == "de":
+        st.title("Willkommen bei Vacalyzer")
+        st.write(
+            "Dieses Tool hilft Ihnen, eine Stellenanzeige zu analysieren und fehlende Informationen zu sammeln."
+        )
+        st.subheader("Sie benötigen")
+        st.markdown("- Stellenanzeige (URL oder PDF)")
+        st.markdown("- Kenntnisse über Unternehmensdetails")
+        st.write(
+            "Der Prozess umfasst 9 Schritte und generiert am Ende eine Stellenanzeige sowie einen Interviewleitfaden."
+        )
+        st.checkbox("Intro beim nächsten Mal überspringen", key="skip_intro")
+        if st.button("🚀 Los geht's"):
+            st.session_state["current_section"] = 1
+            st.rerun()
+    else:
+        st.title("Welcome to Vacalyzer")
+        st.write(
+            "This tool will help you analyze a job ad and gather missing information."
+        )
+        st.subheader("You'll need")
+        st.markdown("- Job description (URL or PDF)")
+        st.markdown("- Knowledge of company details")
+        st.write(
+            "The process has 9 steps and will generate a job ad and interview guide at the end."
+        )
+        st.checkbox("Skip intro next time", key="skip_intro")
+        if st.button("🚀 Get Started"):
+            st.session_state["current_section"] = 1
+            st.rerun()
+
+
 def start_discovery_page():
     """Start page: Input job title and job ad content (URL or file) for analysis."""
     lang = st.session_state.get("lang", "en")


### PR DESCRIPTION
## Summary
- add bilingual intro page to wizard with optional skip for returning users
- include intro step in app sections and adjust progress handling
- document new onboarding step in README

## Testing
- `ruff check --fix .`
- `black .`
- `mypy .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bad1cbea88320b4b89dca5ce60899