### PR TITLE
feat: add branding customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - **Onboarding Intro**: welcome step explains required inputs and allows skipping for returning users
 - **Responsive layout**: mobile-friendly columns and touch-sized buttons
 - **Salary analytics dashboard**: live sidebar estimate with optional factor explanations
+- **Branding options**: upload a company logo, provide style‑guide hints and toggle between dark and light themes
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -21,9 +21,6 @@ st.set_page_config(
     layout="centered",
 )
 
-# Inject Tailwind CSS for styling
-inject_tailwind(theme="dark")
-
 # Initialize session state defaults
 if "skip_intro" not in st.session_state:
     st.session_state["skip_intro"] = False
@@ -35,12 +32,34 @@ if "lang" not in st.session_state:
     st.session_state["lang"] = "de" if DEFAULT_LANGUAGE.startswith("de") else "en"
 if "llm_model" not in st.session_state:
     st.session_state["llm_model"] = None
+if "theme" not in st.session_state:
+    st.session_state["theme"] = "dark"
+if "company_logo" not in st.session_state:
+    st.session_state["company_logo"] = None
+
+# Sidebar branding options
+logo_file = st.sidebar.file_uploader("Company Logo", type=["png", "jpg", "jpeg"])
+if logo_file:
+    st.session_state["company_logo"] = logo_file.getvalue()
+if st.session_state.get("company_logo"):
+    st.sidebar.image(st.session_state["company_logo"], use_container_width=True)
+else:
+    st.sidebar.image(
+        "images/color1_logo_transparent_background.png", use_container_width=True
+    )
+theme_choice = st.sidebar.selectbox(
+    "Theme",
+    ["Dark", "Light"],
+    0 if st.session_state["theme"] == "dark" else 1,
+)
+st.session_state["theme"] = "dark" if theme_choice == "Dark" else "light"
+
+# Inject Tailwind CSS for styling
+inject_tailwind(theme=st.session_state["theme"])
 
 # Apply global styles
-apply_global_styling()
-st.sidebar.image(
-    "images/color1_logo_transparent_background.png", use_container_width=True
-)
+apply_global_styling(theme=st.session_state["theme"])
+
 # Sidebar language switcher
 lang_choice = st.sidebar.selectbox(
     "Language / Sprache",

--- a/components/tailwind_injector.py
+++ b/components/tailwind_injector.py
@@ -1,14 +1,86 @@
+"""Utility to inject TailwindCSS and basic theming variables into Streamlit.
+
+The function toggles between a dark and light theme by manipulating the
+parent document's stylesheet. This keeps styling centralised while allowing
+runtime theme switching.
+"""
+
 from __future__ import annotations
+
 import streamlit.components.v1 as components
 
 
 def inject_tailwind(theme: str = "dark") -> None:
+    """Inject Tailwind CSS and theme variables into the Streamlit app."""
+
+    dark_vars = """
+          :root {
+            --bg-app: #0b0f14;
+            --bg-card: #111827;
+            --fg-muted: #9ca3af;
+            --fg: #e5e7eb;
+            --primary: #22d3ee;
+            --accent: #a78bfa;
+          }
+          body, .stApp {
+            background-color: var(--bg-app) !important;
+            color: var(--fg) !important;
+          }
+          .stButton > button {
+            background: linear-gradient(135deg, var(--primary), var(--accent));
+            color: #0c1116;
+            border: none;
+            border-radius: 10px;
+            font-weight: 600;
+          }
+          .stButton > button:hover { filter: brightness(0.95); }
+          .stTextInput > div > div input,
+          textarea,
+          select {
+            background-color: var(--bg-card) !important;
+            color: var(--fg) !important;
+            border: 1px solid #1f2937 !important;
+          }
+    """
+
+    light_vars = """
+          :root {
+            --bg-app: #ffffff;
+            --bg-card: #f9fafb;
+            --fg-muted: #6b7280;
+            --fg: #111827;
+            --primary: #0ea5e9;
+            --accent: #6366f1;
+          }
+          body, .stApp {
+            background-color: var(--bg-app) !important;
+            color: var(--fg) !important;
+          }
+          .stButton > button {
+            background: linear-gradient(135deg, var(--primary), var(--accent));
+            color: #fff;
+            border: none;
+            border-radius: 10px;
+            font-weight: 600;
+          }
+          .stButton > button:hover { filter: brightness(0.95); }
+          .stTextInput > div > div input,
+          textarea,
+          select {
+            background-color: var(--bg-card) !important;
+            color: var(--fg) !important;
+            border: 1px solid #d1d5db !important;
+          }
+    """
+
+    css_vars = dark_vars if theme == "dark" else light_vars
+
     html = f"""
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8" />
-  <script src="https://cdn.tailwindcss.com"></script>
+  <meta charset=\"utf-8\" />
+  <script src=\"https://cdn.tailwindcss.com\"></script>
   <script>
   (function() {{
     try {{
@@ -19,48 +91,15 @@ def inject_tailwind(theme: str = "dark") -> None:
         s.id = 'tailwind-cdn';
         parentDoc.head.appendChild(s);
       }}
-      if ('{theme}' === 'dark') {{
-        parentDoc.documentElement.classList.add('dark');
-      }} else {{
-        parentDoc.documentElement.classList.remove('dark');
-      }}
+      parentDoc.documentElement.classList.toggle('dark', '{theme}' === 'dark');
       const styleId = 'vacalyser-theme-vars';
-      if (!parentDoc.getElementById(styleId)) {{
-        const st = parentDoc.createElement('style');
+      let st = parentDoc.getElementById(styleId);
+      if (!st) {{
+        st = parentDoc.createElement('style');
         st.id = styleId;
-        st.innerHTML = `
-          :root {{
-            --bg-app: #0b0f14;
-            --bg-card: #111827;
-            --fg-muted: #9ca3af;
-            --fg: #e5e7eb;
-            --primary: #22d3ee;
-            --accent: #a78bfa;
-          }}
-          .dark body, .dark .stApp {{
-            background-color: var(--bg-app) !important;
-            color: var(--fg) !important;
-          }}
-          .dark .stButton > button {{
-            background: linear-gradient(135deg, var(--primary), var(--accent));
-            color: #0c1116;
-            border: none;
-            border-radius: 10px;
-            font-weight: 600;
-          }}
-          .dark .stButton > button:hover {{
-            filter: brightness(0.95);
-          }}
-          .dark .stTextInput > div > div input,
-          .dark textarea,
-          .dark select {{
-            background-color: var(--bg-card) !important;
-            color: var(--fg) !important;
-            border: 1px solid #1f2937 !important;
-          }}
-        `;
         parentDoc.head.appendChild(st);
       }}
+      st.innerHTML = `{css_vars}`;
     }} catch (e) {{}}
   }})();
   </script>

--- a/wizard.py
+++ b/wizard.py
@@ -152,36 +152,56 @@ def normalise_state(reapply_aliases: bool = True):
     return jd
 
 
-def apply_global_styling() -> None:
+def apply_global_styling(theme: str = "dark") -> None:
     """Apply global styling and background image to the app.
 
-    Injects fonts, colors and a background image into the Streamlit application.
+    Injects fonts and colors into the Streamlit application. When ``theme`` is
+    ``"dark"`` a textured background image and dark palette are used. For
+    ``"light"`` the background image is removed and light colors are applied.
     """
+
     bg_path = Path("images/AdobeStock_506577005.jpeg")
+    if theme == "dark":
+        st.markdown(
+            f"""
+            <style>
+                .stApp {{
+                    background: url("{bg_path.as_posix()}") no-repeat center center fixed;
+                    background-size: cover;
+                }}
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
+        body_styles = "body, .stApp { background-color: #0b0f14; color: #e5e7eb; font-family: 'Comfortaa', sans-serif; }"
+        card_bg = "#111827"
+        heading_color = "#ffffff"
+    else:
+        st.markdown(
+            """
+            <style>
+                .stApp { background: none !important; }
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
+        body_styles = "body, .stApp { background-color: #ffffff; color: #111827; font-family: 'Comfortaa', sans-serif; }"
+        card_bg = "#f9fafb"
+        heading_color = "#000000"
+
     st.markdown(
         f"""
         <style>
-            .stApp {{
-                background: url("{bg_path.as_posix()}") no-repeat center center fixed;
-                background-size: cover;
-            }}
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
-    st.markdown(
-        """
-        <style>
         @import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;400;700&display=swap');
-        body, .stApp { background-color: #0b0f14; color: #e5e7eb; font-family: 'Comfortaa', sans-serif; }
-        h1,h2,h3,h4 { color: #ffffff; }
-        .card { background-color: #111827; padding: 1rem; border-radius: 12px; margin-bottom: 1.25rem; }
-        .stButton > button { border-radius: 10px; min-height: 2.5rem; }
-        @media (max-width: 768px) {
-            div[data-testid="stHorizontalBlock"] { flex-direction: column; }
-            div[data-testid="stHorizontalBlock"] > div[data-testid="stColumn"] { width: 100%; }
-            .stButton > button { width: 100%; }
-        }
+        {body_styles}
+        h1,h2,h3,h4 {{ color: {heading_color}; }}
+        .card {{ background-color: {card_bg}; padding: 1rem; border-radius: 12px; margin-bottom: 1.25rem; }}
+        .stButton > button {{ border-radius: 10px; min-height: 2.5rem; }}
+        @media (max-width: 768px) {{
+            div[data-testid="stHorizontalBlock"] {{ flex-direction: column; }}
+            div[data-testid="stHorizontalBlock"] > div[data-testid="stColumn"] {{ width: 100%; }}
+            .stButton > button {{ width: 100%; }}
+        }}
         </style>
         """,
         unsafe_allow_html=True,
@@ -622,6 +642,14 @@ def company_information_page():
         "Company Website" if lang != "de" else "Webseite",
         st.session_state.get("company_website", ""),
     )
+    st.session_state["company_style_guide"] = st.text_area(
+        (
+            "Style guide (colors, fonts, etc.)"
+            if lang != "de"
+            else "Styleguide (Farben, Schriften, usw.)"
+        ),
+        st.session_state.get("company_style_guide", ""),
+    )
     # Optional: Fetch company info (mission, values, etc.) from website
     if st.button("🔄 Fetch Company Info from Website"):
         with st.spinner("Fetching company information..."):
@@ -970,6 +998,12 @@ def summary_outputs_page():
     st.header(
         "📊 Summary & Outputs" if lang != "de" else "📊 Zusammenfassung & Ergebnisse"
     )
+    if st.session_state.get("company_logo"):
+        st.image(st.session_state["company_logo"], width=150)
+    if st.session_state.get("company_name"):
+        st.subheader(st.session_state["company_name"])
+    if st.session_state.get("company_style_guide"):
+        st.markdown(f"**Style Guide:** {st.session_state['company_style_guide']}")
     # Show ESCO occupation classification if available
     if st.session_state.get("occupation_label"):
         occ_label = st.session_state["occupation_label"]


### PR DESCRIPTION
## Summary
- allow uploading a company logo and toggling light/dark themes
- expose style guide text area and show branding on summary page
- support dark and light styles via Tailwind and global styling

## Testing
- `ruff check --fix .`
- `black .`
- `mypy .`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c44a936c4832092173a3bde846903