### PR TITLE
feat: enrich job ad prompt with more fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - **Cross-field deduplication**: avoids repeating the same information across multiple fields
 - **Boolean Builder 2.0**: interactive search string with selectable skills and title synonyms
 - **Export**: clean JSON profile, job‑ad markdown, interview guide
+- **Comprehensive job ads**: generated ads now mention requirements, salary and work policy when provided
 - **Onboarding Intro**: welcome step explains required inputs and allows skipping for returning users
 
 ---

--- a/tests/test_generate_job_ad.py
+++ b/tests/test_generate_job_ad.py
@@ -1,0 +1,30 @@
+import openai_utils
+
+
+def test_generate_job_ad_includes_optional_fields(monkeypatch):
+    captured = {}
+
+    def fake_call_chat_api(messages, **kwargs):
+        captured["prompt"] = messages[0]["content"]
+        return "ok"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+
+    session = {
+        "job_title": "Software Engineer",
+        "company_name": "Acme Corp",
+        "location": "Berlin",
+        "role_summary": "Build web apps",
+        "tasks": "Develop features",
+        "benefits": "Stock options",
+        "qualifications": "Python experience",
+        "remote_policy": "Remote-friendly",
+        "salary_range": "€50k-70k",
+        "lang": "en",
+    }
+
+    openai_utils.generate_job_ad(session)
+    prompt = captured["prompt"]
+    assert "Requirements: Python experience" in prompt
+    assert "Work Policy: Remote-friendly" in prompt
+    assert "Salary Range: €50k-70k" in prompt


### PR DESCRIPTION
## Summary
- expand job ad prompt to include optional fields like requirements, salary range, and remote policy
- document comprehensive job ad generation in README
- test that optional fields appear in generated job ad prompts

## Testing
- `black openai_utils.py tests/test_generate_job_ad.py`
- `ruff check openai_utils.py tests/test_generate_job_ad.py`
- `mypy openai_utils.py tests/test_generate_job_ad.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689baf65ba70832084de709be0484f94