### PR TITLE
fix: merge alias fields and test extraction flow

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -429,8 +429,24 @@ def coerce_and_fill(data: Dict[str, Any]) -> VacalyserJD:
             flat[key] = val
     # apply alias mapping
     for old, new in ALIASES.items():
-        if old in flat and new not in flat:
-            flat[new] = flat.pop(old)
+        if old not in flat:
+            continue
+        old_val = flat.pop(old)
+        if new in flat:
+            if new in LIST_FIELDS:
+                new_val = flat[new]
+                if not isinstance(new_val, list):
+                    new_val = [new_val]
+                if isinstance(old_val, list):
+                    combined = new_val + old_val
+                else:
+                    combined = new_val + [old_val]
+                flat[new] = combined
+            else:
+                # Canonical value already present; discard alias value
+                pass
+        else:
+            flat[new] = old_val
     data = flat
     # 2) insert missing keys with defaults from the canonical model
     #    This preserves numeric/boolean defaults instead of generic strings.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -43,15 +43,38 @@ def test_default_insertion() -> None:
 
 
 def test_alias_priority() -> None:
-    data = {
-        "responsibilities": {"items": ["A"]},
-        "tasks": "B",
-        "job_title": "Old",
-        "position": {"job_title": "New"},
-    }
+    data = {"job_title": "Old", "position": {"job_title": "New"}}
     jd = coerce_and_fill(data)
-    assert jd.responsibilities.items == ["A"]
     assert jd.position.job_title == "New"
+
+
+def test_tasks_merge_without_duplicates() -> None:
+    jd = coerce_and_fill(
+        {
+            "responsibilities": {"items": ["Task A"]},
+            "tasks": "Task B",
+        }
+    )
+    assert jd.responsibilities.items == ["Task A", "Task B"]
+
+    jd2 = coerce_and_fill(
+        {
+            "responsibilities": {"items": ["Task A"]},
+            "tasks": "Task A",
+        }
+    )
+    assert jd2.responsibilities.items == ["Task A"]
+
+
+def test_remote_policy_alias_priority() -> None:
+    jd = coerce_and_fill(
+        {
+            "employment": {"work_policy": "Hybrid"},
+            "remote_policy": "Fully remote",
+        }
+    )
+    assert jd.employment.work_policy == "Hybrid"
+    assert "remote_policy" not in jd.model_dump(mode="json")
 
 
 def test_list_coercion_split_and_dedupe() -> None:

--- a/tests/test_wizard_flow.py
+++ b/tests/test_wizard_flow.py
@@ -1,0 +1,63 @@
+import json
+
+import streamlit as st
+import wizard
+
+
+def test_normalise_state_populates_aliases() -> None:
+    st.session_state.clear()
+    st.session_state["position.job_title"] = "Engineer"
+    st.session_state["responsibilities.items"] = "Task A\nTask B"
+    st.session_state["employment.job_type"] = "full time"
+    st.session_state["employment.work_policy"] = "Remote"
+    wizard.normalise_state()
+    assert st.session_state["tasks"] == "Task A\nTask B"
+    assert st.session_state["contract_type"] == "Full-time"
+    assert st.session_state["remote_policy"] == "Remote"
+    jd = json.loads(st.session_state["validated_json"])
+    assert jd["employment"]["job_type"] == "Full-time"
+    assert jd["employment"]["work_policy"] == "Remote"
+    assert jd["responsibilities"]["items"] == ["Task A", "Task B"]
+
+
+def test_run_extraction_flow(monkeypatch) -> None:
+    st.session_state.clear()
+    st.session_state["uploaded_text"] = "Example text"
+    st.session_state["llm_model"] = "gpt-4"
+
+    monkeypatch.setattr(wizard, "build_extract_messages", lambda text: [])
+    monkeypatch.setattr(
+        wizard, "build_extraction_function", lambda: {"name": "extract"}
+    )
+
+    def fake_call_chat_api(*args, **kwargs):
+        return json.dumps(
+            {
+                "company": {"name": "ACME"},
+                "position": {"job_title": "Engineer"},
+                "employment": {"job_type": "full-time", "work_policy": "Remote"},
+                "responsibilities": {"items": ["Build things"]},
+            }
+        )
+
+    monkeypatch.setattr(wizard, "call_chat_api", fake_call_chat_api)
+    monkeypatch.setattr(wizard, "generate_followup_questions", lambda *a, **k: [])
+    monkeypatch.setattr(
+        wizard.esco_utils,
+        "classify_occupation",
+        lambda *a, **k: {"preferredLabel": "Engineer", "group": "123"},
+    )
+    monkeypatch.setattr(wizard, "log_event", lambda *a, **k: None)
+    monkeypatch.setattr(st, "warning", lambda *a, **k: None)
+    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+
+    wizard._run_extraction("en")
+
+    assert st.session_state["company.name"] == "ACME"
+    assert st.session_state["position.job_title"] == "Engineer"
+    assert st.session_state["employment.work_policy"] == "Remote"
+    assert st.session_state["responsibilities.items"] == "Build things"
+    assert st.session_state["tasks"] == "Build things"
+    assert st.session_state["contract_type"] == "Full-time"
+    assert st.session_state["remote_policy"] == "Remote"
+    assert st.session_state["extraction_success"] is True

--- a/wizard.py
+++ b/wizard.py
@@ -224,7 +224,12 @@ def normalise_state(reapply_aliases: bool = True):
         # Keep legacy alias fields in sync for UI (if needed)
         st.session_state["requirements"] = st.session_state.get("qualifications", "")
         st.session_state["tasks"] = st.session_state.get("responsibilities.items", "")
-        st.session_state["contract_type"] = st.session_state.get("job_type", "")
+        st.session_state["contract_type"] = st.session_state.get(
+            "employment.job_type", ""
+        )
+        st.session_state["remote_policy"] = st.session_state.get(
+            "employment.work_policy", ""
+        )
     st.session_state["validated_json"] = json.dumps(
         jd.model_dump(mode="json"), indent=2, ensure_ascii=False
     )
@@ -585,11 +590,8 @@ def _run_extraction(lang: str) -> None:
         st.error(err_msg)
         return
     try:
-        data = coerce_and_fill(json.loads(response)).model_dump(mode="json")
-        for key, val in data.items():
-            st.session_state[key] = (
-                "\n".join(val) if isinstance(val, list) else str(val)
-            )
+        jd = coerce_and_fill(json.loads(response))
+        to_session_state(jd, cast(dict[str, Any], st.session_state))
         normalise_state()
         try:
             followups = generate_followup_questions(


### PR DESCRIPTION
## Summary
- merge alias inputs for list fields and ignore conflicting remote text
- keep alias keys in sync after normalization and flatten extraction output
- test alias merging and mocked extraction flow end-to-end

## Testing
- `mypy core/schema.py wizard.py tests/test_schema.py tests/test_wizard_flow.py`
- `ruff check core/schema.py wizard.py tests/test_schema.py tests/test_wizard_flow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cd6cefb648320833430d802db45b6