### PR TITLE
feat: normalize job type categories

### DIFF
--- a/docs/json_pipeline.md
+++ b/docs/json_pipeline.md
@@ -29,6 +29,9 @@ The schema contains 22 fields ordered for prompting:
 - languages_required
 - tools_and_technologies
 
+`job_type` values are normalized to one of the canonical categories:
+`Full-time`, `Part-time`, `Contract`, `Temporary`, or `Internship`.
+
 Example JSON produced by the pipeline:
 
 ```json

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,3 +1,5 @@
+import pytest
+
 from core.schema import (
     ALL_FIELDS,
     LIST_FIELDS,
@@ -34,7 +36,7 @@ def test_coerce_and_fill_partial_and_aliases() -> None:
     assert jd.job_title == "Engineer"
     assert jd.hard_skills == ["Python"]
     assert jd.qualifications == "BSc"
-    assert jd.job_type == "full-time"
+    assert jd.job_type == "Full-time"
     assert jd.responsibilities == ["Code apps"]
     assert jd.benefits == ["Gym"]
     # missing field filled with default
@@ -78,3 +80,13 @@ def test_cross_field_dedupe() -> None:
     assert jd.remote_policy == "Fully remote"
     assert jd.travel_required == ""
     assert jd.responsibilities == ["Develop APIs"]
+
+
+def test_job_type_normalization() -> None:
+    jd = coerce_and_fill({"job_type": "full time"})
+    assert jd.job_type == "Full-time"
+
+
+def test_job_type_invalid() -> None:
+    with pytest.raises(ValueError):
+        coerce_and_fill({"job_type": "unknown"})


### PR DESCRIPTION
## Summary
- standardize job type values via category mapping and validation
- document canonical job type categories
- test job type normalization and invalid inputs

## Testing
- `ruff check .`
- `black --check core/schema.py tests/test_schema.py`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bbbec41a08320a3dc3519716fbefd