### PR TITLE
feat: expand schema field registry

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -13,7 +13,7 @@ except ImportError:
     ConfigDict = None
     _HAS_V2 = False
 
-SCHEMA_VERSION = "v2.0"
+SCHEMA_VERSION = "v2.1"
 
 
 # Define nested models for each schema group (priority 1-3 fields only)
@@ -182,7 +182,7 @@ else:
 
 
 class VacalyserJD(_BaseModel):
-    """Canonical job description model (Vacalyzer v2.0)."""
+    """Canonical job description model (Vacalyzer v2.1)."""
 
     schema_version: str = Field(default=SCHEMA_VERSION)
     company: Company = Field(default_factory=Company)
@@ -222,6 +222,10 @@ ALL_FIELDS: List[str] = [
     "position.team_roles",
     "position.team_size",
     "position.team_structure",
+    "position.occupation_esco_code",
+    "position.occupation_esco_title",
+    "position.cross_functional",
+    "position.job_family",
     # Compensation fields
     "compensation.salary_currency",
     "compensation.salary_min",
@@ -272,13 +276,17 @@ ALL_FIELDS: List[str] = [
     # Contacts fields
     "contacts.hiring_manager.name",
     "contacts.hiring_manager.email",
+    "contacts.hiring_manager.phone",
     "contacts.hiring_manager.notify_stages",
     "contacts.hr.name",
     "contacts.hr.email",
+    "contacts.hr.phone",
     "contacts.hr.notify_stages",
     "contacts.recruiter.name",
     "contacts.recruiter.email",
+    "contacts.recruiter.phone",
     "contacts.recruiter.notify_stages",
+    "contacts.additional_notes",
     # Requirements fields
     "requirements.hard_skills",
     "requirements.education_level",
@@ -292,6 +300,9 @@ ALL_FIELDS: List[str] = [
     "requirements.portfolio_required",
     "requirements.portfolio_url",
     "requirements.reference_check_required",
+    "requirements.language_level_english",
+    "requirements.language_level_german",
+    "requirements.years_experience_preferred",
     # Responsibilities fields
     "responsibilities.items",
     "responsibilities.top3",
@@ -339,6 +350,11 @@ ALIASES: Dict[str, str] = {
     "tasks": "responsibilities.items",
     "travel_required": "employment.travel_required",
     "tools_technologies": "requirements.tools_and_technologies",
+    "hiring_manager_phone": "contacts.hiring_manager.phone",
+    "hr_phone": "contacts.hr.phone",
+    "recruiter_phone": "contacts.recruiter.phone",
+    "english_level": "requirements.language_level_english",
+    "german_level": "requirements.language_level_german",
     # Note: "qualifications" field is removed; no direct alias for "requirements" group as a whole.
 }
 

--- a/docs/json_pipeline.md
+++ b/docs/json_pipeline.md
@@ -1,4 +1,4 @@
-## Schema (v2.0)
+## Schema (v2.1)
 Vacalyzer's schema is now hierarchical, grouping related fields for a vacancy. Each top-level key represents a category (such as `company`, `position`, `compensation`, etc.), containing sub-fields. We focus on core fields (priority 1–3) to gather essential information first. Below are the groups and example fields:
 - **company:** `name`, `industry`, `hq_location`, `size`, `website`  
 - **position:** `job_title`, `seniority_level`, `department`, `management_scope`, `reporting_line`, `role_summary`, `team_structure`, etc.  
@@ -8,12 +8,12 @@ Vacalyzer's schema is now hierarchical, grouping related fields for a vacancy. E
 - **responsibilities:** `items` (list of key responsibilities), `top3` (the top three responsibilities).  
 *(Other groups like contacts, process, and analytics exist in the schema but may not be fully utilized in the initial extraction.)*
 
-All fields are expected in the JSON output, even if empty (empty string for text, empty list for lists). The `schema_version` is "v2.0" indicating the expanded schema.
+All fields are expected in the JSON output, even if empty (empty string for text, empty list for lists). The `schema_version` is "v2.1" indicating the expanded schema.
 
 Example JSON output from the extractor (abridged):
 ```json
 {
-  "schema_version": "v2.0",
+  "schema_version": "v2.1",
   "company": {
     "name": "TechCorp",
     "industry": "Information Technology",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -113,10 +113,26 @@ def test_job_type_invalid() -> None:
 def test_new_fields_defaults() -> None:
     jd = VacalyserJD()
     assert jd.contacts.hiring_manager.phone == ""
+    assert jd.contacts.hr.phone == ""
+    assert jd.contacts.recruiter.phone == ""
     assert jd.contacts.additional_notes == ""
     assert jd.position.occupation_esco_code == ""
+    assert jd.position.occupation_esco_title == ""
     assert jd.position.cross_functional is False
+    assert jd.position.job_family == ""
     assert jd.requirements.language_level_english == ""
+    assert jd.requirements.language_level_german == ""
     assert jd.requirements.years_experience_preferred == 0
     assert jd.process.interview_stages == 0
     assert jd.analytics.esco_missing_skill_count == 0
+
+
+def test_backward_compat_missing_new_fields() -> None:
+    old_data = {
+        "schema_version": "v2.0",
+        "contacts": {"hiring_manager": {"name": "Alice"}},
+    }
+    jd = coerce_and_fill(old_data)
+    dumped = jd.model_dump()
+    assert dumped["contacts"]["hiring_manager"]["phone"] == ""
+    assert dumped["position"]["occupation_esco_code"] == ""

--- a/vacalyser_schema.json
+++ b/vacalyser_schema.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "v2.0",
+  "schema_version": "v2.1",
   "source_file": "/mnt/data/vacalyser_schema_sheet.xlsx",
   "field_count": 186,
   "fields": [
@@ -1805,7 +1805,7 @@
     },
     {
       "key": "meta.schema_version",
-      "default": "v2.0",
+      "default": "v2.1",
       "priority": 4,
       "widget": {
         "kind": "read_only",


### PR DESCRIPTION
## Summary
- expand ALL_FIELDS and alias map to cover newly added schema fields
- bump schema version to v2.1 and update docs
- add regression test for loading pre-v2.1 JSON data

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d9af3bee0832086e04c0ad45e92ec