### PR TITLE
feat: enforce critical field completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - **Robust error handling**: user-facing alerts for API or network issues
 - **Cross-field deduplication**: avoids repeating the same information across multiple fields
 - **Categorized summary**: groups related fields under clear headings for faster review
-- **Missing info alerts**: highlights empty critical fields in the summary and lets you jump back to fill them
+- **Missing info alerts**: highlights empty critical fields and blocks navigation until they're filled, letting you jump back to fix them
 - **Boolean Builder 2.0**: interactive search string with selectable skills and title synonyms
 - **Export**: clean JSON profile, job‑ad markdown, interview guide
 - **Customizable interview guides**: choose 3–10 questions

--- a/tests/test_missing_critical_fields.py
+++ b/tests/test_missing_critical_fields.py
@@ -1,0 +1,31 @@
+"""Tests for critical field validation utilities."""
+
+import streamlit as st
+
+from wizard import FIELD_SECTION_MAP, get_missing_critical_fields
+
+
+def test_section_filtering() -> None:
+    """Fields beyond the inspected section should be ignored."""
+    st.session_state.clear()
+    st.session_state["job_title"] = "Engineer"
+    st.session_state["followup_questions"] = []
+
+    assert get_missing_critical_fields(max_section=1) == []
+    missing = get_missing_critical_fields(max_section=2)
+    assert "company_name" in missing
+
+
+def test_followup_critical_detection() -> None:
+    """Critical follow-up questions count as missing fields."""
+    st.session_state.clear()
+    for field in FIELD_SECTION_MAP:
+        st.session_state[field] = "filled"
+    st.session_state["salary_range"] = ""
+    st.session_state["followup_questions"] = [
+        {"field": "salary_range", "priority": "critical"},
+        {"field": "bonus_compensation", "priority": "normal"},
+    ]
+
+    missing = get_missing_critical_fields(max_section=FIELD_SECTION_MAP["salary_range"])
+    assert missing == ["salary_range"]


### PR DESCRIPTION
## Summary
- block wizard navigation until critical questions are answered
- surface missing required fields to the user
- document that navigation stops when essential inputs are empty

## Testing
- `black wizard.py tests/test_missing_critical_fields.py`
- `ruff check wizard.py tests/test_missing_critical_fields.py`
- `mypy wizard.py tests/test_missing_critical_fields.py`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c304f4f8083208d13c5571c66bcab