### PR TITLE
feat: add draggable skill lists

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ lxml>=4.9
 requests>=2.31
 tenacity>=8.2
 typing-extensions>=4.8
+streamlit-sortables>=0.3.1
 


### PR DESCRIPTION
## Summary
- introduce editable_dragable_list helper with drag-and-drop support
- replace skills, responsibilities and benefits inputs with draggable lists
- add streamlit-sortables dependency

## Testing
- `ruff check wizard.py`
- `black wizard.py`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bd071e62c83209da281592e4c1f82