### PR TITLE
feat: group summary fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - **Cost‑aware**: hybrid models (4o‑mini default), minimal re‑asks
 - **Robust error handling**: user-facing alerts for API or network issues
 - **Cross-field deduplication**: avoids repeating the same information across multiple fields
+- **Categorized summary**: groups related fields under clear headings for faster review
 - **Boolean Builder 2.0**: interactive search string with selectable skills and title synonyms
 - **Export**: clean JSON profile, job‑ad markdown, interview guide
 - **Customizable interview guides**: choose 3–10 questions


### PR DESCRIPTION
## Summary
- group vacancy summary fields by logical categories with localized headings
- document categorized summary view in README

## Testing
- `black wizard.py`
- `ruff check .`
- `mypy --install-types --non-interactive --ignore-missing-imports .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bb66ca95c8320982a5da90bf7d7d6