### PR TITLE
feat: include responsibilities in interview guide

### DIFF
--- a/tests/test_generate_interview_guide.py
+++ b/tests/test_generate_interview_guide.py
@@ -20,3 +20,19 @@ def test_generate_interview_guide_includes_culture(monkeypatch):
     assert "Company culture: Collaborative and transparent" in prompt
     assert "cultural fit" in prompt.lower()
     assert "Tone: casual and friendly." in prompt
+
+
+def test_generate_interview_guide_uses_responsibilities(monkeypatch):
+    captured = {}
+
+    def fake_call_chat_api(messages, **kwargs):
+        captured["prompt"] = messages[0]["content"]
+        return "guide"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+
+    responsibilities = "Design systems\nWrite code"
+    openai_utils.generate_interview_guide("Engineer", responsibilities=responsibilities)
+    prompt = captured["prompt"]
+    assert "Design systems" in prompt
+    assert "Write code" in prompt


### PR DESCRIPTION
## Summary
- expand interview guide generation to use `position.job_title` and full `responsibilities.items`
- update Boolean query and downloads to rely on new job title key
- add test ensuring responsibilities are included in guide prompts

## Testing
- `ruff check wizard.py tests/test_generate_interview_guide.py`
- `mypy wizard.py tests/test_generate_interview_guide.py`
- `PYTHONPATH=. pytest tests/test_generate_interview_guide.py`
- ⚠️ `pytest` *(fails: ValidationError for VacancyProfile and missing attributes in question_logic)*


------
https://chatgpt.com/codex/tasks/task_e_689cd05735a083209edf13f131029147