### PR TITLE
feat: add English level follow-up question

### DIFF
--- a/question_logic.py
+++ b/question_logic.py
@@ -73,6 +73,7 @@ EXTENDED_FIELDS: List[str] = [
     "requirements.tools_and_technologies",
     "requirements.certifications",
     "requirements.languages_required",
+    "requirements.language_level_english",
     "position.seniority_level",
     # employment
     "employment.job_type",
@@ -301,6 +302,7 @@ CRITICAL_FIELDS: Set[str] = {
     "compensation.salary_min",
     "compensation.salary_max",  # treat salary info as critical
     "requirements.languages_required",
+    "requirements.language_level_english",
     "requirements.certifications",
 }
 SKILL_FIELDS: Set[str] = {
@@ -529,6 +531,8 @@ def generate_followup_questions(
             q_text = (
                 "Which tools and technologies should the candidate be familiar with?"
             )
+        elif field == "requirements.language_level_english":
+            q_text = "What English proficiency level is required (e.g., B2, C1)?"
         elif field == "location.primary_city":
             q_text = "In which city is this position based?"
         elif field == "location.country":

--- a/tests/test_question_logic.py
+++ b/tests/test_question_logic.py
@@ -42,6 +42,16 @@ def test_yes_no_default(monkeypatch) -> None:
     ]
 
 
+def test_language_level_question(monkeypatch) -> None:
+    """Missing English level should trigger a specific question."""
+    monkeypatch.setattr(
+        "question_logic.CRITICAL_FIELDS", {"requirements.language_level_english"}
+    )
+    out = generate_followup_questions({}, num_questions=1, use_rag=False)
+    assert out[0]["field"] == "requirements.language_level_english"
+    assert "English" in out[0]["question"]
+
+
 def test_rag_suggestions_merge(monkeypatch) -> None:
     """RAG suggestions should populate the suggestions list."""
     monkeypatch.setattr("question_logic.CRITICAL_FIELDS", {"location.primary_city"})

--- a/wizard.py
+++ b/wizard.py
@@ -81,6 +81,7 @@ FIELD_SECTION_MAP: dict[str, int] = {
     "requirements.soft_skills": 3,
     "requirements.tools_and_technologies": 3,
     "requirements.languages_required": 3,
+    "requirements.language_level_english": 3,
     "requirements.certifications": 3,
     "employment.job_type": 4,
     "employment.work_policy": 4,
@@ -109,6 +110,10 @@ FIELD_LABELS: dict[str, tuple[str, str]] = {
     "requirements.languages_required": (
         "Languages Required",
         "Erforderliche Sprachen",
+    ),
+    "requirements.language_level_english": (
+        "English Proficiency Level",
+        "Englischniveau",
     ),
     "requirements.certifications": ("Certifications", "Zertifizierungen"),
     "employment.job_type": ("Employment Type", "Anstellungsart"),
@@ -177,6 +182,7 @@ SUMMARY_CATEGORIES: list[SummaryCategory] = [
             "requirements.soft_skills",
             "requirements.tools_and_technologies",
             "requirements.languages_required",
+            "requirements.language_level_english",
             "requirements.certifications",
             "position.seniority_level",
         ],


### PR DESCRIPTION
## Summary
- ensure English proficiency is treated as a critical field
- add targeted question when English level is missing
- map English level into wizard navigation and labels

## Testing
- `ruff check --fix question_logic.py wizard.py tests/test_question_logic.py`
- `black question_logic.py wizard.py tests/test_question_logic.py`
- `mypy question_logic.py wizard.py tests/test_question_logic.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d9d00ecb083209c7dcf6d570c2d84