### PR TITLE
feat: add domain-specific field suggestion lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - **Salary analytics dashboard**: live sidebar estimate with optional factor explanations
 - **Branding options**: upload a company logo, provide style‑guide hints and toggle between dark and light themes
 - **Expanded skills section**: enter certifications, language requirements, and tools & technologies alongside hard and soft skills
+- **Domain-specific suggestions**: built-in lists of programming languages, frameworks, databases, cloud providers and DevOps tools help guide inputs
 
 ---
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,1 +1,5 @@
 """Core package for Vacalyser models and utilities."""
+
+from .field_suggestions import FIELD_SUGGESTIONS, get_field_suggestions
+
+__all__ = ["FIELD_SUGGESTIONS", "get_field_suggestions"]

--- a/core/field_suggestions.py
+++ b/core/field_suggestions.py
@@ -1,0 +1,72 @@
+"""Predefined suggestion lists for common vacancy fields."""
+
+from typing import Dict, List
+
+from .esco_utils import normalize_skills
+
+FIELD_SUGGESTIONS: Dict[str, List[str]] = {
+    "programming_languages": [
+        "Python",
+        "Java",
+        "JavaScript",
+        "C#",
+        "C++",
+        "Go",
+        "Ruby",
+        "Rust",
+    ],
+    "frameworks": [
+        "Django",
+        "Flask",
+        "FastAPI",
+        "React",
+        "Angular",
+        "Vue.js",
+        "Spring",
+        "Laravel",
+        "Express.js",
+    ],
+    "databases": [
+        "PostgreSQL",
+        "MySQL",
+        "MongoDB",
+        "SQLite",
+        "Redis",
+        "Oracle",
+        "SQL Server",
+        "Elasticsearch",
+    ],
+    "cloud_providers": [
+        "AWS",
+        "Azure",
+        "Google Cloud Platform",
+        "Heroku",
+        "DigitalOcean",
+    ],
+    "devops_tools": [
+        "Docker",
+        "Kubernetes",
+        "Terraform",
+        "Ansible",
+        "Jenkins",
+        "GitLab CI",
+        "GitHub Actions",
+    ],
+}
+
+__all__ = ["FIELD_SUGGESTIONS", "get_field_suggestions"]
+
+
+def get_field_suggestions(field: str, lang: str = "en") -> List[str]:
+    """Return normalized suggestions for a vacancy field.
+
+    Args:
+        field: Field name such as ``"programming_languages"``.
+        lang: Target language code for normalization.
+
+    Returns:
+        A list of suggestions with consistent formatting.
+    """
+
+    skills = FIELD_SUGGESTIONS.get(field, [])
+    return normalize_skills(skills, lang=lang)

--- a/tests/test_field_suggestions.py
+++ b/tests/test_field_suggestions.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.field_suggestions import (
+    FIELD_SUGGESTIONS,
+    get_field_suggestions,
+)  # noqa: E402
+
+
+def test_get_field_suggestions_normalizes(monkeypatch) -> None:
+    def fake_normalize(skills, lang="en"):
+        return [s.title() for s in skills]
+
+    monkeypatch.setattr("core.field_suggestions.normalize_skills", fake_normalize)
+    out = get_field_suggestions("programming_languages")
+    assert out == [s.title() for s in FIELD_SUGGESTIONS["programming_languages"]]
+
+
+def test_get_field_suggestions_unknown_field() -> None:
+    assert get_field_suggestions("unknown") == []


### PR DESCRIPTION
## Summary
- add FIELD_SUGGESTIONS mapping for common tech domains
- expose helper to normalize suggestions via ESCO
- document built-in domain suggestions

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c4fc48f508320bf507eeb63f2fc7c