### PR TITLE
feat: enhance job ad field formatting

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -316,7 +316,7 @@ def generate_job_ad(
             "Hours per Week",
             "Wochenstunden",
         ),
-        ("employment.travel_required", "Travel Required", "Reise erforderlich"),
+        ("employment.travel_required", "Travel Requirements", "Reisebereitschaft"),
         (
             "employment.relocation_support",
             "Relocation Assistance",
@@ -359,6 +359,13 @@ def generate_job_ad(
         ),
     ]
     details: List[str] = []
+    yes_no = ("Ja", "Nein") if lang.startswith("de") else ("Yes", "No")
+    boolean_fields = {
+        "employment.travel_required",
+        "employment.relocation_support",
+        "employment.visa_sponsorship",
+    }
+
     for key, label_en, label_de in fields_for_ad:
         val = data.get(key, "")
         if not val:
@@ -367,14 +374,24 @@ def generate_job_ad(
         if not formatted:
             continue
         label = label_de if lang.startswith("de") else label_en
-        # Convert boolean fields to Yes/No text
-        boolean_fields = {
-            "employment.travel_required",
-            "employment.relocation_support",
-            "employment.visa_sponsorship",
-        }
-        if key in boolean_fields:
-            formatted = "Yes" if str(val).lower() in ["true", "yes", "1"] else "No"
+
+        if key == "employment.travel_required":
+            detail = str(data.get("travel_required", "")).strip()
+            if detail:
+                formatted = detail
+            else:
+                formatted = (
+                    yes_no[0] if str(val).lower() in ["true", "yes", "1"] else yes_no[1]
+                )
+        elif key == "employment.work_policy":
+            detail = str(data.get("remote_policy", "")).strip()
+            if detail:
+                formatted = f"{formatted} ({detail})"
+        elif key in boolean_fields:
+            formatted = (
+                yes_no[0] if str(val).lower() in ["true", "yes", "1"] else yes_no[1]
+            )
+
         details.append(f"{label}: {formatted}")
     # Handle salary range as a special case
     if data.get("compensation.salary_provided"):

--- a/tests/test_generate_job_ad.py
+++ b/tests/test_generate_job_ad.py
@@ -45,3 +45,37 @@ def test_generate_job_ad_includes_optional_fields(monkeypatch):
     assert "Company Mission: Build the future of collaboration" in prompt
     assert "Company Culture: Inclusive and growth-oriented" in prompt
     assert "Tone: formal and straightforward." in prompt
+
+
+def test_generate_job_ad_formats_travel_and_remote(monkeypatch):
+    prompts: list[str] = []
+
+    def fake_call_chat_api(messages, **kwargs):
+        prompts.append(messages[0]["content"])
+        return "ok"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+
+    session_en = {
+        "employment.travel_required": True,
+        "travel_required": "Occasional (up to 10%)",
+        "employment.work_policy": "Hybrid",
+        "remote_policy": "3 days remote",
+        "lang": "en",
+    }
+    openai_utils.generate_job_ad(session_en)
+    assert "Travel Requirements: Occasional (up to 10%)" in prompts[0]
+    assert "Work Policy: Hybrid (3 days remote)" in prompts[0]
+
+    session_de = {
+        "employment.travel_required": True,
+        "travel_required": "Gelegentlich (bis zu 10%)",
+        "employment.work_policy": "Hybrid",
+        "remote_policy": "3 Tage remote",
+        "employment.relocation_support": True,
+        "lang": "de",
+    }
+    openai_utils.generate_job_ad(session_de)
+    assert "Reisebereitschaft: Gelegentlich (bis zu 10%)" in prompts[1]
+    assert "Arbeitsmodell: Hybrid (3 Tage remote)" in prompts[1]
+    assert "Umzugsunterstützung: Ja" in prompts[1]


### PR DESCRIPTION
## Summary
- localize boolean formatting and incorporate travel/remote details in job ads
- add tests verifying enriched travel and remote formatting in both languages

## Testing
- `ruff check .`
- `black openai_utils.py tests/test_generate_job_ad.py`
- `mypy .`
- `pytest -q` *(fails: ValidationError for VacalyserJD and missing call_chat_api in tests)*

------
https://chatgpt.com/codex/tasks/task_e_689ccc7b35988320a951573cf6b39987