### PR TITLE
fix: merge benefit fields before job ad generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 - **Salary analytics dashboard**: live sidebar estimate with optional factor explanations
 - **Branding options**: upload a company logo, provide style‑guide hints and toggle between dark and light themes
 - **Expanded skills section**: enter certifications, language requirements, and tools & technologies alongside hard and soft skills
-- **Schema-aligned benefits**: benefit inputs bind directly to schema keys so extracted perks appear automatically
+  - **Schema-aligned benefits**: benefit inputs bind directly to schema keys, merging health and retirement perks so all appear automatically
 - **Company insights**: specify headquarters location and company size for clearer context
 - **Domain-specific suggestions**: built-in lists of programming languages, frameworks, databases, cloud providers and DevOps tools help guide inputs
 

--- a/tests/test_generate_job_ad.py
+++ b/tests/test_generate_job_ad.py
@@ -79,3 +79,24 @@ def test_generate_job_ad_formats_travel_and_remote(monkeypatch):
     assert "Reisebereitschaft: Gelegentlich (bis zu 10%)" in prompts[1]
     assert "Arbeitsmodell: Hybrid (3 Tage remote)" in prompts[1]
     assert "Umzugsunterstützung: Ja" in prompts[1]
+
+
+def test_generate_job_ad_merges_all_benefits(monkeypatch):
+    captured = {}
+
+    def fake_call_chat_api(messages, **kwargs):
+        captured["prompt"] = messages[0]["content"]
+        return "ok"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+
+    session = {
+        "compensation.benefits": ["Gym membership"],
+        "health_benefits": ["Health insurance"],
+        "retirement_benefits": "401(k) match",
+        "lang": "en",
+    }
+
+    openai_utils.generate_job_ad(session)
+    prompt = captured["prompt"]
+    assert "Benefits: Gym membership, Health insurance, 401(k) match" in prompt


### PR DESCRIPTION
## Summary
- merge general, health, and retirement perks into `compensation.benefits` during job ad generation
- document unified benefit handling in README
- test merged benefits rendering

## Testing
- `black openai_utils.py tests/test_generate_job_ad.py`
- `ruff check openai_utils.py tests/test_generate_job_ad.py`
- `mypy openai_utils.py tests/test_generate_job_ad.py`
- `pytest` *(fails: ValidationError for VacalyserJD, missing call_chat_api in question_logic)*
- `PYTHONPATH=. pytest tests/test_generate_job_ad.py::test_generate_job_ad_merges_all_benefits -q`


------
https://chatgpt.com/codex/tasks/task_e_689cce93e6f48320af1de5e1f886c044