### PR TITLE
fix: add aliases for legacy flat fields

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -300,6 +300,9 @@ STRING_FIELDS: set[str] = set(ALL_FIELDS) - LIST_FIELDS
 
 # Aliases for backward compatibility (map old keys to new keys)
 ALIASES: Dict[str, str] = {
+    "company_name": "company.name",
+    "job_title": "position.job_title",
+    "location": "location.primary_city",
     "contract_type": "employment.job_type",
     "remote_policy": "employment.work_policy",
     "experience_level": "position.seniority_level",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -60,6 +60,14 @@ def test_list_coercion_split_and_dedupe() -> None:
     assert jd.requirements.hard_skills == ["Python", "Java"]
 
 
+def test_coerce_flat_aliases() -> None:
+    data = {"job_title": "Dev", "company_name": "Acme", "location": "Berlin"}
+    jd = coerce_and_fill(data)
+    assert jd.position.job_title == "Dev"
+    assert jd.company.name == "Acme"
+    assert jd.location.primary_city == "Berlin"
+
+
 def test_cross_field_dedupe() -> None:
     data = {
         "remote_policy": "Fully remote",

--- a/tests/test_ss_bridge.py
+++ b/tests/test_ss_bridge.py
@@ -18,10 +18,25 @@ def test_round_trip_session_state():
 
 
 def test_alias_fields_round_trip():
-    ss = {"tasks": "Alpha\nBeta", "contract_type": "Part-time"}
+    ss = {
+        "tasks": "Alpha\nBeta",
+        "contract_type": "Part-time",
+        "job_title": "Dev",
+        "company_name": "ACME",
+        "location": "Berlin",
+    }
     jd = from_session_state(ss)
     assert jd.responsibilities.items == ["Alpha", "Beta"]
     assert jd.employment.job_type == "Part-time"
+    assert jd.position.job_title == "Dev"
+    assert jd.company.name == "ACME"
+    assert jd.location.primary_city == "Berlin"
     to_session_state(jd, ss)
     assert "tasks" not in ss
     assert "contract_type" not in ss
+    assert "job_title" not in ss
+    assert "company_name" not in ss
+    assert "location" not in ss
+    assert ss["position.job_title"] == "Dev"
+    assert ss["company.name"] == "ACME"
+    assert ss["location.primary_city"] == "Berlin"


### PR DESCRIPTION
## Summary
- map legacy flat fields to new nested schema keys in `ALIASES`
- cover alias handling for job title, company name and location in unit tests

## Testing
- `python -m black core/schema.py tests/test_schema.py tests/test_ss_bridge.py`
- `ruff check core/schema.py tests/test_schema.py tests/test_ss_bridge.py`
- `mypy core/schema.py tests/test_schema.py tests/test_ss_bridge.py`
- `mypy core tests` *(fails: Library stubs not installed for "requests"; many Name errors in wizard.py)*
- `pytest` *(fails: SyntaxError: 'return' outside function in wizard.py)*

------
https://chatgpt.com/codex/tasks/task_e_689ca831f87c8320ba2bf6accbc1d72b