### PR TITLE
feat: flag missing critical fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - **Robust error handling**: user-facing alerts for API or network issues
 - **Cross-field deduplication**: avoids repeating the same information across multiple fields
 - **Categorized summary**: groups related fields under clear headings for faster review
+- **Missing info alerts**: highlights empty critical fields in the summary and lets you jump back to fill them
 - **Boolean Builder 2.0**: interactive search string with selectable skills and title synonyms
 - **Export**: clean JSON profile, job‑ad markdown, interview guide
 - **Customizable interview guides**: choose 3–10 questions

--- a/tests/test_field_section_map.py
+++ b/tests/test_field_section_map.py
@@ -1,0 +1,10 @@
+"""Tests for FIELD_SECTION_MAP coverage of critical fields."""
+
+from wizard import FIELD_SECTION_MAP
+from question_logic import CRITICAL_FIELDS
+
+
+def test_all_critical_fields_mapped() -> None:
+    """Ensure every critical field has a section mapping."""
+    missing = CRITICAL_FIELDS - set(FIELD_SECTION_MAP)
+    assert not missing, f"Missing mappings for: {sorted(missing)}"


### PR DESCRIPTION
## Summary
- highlight missing critical fields on summary page and map them back to their wizard sections
- document missing-info alerts in README
- cover field-to-section mapping with tests

## Testing
- `ruff check tests/test_field_section_map.py wizard.py`
- `black .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bbfbc01e88320afddcddabda4e8ea