### PR TITLE
feat: add company info agent

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -23,6 +23,8 @@ class Company(BaseModel):
     hq_location: str = ""
     size: str = ""
     website: str = ""
+    mission: str = ""
+    culture: str = ""
 
 
 class Compensation(BaseModel):
@@ -206,6 +208,8 @@ ALL_FIELDS: List[str] = [
     "company.hq_location",
     "company.size",
     "company.website",
+    "company.mission",
+    "company.culture",
     # Position fields
     "position.job_title",
     "position.seniority_level",
@@ -355,6 +359,8 @@ ALIASES: Dict[str, str] = {
     "recruiter_phone": "contacts.recruiter.phone",
     "english_level": "requirements.language_level_english",
     "german_level": "requirements.language_level_german",
+    "company_mission": "company.mission",
+    "company_culture": "company.culture",
     # Note: "qualifications" field is removed; no direct alias for "requirements" group as a whole.
 }
 

--- a/tests/test_extract_company_info.py
+++ b/tests/test_extract_company_info.py
@@ -1,0 +1,29 @@
+"""Tests for company info extraction helper."""
+
+import json
+
+import openai_utils
+
+
+def test_extract_company_info_parses_json(monkeypatch):
+    """Parse JSON returned by the model into a dictionary."""
+
+    def fake_call_chat_api(messages, **kwargs):
+        return json.dumps(
+            {
+                "name": "Acme Corp",
+                "location": "Berlin, Germany",
+                "mission": "Make widgets greener",
+                "culture": "Collaborative and inclusive",
+            }
+        )
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+
+    result = openai_utils.extract_company_info("dummy text")
+    assert result == {
+        "name": "Acme Corp",
+        "location": "Berlin, Germany",
+        "mission": "Make widgets greener",
+        "culture": "Collaborative and inclusive",
+    }

--- a/vacalyser_schema.json
+++ b/vacalyser_schema.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "v2.1",
   "source_file": "/mnt/data/vacalyser_schema_sheet.xlsx",
-  "field_count": 186,
+  "field_count": 188,
   "fields": [
     {
       "key": "analytics.esco_missing_skill_count",
@@ -226,6 +226,38 @@
       "priority": 3,
       "widget": {
         "kind": "url_input",
+        "options": [],
+        "params": {}
+      },
+      "relation": "—",
+      "group": "company",
+      "required": false,
+      "export_targets": [
+        "job_ad"
+      ]
+    },
+    {
+      "key": "company.mission",
+      "default": null,
+      "priority": 3,
+      "widget": {
+        "kind": "text_area",
+        "options": [],
+        "params": {}
+      },
+      "relation": "—",
+      "group": "company",
+      "required": false,
+      "export_targets": [
+        "job_ad"
+      ]
+    },
+    {
+      "key": "company.culture",
+      "default": null,
+      "priority": 3,
+      "widget": {
+        "kind": "text_area",
         "options": [],
         "params": {}
       },


### PR DESCRIPTION
## Summary
- extract company details from website text via OpenAI
- support mission and culture in schema and UI
- cover company info extraction with unit test

## Testing
- `ruff check .`
- `black .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689da3b4bd748320b232c2c2034fff8c