### PR TITLE
fix: bind benefits UI to schema key

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - **Salary analytics dashboard**: live sidebar estimate with optional factor explanations
 - **Branding options**: upload a company logo, provide style‑guide hints and toggle between dark and light themes
 - **Expanded skills section**: enter certifications, language requirements, and tools & technologies alongside hard and soft skills
+- **Schema-aligned benefits**: benefit inputs bind directly to schema keys so extracted perks appear automatically
 - **Company insights**: specify headquarters location and company size for clearer context
 - **Domain-specific suggestions**: built-in lists of programming languages, frameworks, databases, cloud providers and DevOps tools help guide inputs
 


### PR DESCRIPTION
## Summary
- merge legacy benefit keys into `compensation.benefits`
- show extracted perks directly in benefits UI
- note schema-aligned benefits in README

## Testing
- `ruff check .`
- `mypy .` *(fails: Library stubs not installed for "requests"; argument type issues in wizard.py)*
- `pytest` *(fails: multiple validation errors in VacancyProfile and missing attributes in question_logic)*

------
https://chatgpt.com/codex/tasks/task_e_689cb56303b88320866918df518f0ab1