### PR TITLE
feat: surface mission and culture in outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - **Export**: clean JSON profile, job‑ad markdown, interview guide
 - **Customizable interview guides**: choose 3–10 questions
 - **Comprehensive job ads**: generated ads now mention requirements, salary and work policy when provided
+- **Employer branding**: company mission and culture flow into job ads and interview guides
 - **Onboarding Intro**: welcome step explains required inputs and allows skipping for returning users
 
 ---

--- a/tests/test_generate_interview_guide.py
+++ b/tests/test_generate_interview_guide.py
@@ -1,0 +1,20 @@
+import openai_utils
+
+
+def test_generate_interview_guide_includes_culture(monkeypatch):
+    captured = {}
+
+    def fake_call_chat_api(messages, **kwargs):
+        captured["prompt"] = messages[0]["content"]
+        return "guide"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+
+    openai_utils.generate_interview_guide(
+        "Engineer",
+        tasks="",
+        company_culture="Collaborative and transparent",
+    )
+    prompt = captured["prompt"]
+    assert "Company culture: Collaborative and transparent" in prompt
+    assert "cultural fit" in prompt.lower()

--- a/tests/test_generate_job_ad.py
+++ b/tests/test_generate_job_ad.py
@@ -20,6 +20,8 @@ def test_generate_job_ad_includes_optional_fields(monkeypatch):
         "qualifications": "Python experience",
         "remote_policy": "Remote-friendly",
         "salary_range": "€50k-70k",
+        "company_mission": "Build the future of collaboration",
+        "company_culture": "Inclusive and growth-oriented",
         "lang": "en",
     }
 
@@ -28,3 +30,5 @@ def test_generate_job_ad_includes_optional_fields(monkeypatch):
     assert "Requirements: Python experience" in prompt
     assert "Work Policy: Remote-friendly" in prompt
     assert "Salary Range: €50k-70k" in prompt
+    assert "Company Mission: Build the future of collaboration" in prompt
+    assert "Company Culture: Inclusive and growth-oriented" in prompt


### PR DESCRIPTION
## Summary
- display and edit company mission and culture in wizard
- weave mission and culture into job-ad and interview-guide prompts
- test mission and culture propagation

## Testing
- `ruff check openai_utils.py wizard.py tests/test_generate_job_ad.py tests/test_generate_interview_guide.py`
- `mypy --ignore-missing-imports --follow-imports=skip openai_utils.py wizard.py tests/test_generate_job_ad.py tests/test_generate_interview_guide.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bc415e7e083209775bb0b7a74d00b