### PR TITLE
feat: surface mission and culture

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 - **Tone control**: pick formal, casual, creative, or diversity-focused styles for job ads and interview guides
 - **Comprehensive job ads**: generated ads now mention requirements, salary and work policy when provided
 - **Employer branding**: company mission and culture flow into job ads and interview guides
+- **Culture-aware interviews**: German guides automatically include a question on cultural fit when a company culture is specified
+- **Mission & culture overview**: summary page highlights company mission and culture for quick reviewer context
 - **Bias check**: flags potentially discriminatory terms and suggests inclusive alternatives in generated job ads
 - **Onboarding Intro**: welcome step explains required inputs and allows skipping for returning users
 - **Responsive layout**: mobile-friendly columns and touch-sized buttons

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -339,7 +339,9 @@ def generate_interview_guide(
 
     hard_list = _normalize(hard_skills)
     soft_list = _normalize(soft_skills)
-    total_questions = num_questions + len(hard_list) + len(soft_list)
+    total_questions = (
+        num_questions + len(hard_list) + len(soft_list) + (1 if company_culture else 0)
+    )
     job_title = job_title.strip() or "this position"
     if lang.startswith("de"):
         tone = tone or "professionell und hilfreich"

--- a/tests/test_generate_interview_guide.py
+++ b/tests/test_generate_interview_guide.py
@@ -22,6 +22,27 @@ def test_generate_interview_guide_includes_culture(monkeypatch):
     assert "Tone: casual and friendly." in prompt
 
 
+def test_generate_interview_guide_adds_culture_question_de(monkeypatch):
+    captured = {}
+
+    def fake_call_chat_api(messages, **kwargs):
+        captured["prompt"] = messages[0]["content"]
+        return "guide"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+
+    openai_utils.generate_interview_guide(
+        "Engineer",
+        company_culture="Transparente Zusammenarbeit",
+        lang="de",
+        num_questions=2,
+    )
+    prompt = captured["prompt"]
+    assert "Unternehmenskultur: Transparente Zusammenarbeit" in prompt
+    assert "Passung zur Unternehmenskultur" in prompt
+    assert "Formuliere 3 Schlüsselfragen" in prompt
+
+
 def test_generate_interview_guide_uses_responsibilities(monkeypatch):
     captured = {}
 

--- a/tests/test_generate_job_ad.py
+++ b/tests/test_generate_job_ad.py
@@ -47,6 +47,27 @@ def test_generate_job_ad_includes_optional_fields(monkeypatch):
     assert "Tone: formal and straightforward." in prompt
 
 
+def test_generate_job_ad_includes_mission_and_culture_de(monkeypatch):
+    captured = {}
+
+    def fake_call_chat_api(messages, **kwargs):
+        captured["prompt"] = messages[0]["content"]
+        return "ok"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+
+    session = {
+        "company.mission": "Weltklasse Produkte bauen",
+        "company.culture": "Teamorientiert und offen",
+        "lang": "de",
+    }
+
+    openai_utils.generate_job_ad(session)
+    prompt = captured["prompt"]
+    assert "Unternehmensmission: Weltklasse Produkte bauen" in prompt
+    assert "Unternehmenskultur: Teamorientiert und offen" in prompt
+
+
 def test_generate_job_ad_formats_travel_and_remote(monkeypatch):
     prompts: list[str] = []
 

--- a/wizard.py
+++ b/wizard.py
@@ -1437,6 +1437,19 @@ def summary_outputs_page():
         st.subheader(st.session_state["company.name"])
     if st.session_state.get("company_style_guide"):
         st.markdown(f"**Style Guide:** {st.session_state['company_style_guide']}")
+    mission = st.session_state.get("company.mission")
+    culture = st.session_state.get("company.culture")
+    if mission or culture:
+        if lang == "de":
+            if mission:
+                st.markdown(f"**Unternehmensmission:** {mission}")
+            if culture:
+                st.markdown(f"**Unternehmenskultur:** {culture}")
+        else:
+            if mission:
+                st.markdown(f"**Company Mission:** {mission}")
+            if culture:
+                st.markdown(f"**Company Culture:** {culture}")
     # Show ESCO occupation classification if available
     if st.session_state.get("occupation_label"):
         occ_label = st.session_state["occupation_label"]


### PR DESCRIPTION
## Summary
- ensure interview guide adds an extra question when company culture is provided
- surface company mission and culture on the summary page for quick context
- document and test mission/culture handling across job ads and interview guides

## Testing
- `ruff check openai_utils.py wizard.py tests/test_generate_interview_guide.py tests/test_generate_job_ad.py`
- `black openai_utils.py wizard.py tests/test_generate_interview_guide.py tests/test_generate_job_ad.py`
- `mypy openai_utils.py wizard.py` *(fails: process hung and was interrupted)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689da8302f0c83208ef6b2a18ca96212