### PR TITLE
feat: add model choice for suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **No system OCR deps**: uses **OpenAI Vision** (set `OCR_BACKEND=none` to disable)
 - **Cost‑aware**: hybrid models (4o‑mini default), minimal re‑asks
+- **Model toggle**: choose GPT‑3.5 (fast, cheap) or GPT‑4 (accurate) for suggestions
 - **Robust error handling**: user-facing alerts for API or network issues
 - **Cross-field deduplication**: avoids repeating the same information across multiple fields
 - **Categorized summary**: groups related fields under clear headings for faster review

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -1,0 +1,30 @@
+import openai_utils
+import core.esco_utils as esco_utils
+
+
+def test_suggest_additional_skills_model(monkeypatch):
+    captured = {}
+
+    def fake_call_chat_api(messages, model=None, **kwargs):
+        captured["model"] = model
+        return "- Tech1\n- Tech2\nSoft skills:\n- Communication"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+    monkeypatch.setattr(esco_utils, "normalize_skills", lambda skills, **_: skills)
+    out = openai_utils.suggest_additional_skills("Engineer", model="gpt-4")
+    assert captured["model"] == "gpt-4"
+    assert out["technical"] == ["Tech1", "Tech2"]
+    assert out["soft"] == ["Communication"]
+
+
+def test_suggest_benefits_model(monkeypatch):
+    captured = {}
+
+    def fake_call_chat_api(messages, model=None, **kwargs):
+        captured["model"] = model
+        return "- BenefitA\n- BenefitB"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+    out = openai_utils.suggest_benefits("Engineer", model="gpt-4")
+    assert captured["model"] == "gpt-4"
+    assert out == ["BenefitA", "BenefitB"]


### PR DESCRIPTION
## Summary
- allow skill and benefit helpers to choose OpenAI model
- add dropdowns to pick GPT-3.5 or GPT-4 next to suggestion buttons
- document model toggle and cover with tests

## Testing
- `python -m black tests/test_model_selection.py openai_utils.py wizard.py`
- `ruff check openai_utils.py wizard.py tests/test_model_selection.py`
- `mypy openai_utils.py wizard.py tests/test_model_selection.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bb9b8116c8320a2ed8219cc0d49f0