### PR TITLE
feat: scan job ads for biased language

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - **Customizable interview guides**: choose 3–10 questions
 - **Comprehensive job ads**: generated ads now mention requirements, salary and work policy when provided
 - **Employer branding**: company mission and culture flow into job ads and interview guides
+- **Bias check**: flags potentially discriminatory terms and suggests inclusive alternatives in generated job ads
 - **Onboarding Intro**: welcome step explains required inputs and allows skipping for returning users
 - **Responsive layout**: mobile-friendly columns and touch-sized buttons
 - **Salary analytics dashboard**: live sidebar estimate with optional factor explanations

--- a/nlp/bias.py
+++ b/nlp/bias.py
@@ -1,0 +1,39 @@
+"""Bias and inclusion language checks."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+BIAS_TERMS: Dict[str, Dict[str, str]] = {
+    "en": {
+        "young": "Specify required experience instead of age.",
+        "recent grad": "Use 'entry-level candidate' instead of age-specific terms.",
+        "digital native": "Focus on specific technical skills rather than age-related terms.",
+    },
+    "de": {
+        "jung": "Beschreiben Sie das notwendige Erfahrungsniveau statt des Alters.",
+        "berufsanfänger": "Verwenden Sie 'Einsteiger' oder geben Sie die Erfahrungsebene an.",
+        "digital native": "Nennen Sie konkrete digitale Fähigkeiten statt altersbezogener Begriffe.",
+    },
+}
+
+
+def scan_bias_language(text: str, lang: str = "en") -> List[Dict[str, str]]:
+    """Scan text for potentially biased terms.
+
+    Args:
+        text: Text to analyze.
+        lang: Language code (``en`` or ``de``).
+
+    Returns:
+        List of findings with the biased ``term`` and an inclusive ``suggestion``.
+    """
+    text_lower = text.lower()
+    mapping = BIAS_TERMS.get(lang[:2], {})
+    findings: List[Dict[str, str]] = []
+    for term, suggestion in mapping.items():
+        pattern = r"\b" + re.escape(term.lower()) + r"\b"
+        if re.search(pattern, text_lower):
+            findings.append({"term": term, "suggestion": suggestion})
+    return findings

--- a/tests/test_bias_check.py
+++ b/tests/test_bias_check.py
@@ -1,0 +1,14 @@
+from nlp.bias import scan_bias_language
+
+
+def test_scan_bias_language_flags_terms() -> None:
+    text = "We are looking for a young and dynamic recent grad."
+    findings = scan_bias_language(text, lang="en")
+    terms = {item["term"] for item in findings}
+    assert "young" in terms
+    assert "recent grad" in terms
+
+
+def test_scan_bias_language_no_terms() -> None:
+    text = "We welcome applicants with diverse backgrounds."
+    assert scan_bias_language(text) == []

--- a/wizard.py
+++ b/wizard.py
@@ -28,6 +28,7 @@ from llm.client import build_extraction_function
 from question_logic import CRITICAL_FIELDS, generate_followup_questions
 from core import esco_utils  # Added import to use ESCO classification
 from streamlit_sortables import sort_items
+from nlp.bias import scan_bias_language
 
 MODEL_OPTIONS = {
     "GPT-3.5 (fast, cheap)": "gpt-3.5-turbo",
@@ -906,6 +907,16 @@ def summary_outputs_page():
                     ),
                 )
                 st.write(job_ad_text)
+                findings = scan_bias_language(job_ad_text, lang)
+                if findings:
+                    warn = (
+                        "Potentially biased terms detected:"
+                        if lang != "de"
+                        else "Möglicherweise vorbelastete Begriffe gefunden:"
+                    )
+                    st.warning(warn)
+                    for item in findings:
+                        st.markdown(f"- `{item['term']}` → {item['suggestion']}")
                 # Basic SEO optimization suggestions for the generated ad
                 seo = seo_optimize(job_ad_text)
                 if seo["keywords"]:


### PR DESCRIPTION
## Summary
- add bias term dictionary and scanning helper
- warn in wizard when generated job ad contains biased wording
- document bias check capability

## Testing
- `python -m black nlp/bias.py wizard.py tests/test_bias_check.py`
- `ruff check nlp/bias.py wizard.py tests/test_bias_check.py`
- `mypy nlp/bias.py wizard.py tests/test_bias_check.py`
- `PYTHONPATH=. pytest tests/test_bias_check.py tests/test_generate_job_ad.py`


------
https://chatgpt.com/codex/tasks/task_e_689be1ea74f483209e083bdd229cce5d