### PR TITLE
feat: expand role field map

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - **Instant overview**: review extracted fields in a compact tabbed table before continuing
 - **API helper**: `call_chat_api` supports OpenAI function calls for reliable extraction
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance, shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
-- **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts).
+- **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts, HR software for human resource professionals, engineering tools for civil engineers, cuisine specialties for chefs).
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **No system OCR deps**: uses **OpenAI Vision** (set `OCR_BACKEND=none` to disable)

--- a/core/schema.py
+++ b/core/schema.py
@@ -58,6 +58,33 @@ LIST_FIELDS = {
     "benefits",
     "languages_required",
     "tools_and_technologies",
+    # role-specific list fields
+    "programming_languages",
+    "frameworks",
+    "tech_stack",
+    "code_quality_practices",
+    "target_markets",
+    "crm_tools",
+    "campaign_types",
+    "digital_marketing_platforms",
+    "required_certifications",
+    "design_software_tools",
+    "project_management_methodologies",
+    "project_management_tools",
+    "stakeholder_types",
+    "machine_learning_frameworks",
+    "data_analysis_tools",
+    "data_visualization_tools",
+    "accounting_software",
+    "professional_certifications",
+    "reporting_standards",
+    "regulatory_frameworks",
+    "hr_software_tools",
+    "recruitment_channels",
+    "employee_engagement_strategies",
+    "engineering_software_tools",
+    "civil_project_types",
+    "cuisine_specialties",
 }
 
 # Convenience set of string-typed fields.
@@ -156,6 +183,46 @@ class VacalyserJD(_BaseModel):
     benefits: List[str] = []
     languages_required: List[str] = []
     tools_and_technologies: List[str] = []
+    # Role-specific optional fields
+    programming_languages: List[str] = []
+    frameworks: List[str] = []
+    tech_stack: List[str] = []
+    code_quality_practices: List[str] = []
+    development_methodology: str = ""
+    target_markets: List[str] = []
+    sales_quota: str = ""
+    crm_tools: List[str] = []
+    campaign_types: List[str] = []
+    digital_marketing_platforms: List[str] = []
+    required_certifications: List[str] = []
+    shift_schedule: str = ""
+    patient_ratio: str = ""
+    board_certification: str = ""
+    on_call_requirements: str = ""
+    grade_level: str = ""
+    teaching_license: str = ""
+    design_software_tools: List[str] = []
+    portfolio_url: str = ""
+    project_management_methodologies: List[str] = []
+    project_management_tools: List[str] = []
+    stakeholder_types: List[str] = []
+    budget_responsibility: str = ""
+    machine_learning_frameworks: List[str] = []
+    data_analysis_tools: List[str] = []
+    data_visualization_tools: List[str] = []
+    accounting_software: List[str] = []
+    professional_certifications: List[str] = []
+    reporting_standards: List[str] = []
+    regulatory_frameworks: List[str] = []
+    hr_software_tools: List[str] = []
+    recruitment_channels: List[str] = []
+    employee_engagement_strategies: List[str] = []
+    engineering_software_tools: List[str] = []
+    civil_project_types: List[str] = []
+    site_visit_frequency: str = ""
+    cuisine_specialties: List[str] = []
+    kitchen_environment: str = ""
+    menu_development_responsibility: str = ""
 
 
 def _dedupe_preserve_order(items: Iterable[str]) -> List[str]:

--- a/question_logic.py
+++ b/question_logic.py
@@ -146,6 +146,21 @@ ROLE_FIELD_MAP: Dict[str, List[str]] = {
         "reporting_standards",
         "regulatory_frameworks",
     ],
+    "human resource professionals": [
+        "hr_software_tools",
+        "recruitment_channels",
+        "employee_engagement_strategies",
+    ],
+    "civil engineers": [
+        "engineering_software_tools",
+        "civil_project_types",
+        "site_visit_frequency",
+    ],
+    "chefs": [
+        "cuisine_specialties",
+        "kitchen_environment",
+        "menu_development_responsibility",
+    ],
 }
 
 # Predefined role-specific follow-up questions keyed by ESCO group (lowercased)
@@ -242,6 +257,32 @@ ROLE_QUESTION_MAP: Dict[str, List[Dict[str, str]]] = {
         {
             "field": "professional_certifications",
             "question": "Which professional certifications are required?",
+        },
+    ],
+    "human resource professionals": [
+        {
+            "field": "hr_software_tools",
+            "question": "Which HR software tools are used?",
+        },
+        {
+            "field": "recruitment_channels",
+            "question": "Which recruitment channels are prioritized?",
+        },
+    ],
+    "civil engineers": [
+        {
+            "field": "civil_project_types",
+            "question": "What types of civil projects will the engineer handle?",
+        },
+        {
+            "field": "engineering_software_tools",
+            "question": "Which engineering software tools are required?",
+        },
+    ],
+    "chefs": [
+        {
+            "field": "cuisine_specialties",
+            "question": "Which cuisine specialties should the chef have?",
         },
     ],
 }

--- a/tests/test_bias_check.py
+++ b/tests/test_bias_check.py
@@ -1,3 +1,8 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 from nlp.bias import scan_bias_language
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -11,7 +11,7 @@ from core.schema import (
 
 def test_constants() -> None:
     assert len(ALL_FIELDS) == 22
-    assert LIST_FIELDS == {
+    base_lists = {
         "responsibilities",
         "hard_skills",
         "soft_skills",
@@ -20,6 +20,7 @@ def test_constants() -> None:
         "languages_required",
         "tools_and_technologies",
     }
+    assert base_lists <= LIST_FIELDS
 
 
 def test_coerce_and_fill_partial_and_aliases() -> None:
@@ -51,6 +52,9 @@ def test_default_insertion() -> None:
         assert getattr(jd, field) == ""
     for field in LIST_FIELDS:
         assert getattr(jd, field) == []
+    # role-specific defaults
+    assert jd.programming_languages == []
+    assert jd.development_methodology == ""
 
 
 def test_alias_priority() -> None:


### PR DESCRIPTION
## Summary
- support additional occupation groups in ROLE_FIELD_MAP
- add corresponding optional fields to VacalyserJD model
- refine tests to cover role defaults and resolve bias test import

## Testing
- `black core/schema.py question_logic.py tests/test_schema.py tests/test_bias_check.py`
- `ruff check core/schema.py question_logic.py tests/test_schema.py tests/test_bias_check.py`
- `mypy core/schema.py question_logic.py tests/test_schema.py tests/test_bias_check.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c4d9946bc83208125e1616ac46114