### PR TITLE
feat: extend role field map for more occupations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **Structured output**: function calling/JSON mode ensures valid responses
 - **API helper**: `call_chat_api` supports OpenAI function calls for reliable extraction
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance, shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
-- **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses).
+- **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts).
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **No system OCR deps**: uses **OpenAI Vision** (set `OCR_BACKEND=none` to disable)

--- a/question_logic.py
+++ b/question_logic.py
@@ -128,6 +128,24 @@ ROLE_FIELD_MAP: Dict[str, List[str]] = {
         "design_software_tools",
         "portfolio_url",
     ],
+    "business services and administration managers not elsewhere classified": [
+        "project_management_methodologies",
+        "project_management_tools",
+        "stakeholder_types",
+        "budget_responsibility",
+    ],
+    "systems analysts": [
+        "machine_learning_frameworks",
+        "data_analysis_tools",
+        "data_visualization_tools",
+        "programming_languages",
+    ],
+    "accountants": [
+        "accounting_software",
+        "professional_certifications",
+        "reporting_standards",
+        "regulatory_frameworks",
+    ],
 }
 
 # Predefined role-specific follow-up questions keyed by ESCO group (lowercased)
@@ -194,6 +212,36 @@ ROLE_QUESTION_MAP: Dict[str, List[Dict[str, str]]] = {
         {
             "field": "portfolio_url",
             "question": "What is the portfolio URL?",
+        },
+    ],
+    "business services and administration managers not elsewhere classified": [
+        {
+            "field": "project_management_methodologies",
+            "question": "Which project management methodologies are used?",
+        },
+        {
+            "field": "budget_responsibility",
+            "question": "What budget responsibility does this role carry?",
+        },
+    ],
+    "systems analysts": [
+        {
+            "field": "machine_learning_frameworks",
+            "question": "Which machine learning frameworks are required?",
+        },
+        {
+            "field": "data_analysis_tools",
+            "question": "Which data analysis tools are used?",
+        },
+    ],
+    "accountants": [
+        {
+            "field": "accounting_software",
+            "question": "Which accounting software is used?",
+        },
+        {
+            "field": "professional_certifications",
+            "question": "Which professional certifications are required?",
         },
     ],
 }


### PR DESCRIPTION
## Summary
- add project management, data science, and accounting roles to ROLE_FIELD_MAP
- include corresponding follow-up questions and document role-aware extras

## Testing
- `black question_logic.py`
- `ruff check .`
- `mypy .` *(fails: Argument 1 to "from_session_state" has incompatible type "SessionStateProxy"; expected "dict[Any, Any]")*
- `mypy question_logic.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bcdf03088832083c3e9297ba7e9ba