### PR TITLE
fix: align wizard sections with new field grouping

### DIFF
--- a/tests/test_missing_critical_fields.py
+++ b/tests/test_missing_critical_fields.py
@@ -9,11 +9,14 @@ def test_section_filtering() -> None:
     """Fields beyond the inspected section should be ignored."""
     st.session_state.clear()
     st.session_state["position.job_title"] = "Engineer"
+    st.session_state["company.name"] = "Acme"
+    st.session_state["location.primary_city"] = "Berlin"
+    st.session_state["location.country"] = "DE"
     st.session_state["followup_questions"] = []
 
     assert get_missing_critical_fields(max_section=1) == []
     missing = get_missing_critical_fields(max_section=2)
-    assert "company.name" in missing
+    assert "position.role_summary" in missing
 
 
 def test_followup_critical_detection() -> None:


### PR DESCRIPTION
## Summary
- align FIELD_SECTION_MAP with updated wizard sections
- add human-friendly labels for required fields in navigation warnings
- adapt critical-field tests to new section assignments

## Testing
- `ruff check wizard.py tests/test_missing_critical_fields.py`
- `mypy wizard.py tests/test_missing_critical_fields.py`
- `pytest` *(fails: pydantic validation errors and missing attributes in question_logic)*

------
https://chatgpt.com/codex/tasks/task_e_689cb9a1f31c8320917e0e76b2a92813