### PR TITLE
feat: enable full-width document refinement and model switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **No system OCR deps**: uses **OpenAI Vision** (set `OCR_BACKEND=none` to disable)
 - **Cost‑aware**: hybrid models (4o‑mini default), minimal re‑asks
-- **Model toggle**: choose GPT‑3.5 (fast, cheap) or GPT‑4 (accurate) for suggestions
+- **Model toggle**: choose GPT‑3.5 (fast, cheap) or GPT‑4 (accurate) for suggestions and outputs
+- **Inline refinement**: adjust generated documents with custom instructions and instantly update the view
 - **Robust error handling**: user-facing alerts for API or network issues
 - **Cross-field deduplication**: avoids repeating the same information across multiple fields
 - **Tabbed summary**: collected fields are editable in stage-based tabs for faster review

--- a/components/model_selector.py
+++ b/components/model_selector.py
@@ -1,0 +1,25 @@
+"""Model selection component for Streamlit UI."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from config import OPENAI_MODEL
+
+
+def model_selector(key: str = "llm_model") -> str:
+    """Render a selectbox to allow users to choose the OpenAI model.
+
+    Args:
+        key: Session state key to store the selected model.
+
+    Returns:
+        The chosen model identifier.
+    """
+    models = ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"]
+    default = st.session_state.get(key, OPENAI_MODEL)
+    if default not in models:
+        default = models[0]
+    model = st.selectbox("Model", models, index=models.index(default))
+    st.session_state[key] = model
+    return model

--- a/tests/test_refine_and_explain.py
+++ b/tests/test_refine_and_explain.py
@@ -1,0 +1,36 @@
+import openai_utils
+
+
+def test_refine_document_passes_model(monkeypatch):
+    captured = {}
+
+    def fake_call_chat_api(messages, model=None, **kwargs):
+        captured["prompt"] = messages[0]["content"]
+        captured["model"] = model
+        return "updated"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+    out = openai_utils.refine_document("orig", "shorter", model="gpt-4")
+    assert "orig" in captured["prompt"]
+    assert "shorter" in captured["prompt"]
+    assert captured["model"] == "gpt-4"
+    assert out == "updated"
+
+
+def test_what_happened_lists_keys(monkeypatch):
+    captured = {}
+
+    def fake_call_chat_api(messages, model=None, **kwargs):
+        captured["prompt"] = messages[0]["content"]
+        captured["model"] = model
+        return "explanation"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+    session = {"job_title": "Eng", "location": "Berlin", "empty": ""}
+    out = openai_utils.what_happened(session, "doc", doc_type="job ad", model="gpt-4")
+    assert "job ad" in captured["prompt"]
+    assert "job_title" in captured["prompt"]
+    assert "location" in captured["prompt"]
+    assert "empty" not in captured["prompt"]
+    assert captured["model"] == "gpt-4"
+    assert out == "explanation"


### PR DESCRIPTION
## Summary
- allow users to switch GPT models via new selector component
- enable inline refinement of generated documents and explain how outputs were produced
- display job ad and interview guide full width with update and explanation buttons

## Testing
- `black openai_utils.py components/model_selector.py wizard.py tests/test_refine_and_explain.py`
- `ruff check openai_utils.py components/model_selector.py wizard.py tests/test_refine_and_explain.py`
- `mypy openai_utils.py components/model_selector.py wizard.py tests/test_refine_and_explain.py`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c3e3a4b2c8320b99d1564e285dee5