### PR TITLE
fix: add German translations for skill suggestions

### DIFF
--- a/question_logic.py
+++ b/question_logic.py
@@ -536,7 +536,11 @@ def generate_followup_questions(
         else:
             # Default question format
             label = field.split(".")[-1].replace("_", " ")
-            q_text = f"Please provide the {label}."
+            q_text = (
+                f"Please provide the {label}."
+                if lang != "de"
+                else f"Bitte geben Sie {label} an."
+            )
         priority = _priority_for(field, field in missing_esco_skills)
         suggestions = suggestions_map.get(field, [])
         prefill = None

--- a/wizard.py
+++ b/wizard.py
@@ -1036,13 +1036,21 @@ with soft_col:
             "suggested_soft_skills"
         ):
             st.success(
-                "✔️ Skill suggestions generated. Click on a suggestion to add it."
+                (
+                    "✔️ Skill suggestions generated. Click on a suggestion to add it."
+                    if lang != "de"
+                    else "✔️ Skill-Vorschläge generiert. Klicken Sie auf einen Vorschlag, um ihn hinzuzufügen."
+                )
             )
     # If suggestions are available, display them as chips for selection
     tech_list = st.session_state.get("suggested_tech_skills", [])
     soft_list = st.session_state.get("suggested_soft_skills", [])
     if tech_list:
-        st.caption("**Suggested Technical Skills:**")
+        st.caption(
+            "**Suggested Technical Skills:**"
+            if lang != "de"
+            else "**Vorgeschlagene technische Fähigkeiten:**"
+        )
         cols = st.columns(len(tech_list))
         for i, (col, skill) in enumerate(zip(cols, tech_list)):
             with col:
@@ -1058,7 +1066,11 @@ with soft_col:
                     ]
                     st.rerun()
     if soft_list:
-        st.caption("**Suggested Soft Skills:**")
+        st.caption(
+            "**Suggested Soft Skills:**"
+            if lang != "de"
+            else "**Vorgeschlagene Soft Skills:**"
+        )
         cols = st.columns(len(soft_list))
         for j, (col, skill) in enumerate(zip(cols, soft_list)):
             with col:


### PR DESCRIPTION
## Summary
- localize default follow-up question text for German
- add German translations for skill suggestion success and captions

## Testing
- `black question_logic.py wizard.py`
- `ruff check question_logic.py wizard.py`
- `mypy question_logic.py wizard.py`
- `pytest` *(fails: ValidationError and AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_689cc39e56548320bb2e9562a8b70cff