### PR TITLE
feat: expand interview guide with skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - **Missing info alerts**: highlights empty critical fields and blocks navigation until they're filled, letting you jump back to fix them
 - **Boolean Builder 2.0**: interactive search string with selectable skills and title synonyms
 - **Export**: clean JSON profile, job‑ad markdown, interview guide
-- **Customizable interview guides**: choose 3–10 questions
+- **Customizable interview guides**: choose 3–10 questions, automatically covering responsibilities, culture, and specified hard and soft skills
 - **Tone control**: pick formal, casual, creative, or diversity-focused styles for job ads and interview guides
 - **Comprehensive job ads**: generated ads now mention requirements, salary and work policy when provided
 - **Employer branding**: company mission and culture flow into job ads and interview guides

--- a/tests/test_generate_interview_guide.py
+++ b/tests/test_generate_interview_guide.py
@@ -36,3 +36,24 @@ def test_generate_interview_guide_uses_responsibilities(monkeypatch):
     prompt = captured["prompt"]
     assert "Design systems" in prompt
     assert "Write code" in prompt
+
+
+def test_generate_interview_guide_includes_skills(monkeypatch):
+    captured = {}
+
+    def fake_call_chat_api(messages, **kwargs):
+        captured["prompt"] = messages[0]["content"]
+        return "guide"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+
+    openai_utils.generate_interview_guide(
+        "Engineer",
+        responsibilities="",
+        hard_skills=["Python", "SQL"],
+        soft_skills=["Teamwork"],
+    )
+    prompt = captured["prompt"]
+    assert "Python" in prompt and "SQL" in prompt
+    assert "Teamwork" in prompt
+    assert "assess each of these skills" in prompt

--- a/wizard.py
+++ b/wizard.py
@@ -1588,6 +1588,8 @@ def summary_outputs_page():
                 guide = generate_interview_guide(
                     title,
                     responsibilities,
+                    hard_skills=st.session_state.get("hard_skills", ""),
+                    soft_skills=st.session_state.get("soft_skills", ""),
                     audience="hiring managers",
                     num_questions=num_questions,
                     lang=lang,


### PR DESCRIPTION
## Summary
- extend interview guide generator to include hard and soft skill questions
- pass collected skills to guide generation in wizard UI
- document skill-aware guides and add coverage tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy openai_utils.py wizard.py tests/test_generate_interview_guide.py` (fails: Library stubs not installed for "requests")
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d9f21cce083209196e41915efa8fa