### PR TITLE
feat: add tone selection for outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - **Boolean Builder 2.0**: interactive search string with selectable skills and title synonyms
 - **Export**: clean JSON profile, job‑ad markdown, interview guide
 - **Customizable interview guides**: choose 3–10 questions
+- **Tone control**: pick formal, casual, creative, or diversity-focused styles for job ads and interview guides
 - **Comprehensive job ads**: generated ads now mention requirements, salary and work policy when provided
 - **Employer branding**: company mission and culture flow into job ads and interview guides
 - **Bias check**: flags potentially discriminatory terms and suggests inclusive alternatives in generated job ads

--- a/tests/test_generate_interview_guide.py
+++ b/tests/test_generate_interview_guide.py
@@ -14,7 +14,9 @@ def test_generate_interview_guide_includes_culture(monkeypatch):
         "Engineer",
         tasks="",
         company_culture="Collaborative and transparent",
+        tone="casual and friendly",
     )
     prompt = captured["prompt"]
     assert "Company culture: Collaborative and transparent" in prompt
     assert "cultural fit" in prompt.lower()
+    assert "Tone: casual and friendly." in prompt

--- a/tests/test_generate_job_ad.py
+++ b/tests/test_generate_job_ad.py
@@ -25,10 +25,11 @@ def test_generate_job_ad_includes_optional_fields(monkeypatch):
         "lang": "en",
     }
 
-    openai_utils.generate_job_ad(session)
+    openai_utils.generate_job_ad(session, tone="formal and straightforward")
     prompt = captured["prompt"]
     assert "Requirements: Python experience" in prompt
     assert "Work Policy: Remote-friendly" in prompt
     assert "Salary Range: €50k-70k" in prompt
     assert "Company Mission: Build the future of collaboration" in prompt
     assert "Company Culture: Inclusive and growth-oriented" in prompt
+    assert "Tone: formal and straightforward." in prompt


### PR DESCRIPTION
## Summary
- allow users to choose tone for job ads and interview guides via UI dropdowns
- pass selected tone into generation prompts for job ads and interview guides
- document new tone control feature and expand tests

## Testing
- `python -m black openai_utils.py wizard.py tests/test_generate_job_ad.py tests/test_generate_interview_guide.py`
- `ruff check openai_utils.py wizard.py tests/test_generate_job_ad.py tests/test_generate_interview_guide.py`
- `mypy openai_utils.py wizard.py tests/test_generate_job_ad.py tests/test_generate_interview_guide.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c471967548320aacbe38af9c39a23