### PR TITLE
feat: add tabbed extraction summary step

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - **Dynamic Wizard**: multi‑step, bilingual (EN/DE), low‑friction inputs with auto-start analysis on upload/URL
 - **One‑hop extraction**: Parse PDFs/DOCX/URLs into 20+ fields
 - **Structured output**: function calling/JSON mode ensures valid responses
+- **Instant overview**: review extracted fields in a compact tabbed table before continuing
 - **API helper**: `call_chat_api` supports OpenAI function calls for reliable extraction
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance, shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
 - **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts).


### PR DESCRIPTION
## Summary
- add typed summary categories and render_extraction_summary helper
- show extracted data in tabbed table with Start Discovery CTA
- centralize summary categories for summary outputs

## Testing
- `black wizard.py`
- `ruff check wizard.py`
- `mypy wizard.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c415e13248320afc16a37965d4f22