### PR TITLE
fix: drop legacy keys and update job ad

### DIFF
--- a/tests/test_generate_job_ad.py
+++ b/tests/test_generate_job_ad.py
@@ -81,7 +81,7 @@ def test_generate_job_ad_formats_travel_and_remote(monkeypatch):
     assert "Umzugsunterstützung: Ja" in prompts[1]
 
 
-def test_generate_job_ad_merges_all_benefits(monkeypatch):
+def test_generate_job_ad_lists_unique_benefits(monkeypatch):
     captured = {}
 
     def fake_call_chat_api(messages, **kwargs):
@@ -91,12 +91,10 @@ def test_generate_job_ad_merges_all_benefits(monkeypatch):
     monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
 
     session = {
-        "compensation.benefits": ["Gym membership"],
-        "health_benefits": ["Health insurance"],
-        "retirement_benefits": "401(k) match",
+        "compensation.benefits": ["Gym membership", "Gym membership", "401(k) match"],
         "lang": "en",
     }
 
     openai_utils.generate_job_ad(session)
     prompt = captured["prompt"]
-    assert "Benefits: Gym membership, Health insurance, 401(k) match" in prompt
+    assert "Benefits: Gym membership, 401(k) match" in prompt

--- a/wizard.py
+++ b/wizard.py
@@ -222,7 +222,6 @@ def normalise_state(reapply_aliases: bool = True):
     to_session_state(jd, cast(dict[str, Any], st.session_state))
     if reapply_aliases:
         # Keep legacy alias fields in sync for UI (if needed)
-        st.session_state["requirements"] = st.session_state.get("qualifications", "")
         st.session_state["tasks"] = st.session_state.get("responsibilities.items", "")
         st.session_state["contract_type"] = st.session_state.get(
             "employment.job_type", ""
@@ -618,7 +617,7 @@ def _run_extraction(lang: str) -> None:
             st.session_state["occupation_group"] = occ.get("group", "")
         st.session_state["extraction_success"] = True
         log_event(
-            f"ANALYZE by {st.session_state.get('user', 'anonymous')} title='{st.session_state.get('job_title', '')}'"
+            f"ANALYZE by {st.session_state.get('user', 'anonymous')} title='{st.session_state.get('position.job_title', '')}'"
         )
     except Exception:
         st.session_state["extraction_success"] = False
@@ -1233,13 +1232,6 @@ if sal_provided:
             key="compensation.salary_period",
         )
     benefits_label = "Benefits/Perks" if lang != "de" else "Vorteile/Extras"
-    # Merge deprecated benefit keys into the schema-aligned field.
-    merged = st.session_state.get("compensation.benefits", "")
-    for legacy in ("health_benefits", "retirement_benefits"):
-        extra = st.session_state.pop(legacy, "")
-        if extra:
-            merged = f"{merged}\n{extra}" if merged else extra
-    st.session_state["compensation.benefits"] = merged
     editable_draggable_list("compensation.benefits", benefits_label)
     st.text_area(
         (


### PR DESCRIPTION
## Summary
- remove legacy schema fields from job ad generator
- dedupe benefits only from `compensation.benefits`
- fix outdated session-state keys and benefit merging in wizard

## Testing
- `ruff check openai_utils.py wizard.py tests/test_generate_job_ad.py --fix`
- `black openai_utils.py wizard.py tests/test_generate_job_ad.py`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d8e62aa848320b1e6c58436e8e64e