### PR TITLE
feat: expand role field map for more occupations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **Structured output**: function calling/JSON mode ensures valid responses
 - **API helper**: `call_chat_api` supports OpenAI function calls for reliable extraction
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance, shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
-- **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, shift schedules for nurses).
+- **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses).
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **No system OCR deps**: uses **OpenAI Vision** (set `OCR_BACKEND=none` to disable)

--- a/question_logic.py
+++ b/question_logic.py
@@ -102,16 +102,31 @@ ROLE_FIELD_MAP: Dict[str, List[str]] = {
         "frameworks",
         "tech_stack",
         "code_quality_practices",
+        "development_methodology",
     ],
     "sales, marketing and public relations professionals": [
         "target_markets",
         "sales_quota",
         "crm_tools",
+        "campaign_types",
+        "digital_marketing_platforms",
     ],
     "nursing and midwifery professionals": [
         "required_certifications",
         "shift_schedule",
         "patient_ratio",
+    ],
+    "medical doctors": [
+        "board_certification",
+        "on_call_requirements",
+    ],
+    "teaching professionals": [
+        "grade_level",
+        "teaching_license",
+    ],
+    "graphic and multimedia designers": [
+        "design_software_tools",
+        "portfolio_url",
     ],
 }
 
@@ -121,7 +136,11 @@ ROLE_QUESTION_MAP: Dict[str, List[Dict[str, str]]] = {
         {
             "field": "programming_languages",
             "question": "Which programming languages will the developer use?",
-        }
+        },
+        {
+            "field": "development_methodology",
+            "question": "Which development methodology does the team follow?",
+        },
     ],
     "sales, marketing and public relations professionals": [
         {
@@ -132,12 +151,50 @@ ROLE_QUESTION_MAP: Dict[str, List[Dict[str, str]]] = {
             "field": "sales_quota",
             "question": "What is the sales quota for this role?",
         },
+        {
+            "field": "campaign_types",
+            "question": "What campaign types will the marketer manage?",
+        },
+        {
+            "field": "digital_marketing_platforms",
+            "question": "Which digital marketing platforms are used?",
+        },
     ],
     "nursing and midwifery professionals": [
         {
             "field": "shift_schedule",
             "question": "What is the shift schedule?",
-        }
+        },
+    ],
+    "medical doctors": [
+        {
+            "field": "board_certification",
+            "question": "What board certifications are required?",
+        },
+        {
+            "field": "on_call_requirements",
+            "question": "Are there on-call requirements for this role?",
+        },
+    ],
+    "teaching professionals": [
+        {
+            "field": "grade_level",
+            "question": "Which grade levels will the teacher instruct?",
+        },
+        {
+            "field": "teaching_license",
+            "question": "Is a teaching license required?",
+        },
+    ],
+    "graphic and multimedia designers": [
+        {
+            "field": "design_software_tools",
+            "question": "Which design software tools should the designer be proficient in?",
+        },
+        {
+            "field": "portfolio_url",
+            "question": "What is the portfolio URL?",
+        },
     ],
 }
 


### PR DESCRIPTION
## Summary
- extend `ROLE_FIELD_MAP` with new fields for developers, marketers, doctors, teachers, and designers
- add role-specific follow-up questions for the new fields
- document expanded role-aware extras in README

## Testing
- `black question_logic.py`
- `ruff check question_logic.py`
- `mypy question_logic.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bcc3a3c908320b150363ceb07b7d0