### PR TITLE
feat: add automatic follow-up loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - **Instant overview**: review extracted fields in a compact tabbed table before continuing
 - **API helper**: `call_chat_api` supports OpenAI function calls for reliable extraction
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance, shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
+- **Auto re‑ask loop**: optional toggle that keeps asking follow-up questions automatically until all critical fields are filled.
 - **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts, HR software for human resource professionals, engineering tools for civil engineers, cuisine specialties for chefs).
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **RAG‑Assist**: use your vector store to fill/contextualize

--- a/tests/test_auto_reask_loop.py
+++ b/tests/test_auto_reask_loop.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+import streamlit as st
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import wizard
+
+
+def test_auto_mode_generates_next_question(monkeypatch) -> None:
+    """Auto mode should fetch the next follow-up question automatically."""
+    st.session_state.clear()
+    st.session_state["lang"] = "en"
+    st.session_state["auto_mode"] = True
+    st.session_state["followup_questions"] = []
+    # Leave a critical field blank so a question is needed
+    st.session_state["company.name"] = ""
+
+    called: dict[str, int | None] = {}
+
+    def fake_generate(jd, num_questions=None, **_):
+        called["num_questions"] = num_questions
+        return [{"field": "company.name", "question": "Name?"}]
+
+    monkeypatch.setattr(wizard, "generate_followup_questions", fake_generate)
+    monkeypatch.setattr(st, "checkbox", lambda *a, **k: True)
+    monkeypatch.setattr(st, "caption", lambda *a, **k: None)
+    monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
+
+    wizard.render_followups_for(["company.name"])
+
+    assert called["num_questions"] == 1
+    assert st.session_state["followup_questions"]

--- a/tests/test_followup_inline.py
+++ b/tests/test_followup_inline.py
@@ -13,6 +13,7 @@ def test_render_followups_updates_state(monkeypatch) -> None:
         {"field": "compensation.salary_min", "question": "Salary?"}
     ]
 
+    monkeypatch.setattr(st, "checkbox", lambda *a, **k: False)
     monkeypatch.setattr(st, "text_input", lambda *a, **k: "100k")
     render_followups_for(["compensation.salary_min"])
 
@@ -32,6 +33,7 @@ def test_render_followups_prefill(monkeypatch) -> None:
         assert value == "Berlin"
         return value
 
+    monkeypatch.setattr(st, "checkbox", lambda *a, **k: False)
     monkeypatch.setattr(st, "text_input", fake_input)
     render_followups_for(["location.primary_city"])
 
@@ -56,6 +58,7 @@ def test_render_followups_critical_prefix(monkeypatch) -> None:
         seen["label"] = label
         return "100k"
 
+    monkeypatch.setattr(st, "checkbox", lambda *a, **k: False)
     monkeypatch.setattr(st, "markdown", fake_markdown)
     monkeypatch.setattr(st, "text_input", fake_input)
 


### PR DESCRIPTION
## Summary
- add auto-ask toggle so follow-up questions appear automatically until required fields filled
- generate single follow-up at a time when auto mode is active
- document auto re-ask loop and cover with tests

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689db19dea708320899c433a9a913818