### PR TITLE
feat: make interview question count configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - **Cross-field deduplication**: avoids repeating the same information across multiple fields
 - **Boolean Builder 2.0**: interactive search string with selectable skills and title synonyms
 - **Export**: clean JSON profile, job‑ad markdown, interview guide
+- **Customizable interview guides**: choose 3–10 questions
 - **Comprehensive job ads**: generated ads now mention requirements, salary and work policy when provided
 - **Onboarding Intro**: welcome step explains required inputs and allows skipping for returning users
 

--- a/wizard.py
+++ b/wizard.py
@@ -794,6 +794,18 @@ def summary_outputs_page():
                 )
                 log_event(f"JOB_AD by {st.session_state.get('user', 'anonymous')}")
     with colB:
+        q_label = (
+            "Number of interview questions"
+            if lang != "de"
+            else "Anzahl der Interviewfragen"
+        )
+        num_questions = st.slider(
+            q_label,
+            min_value=3,
+            max_value=10,
+            value=5,
+            key="num_questions",
+        )
         if st.button("📝 Generate Interview Guide"):
             title = st.session_state.get("job_title", "")
             tasks = st.session_state.get("tasks", "") or st.session_state.get(
@@ -806,7 +818,7 @@ def summary_outputs_page():
                         title,
                         tasks,
                         audience="hiring managers",
-                        num_questions=5,
+                        num_questions=num_questions,
                         lang=lang,
                     )
                 except Exception:  # pragma: no cover - network failure


### PR DESCRIPTION
## Summary
- allow users to choose number of interview guide questions (3-10)
- document customizable interview guides

## Testing
- `black wizard.py`
- `ruff check wizard.py`
- `mypy wizard.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bb523477083209f62b4f25091bf06