### PR TITLE
feat: add role-specific follow-up questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - **Structured output**: function calling/JSON mode ensures valid responses
 - **API helper**: `call_chat_api` supports OpenAI function calls for reliable extraction
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance, shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
+- **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, shift schedules for nurses).
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **No system OCR deps**: uses **OpenAI Vision** (set `OCR_BACKEND=none` to disable)

--- a/tests/test_question_logic.py
+++ b/tests/test_question_logic.py
@@ -65,6 +65,25 @@ def test_role_specific_payload(monkeypatch):
     assert data["missing_esco_skills"] == ["Project management"]
 
 
+def test_role_specific_extra_question(monkeypatch):
+    """Role-specific questions should be appended automatically."""
+
+    def fake_call_chat_api(
+        messages, temperature=0.0, max_tokens=0, model=None
+    ) -> str:  # noqa: E501
+        return "[]"
+
+    def fake_classify(job_title, lang="en"):
+        return {"group": "Software developers"}
+
+    monkeypatch.setattr("question_logic.call_chat_api", fake_call_chat_api)
+    monkeypatch.setattr("question_logic.classify_occupation", fake_classify)
+    monkeypatch.setattr("question_logic.OPENAI_API_KEY", "")
+
+    out = generate_followup_questions({"job_title": "Backend Developer"})
+    assert any(q["field"] == "programming_languages" for q in out)
+
+
 def test_optional_field_cap(monkeypatch):
     """Missing optional fields should not exceed the minimum question cap."""
 


### PR DESCRIPTION
## Summary
- ask predefined follow-up questions for specific occupations
- document role-aware extra prompts

## Testing
- `ruff check question_logic.py tests/test_question_logic.py`
- `mypy question_logic.py tests/test_question_logic.py`
- `pytest tests/test_question_logic.py::test_role_specific_extra_question tests/test_question_logic.py::test_role_specific_payload tests/test_question_logic.py::test_generate_followup_questions tests/test_question_logic.py::test_optional_field_cap tests/test_question_logic.py::test_qualification_split tests/test_question_logic.py::test_prefill_from_rag tests/test_question_logic.py::test_yes_no_default`

------
https://chatgpt.com/codex/tasks/task_e_689bc16699b483209e75c821f44f2863