### PR TITLE
feat: highlight critical follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **One‑hop extraction**: Parse PDFs/DOCX/URLs into 20+ fields
 - **Structured output**: function calling/JSON mode ensures valid responses
 - **API helper**: `call_chat_api` supports OpenAI function calls for reliable extraction
-- **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance, shown inline in relevant steps
+- **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance, shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **No system OCR deps**: uses **OpenAI Vision** (set `OCR_BACKEND=none` to disable)

--- a/tests/test_followup_inline.py
+++ b/tests/test_followup_inline.py
@@ -37,3 +37,30 @@ def test_render_followups_prefill(monkeypatch) -> None:
 
     assert st.session_state["location"] == "Berlin"
     assert st.session_state["followup_questions"] == []
+
+
+def test_render_followups_critical_prefix(monkeypatch) -> None:
+    """Critical questions should be prefixed with a red asterisk."""
+    st.session_state.clear()
+    st.session_state["lang"] = "en"
+    st.session_state["followup_questions"] = [
+        {"field": "salary", "question": "Salary?", "priority": "critical"}
+    ]
+
+    seen = {"markdown": None, "label": None}
+
+    def fake_markdown(text, **_):
+        seen["markdown"] = text
+
+    def fake_input(label, value="", key=None):
+        seen["label"] = label
+        return "100k"
+
+    monkeypatch.setattr(st, "markdown", fake_markdown)
+    monkeypatch.setattr(st, "text_input", fake_input)
+
+    render_followups_for(["salary"])
+
+    assert seen["markdown"] is not None
+    assert seen["markdown"].lstrip().startswith("<span style='color:red'>*")
+    assert seen["label"] == ""

--- a/wizard.py
+++ b/wizard.py
@@ -96,6 +96,9 @@ def show_navigation(current_step: int, total_steps: int):
 def render_followups_for(fields: list[str] | None = None) -> None:
     """Display follow-up questions inline for specified fields.
 
+    Critical questions are prefixed with a red asterisk to signal required
+    input.
+
     Args:
         fields: List of field names relevant to the current page. If ``None``,
             all follow-up questions are considered.
@@ -120,11 +123,21 @@ def render_followups_for(fields: list[str] | None = None) -> None:
         field = item.get("field", "")
         question = item.get("question", "")
         key = field or question
+        is_critical = item.get("priority") == "critical"
+
+        label = ""
+        if is_critical:
+            st.markdown(
+                f"<span style='color:red'>* {question}</span>", unsafe_allow_html=True
+            )
+        else:
+            label = question
+
         if field:
             default_val = st.session_state.get(field) or item.get("prefill", "")
-            st.session_state[field] = st.text_input(question, default_val, key=key)
+            st.session_state[field] = st.text_input(label, default_val, key=key)
         else:
-            _ = st.text_input(question, "", key=key)
+            _ = st.text_input(label, "", key=key)
 
         suggestions = item.get("suggestions") or []
         if suggestions and field:


### PR DESCRIPTION
## Summary
- prefix red asterisk for critical follow-up questions
- document critical follow-up styling in README
- test critical question highlighting

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bb3faf6208320936562475ce5b1d5