### PR TITLE
feat: expand job ad field coverage

### DIFF
--- a/tests/test_generate_job_ad.py
+++ b/tests/test_generate_job_ad.py
@@ -17,8 +17,13 @@ def test_generate_job_ad_includes_optional_fields(monkeypatch):
         "position.role_summary": "Build web apps",
         "responsibilities.items": ["Develop features"],
         "compensation.benefits": ["Stock options"],
+        "learning_opportunities": "Annual training budget",
         "requirements.hard_skills": ["Python experience"],
         "employment.work_policy": "Remote",
+        "employment.work_schedule": "Mon-Fri",
+        "employment.relocation_support": True,
+        "employment.visa_sponsorship": True,
+        "position.team_size": 5,
         "compensation.salary_provided": True,
         "compensation.salary_min": 50000,
         "compensation.salary_max": 70000,
@@ -31,6 +36,11 @@ def test_generate_job_ad_includes_optional_fields(monkeypatch):
     prompt = captured["prompt"]
     assert "Hard Skills: Python experience" in prompt
     assert "Work Policy: Remote" in prompt
+    assert "Work Schedule: Mon-Fri" in prompt
+    assert "Relocation Assistance: Yes" in prompt
+    assert "Visa Sponsorship: Yes" in prompt
+    assert "Learning & Development: Annual training budget" in prompt
+    assert "Team Size: 5" in prompt
     assert "Salary Range: 50,000–70,000 EUR per year" in prompt
     assert "Company Mission: Build the future of collaboration" in prompt
     assert "Company Culture: Inclusive and growth-oriented" in prompt


### PR DESCRIPTION
## Summary
- include relocation assistance, visa sponsorship, work schedule, learning budget, and team size in job ad prompt
- normalize mission and culture inputs and surface them with labeled lines
- extend tests to cover new job ad fields

## Testing
- `python -m black openai_utils.py tests/test_generate_job_ad.py`
- `ruff check openai_utils.py tests/test_generate_job_ad.py`
- `PYTHONPATH=. mypy openai_utils.py tests/test_generate_job_ad.py`
- `PYTHONPATH=. pytest tests/test_generate_job_ad.py -q`
- `PYTHONPATH=. pytest -q` *(fails: pydantic_core._pydantic_core.ValidationError and AttributeError: module question_logic missing attributes)*

------
https://chatgpt.com/codex/tasks/task_e_689cc8ef66c083208450d2db320814c9