### PR TITLE
test: cover new schema fields

### DIFF
--- a/tests/test_question_logic.py
+++ b/tests/test_question_logic.py
@@ -63,3 +63,13 @@ def test_rag_suggestions_merge(monkeypatch) -> None:
     out = generate_followup_questions({}, num_questions=1, use_rag=True)
     assert out[0]["field"] == "location.primary_city"
     assert out[0]["suggestions"] == ["Berlin"]
+
+
+def test_new_field_triggers_question(monkeypatch) -> None:
+    """New schema fields should yield follow-up questions when missing."""
+    monkeypatch.setattr(
+        "question_logic.CRITICAL_FIELDS", {"contacts.hiring_manager.phone"}
+    )
+    out = generate_followup_questions({}, num_questions=1, use_rag=False)
+    assert out[0]["field"] == "contacts.hiring_manager.phone"
+    assert "phone" in out[0]["question"].lower()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -136,3 +136,24 @@ def test_backward_compat_missing_new_fields() -> None:
     dumped = jd.model_dump()
     assert dumped["contacts"]["hiring_manager"]["phone"] == ""
     assert dumped["position"]["occupation_esco_code"] == ""
+
+
+def test_coerce_and_fill_new_fields_with_aliases() -> None:
+    data = {
+        "contacts": {
+            "hiring_manager": {"phone": "+49 123"},
+            "recruiter": {"phone": "+1 555"},
+        },
+        "english_level": "C1",
+        "german_level": "B2",
+        "process": {"interview_stages": 3},
+        "analytics": {"esco_missing_skill_count": 2},
+    }
+    jd = coerce_and_fill(data)
+    dumped = jd.model_dump()
+    assert dumped["contacts"]["hiring_manager"]["phone"] == "+49 123"
+    assert dumped["contacts"]["recruiter"]["phone"] == "+1 555"
+    assert dumped["requirements"]["language_level_english"] == "C1"
+    assert dumped["requirements"]["language_level_german"] == "B2"
+    assert dumped["process"]["interview_stages"] == 3
+    assert dumped["analytics"]["esco_missing_skill_count"] == 2


### PR DESCRIPTION
## Summary
- ensure coerce_and_fill handles recently added fields and aliases
- verify follow-up question generator prompts for new fields

## Testing
- `ruff check tests/test_schema.py tests/test_question_logic.py`
- `mypy tests/test_schema.py tests/test_question_logic.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689da19a4a4883208e5268bd8c0d3a93