### PR TITLE
fix: use_container_width for sidebar image

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,7 +38,9 @@ if "llm_model" not in st.session_state:
 
 # Apply global styles
 apply_global_styling()
-st.sidebar.image("images/color1_logo_transparent_background.png", use_column_width=True)
+st.sidebar.image(
+    "images/color1_logo_transparent_background.png", use_container_width=True
+)
 # Sidebar language switcher
 lang_choice = st.sidebar.selectbox(
     "Language / Sprache",


### PR DESCRIPTION
## Summary
- replace deprecated `use_column_width` with `use_container_width` in sidebar logo

## Testing
- `ruff check app.py`
- `black app.py`
- `mypy app.py` *(fails: Library stubs not installed for "requests"; arg-type issues in wizard)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bca7dc2248320ad2597a10bf2c984