### PR TITLE
fix: wire legacy followup wrapper

### DIFF
--- a/questions/generate.py
+++ b/questions/generate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional
 
 from core.schema import VacalyserJD
 
@@ -11,21 +11,34 @@ from question_logic import (
 )
 
 
-def generate_followup_questions(jd: VacalyserJD, lang: str = "en") -> List[str]:
+def generate_followup_questions(
+    jd: VacalyserJD,
+    num_questions: Optional[int] = None,
+    lang: str = "en",
+    use_rag: bool = True,
+) -> List[str]:
     """Return follow-up questions as simple strings.
 
-    This thin wrapper delegates to :func:`question_logic.generate_followup_questions`,
-    which returns rich question objects including priority levels and
-    suggestions. For backwards compatibility, only the ``question`` text is
-    exposed here.
+    This thin wrapper delegates to
+    :func:`question_logic.generate_followup_questions`, which returns rich
+    question objects including priority levels and suggestions. For backwards
+    compatibility, only the ``question`` text is exposed here while the full
+    set of parameters is forwarded to the underlying function.
 
     Args:
         jd: Parsed job description data.
+        num_questions: Optional maximum number of questions to return.
         lang: Language for generated questions.
+        use_rag: Whether to use RAG-based suggestions.
 
     Returns:
         List of follow-up question strings.
     """
 
-    items = _generate_followup_questions(jd.model_dump(), lang=lang)
+    items = _generate_followup_questions(
+        jd.model_dump(),
+        num_questions=num_questions,
+        lang=lang,
+        use_rag=use_rag,
+    )
     return [it["question"] for it in items if it.get("question")]

--- a/tests/test_generate_followups.py
+++ b/tests/test_generate_followups.py
@@ -8,7 +8,17 @@ from questions.generate import generate_followup_questions  # noqa: E402
 
 
 def test_generate_followups_wrapper(monkeypatch):
+    captured = {}
+
     def fake_generate(data, num_questions=None, lang="en", use_rag=True):
+        captured.update(
+            {
+                "data": data,
+                "num_questions": num_questions,
+                "lang": lang,
+                "use_rag": use_rag,
+            }
+        )
         return [
             {"field": "company.name", "question": "Company name?"},
             {"field": "location.primary_city", "question": "Location?"},
@@ -19,8 +29,14 @@ def test_generate_followups_wrapper(monkeypatch):
     )
 
     jd = VacalyserJD(position={"job_title": "Dev"})
-    questions = generate_followup_questions(jd)
+    questions = generate_followup_questions(
+        jd, num_questions=2, lang="de", use_rag=False
+    )
+
     assert questions == ["Company name?", "Location?"]
+    assert captured["num_questions"] == 2
+    assert captured["lang"] == "de"
+    assert captured["use_rag"] is False
 
 
 def test_generate_followups_wrapper_empty(monkeypatch):


### PR DESCRIPTION
## Summary
- expand questions.generate.generate_followup_questions to forward optional parameters and extract legacy question texts
- verify wrapper forwards args via dedicated tests

## Testing
- `ruff check .`
- `black questions/generate.py tests/test_generate_followups.py`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d89cefbb08320b17fcfb3ef5c8b60