### PR TITLE
feat: add auto-ask stop control and user messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - **Instant overview**: review extracted fields in a compact tabbed table before continuing
 - **API helper**: `call_chat_api` supports OpenAI function calls for reliable extraction
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance, shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
-- **Auto re‑ask loop**: optional toggle that keeps asking follow-up questions automatically until all critical fields are filled.
+- **Auto re‑ask loop**: optional toggle that keeps asking follow-up questions automatically until all critical fields are filled, with clear progress messages and a stop button for user control.
 - **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts, HR software for human resource professionals, engineering tools for civil engineers, cuisine specialties for chefs).
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **RAG‑Assist**: use your vector store to fill/contextualize

--- a/tests/test_auto_reask_loop.py
+++ b/tests/test_auto_reask_loop.py
@@ -24,7 +24,8 @@ def test_auto_mode_generates_next_question(monkeypatch) -> None:
 
     monkeypatch.setattr(wizard, "generate_followup_questions", fake_generate)
     monkeypatch.setattr(st, "checkbox", lambda *a, **k: True)
-    monkeypatch.setattr(st, "caption", lambda *a, **k: None)
+    monkeypatch.setattr(st, "info", lambda *a, **k: None)
+    monkeypatch.setattr(st, "button", lambda *a, **k: False)
     monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
 
     wizard.render_followups_for(["company.name"])

--- a/wizard.py
+++ b/wizard.py
@@ -383,7 +383,8 @@ def render_followups_for(fields: list[str] | None = None) -> None:
     """Display follow-up questions inline for specified fields.
 
     Critical questions are prefixed with a red asterisk to signal required
-    input.
+    input. In auto mode questions are generated and shown sequentially,
+    accompanied by a message and a stop button so users keep control.
 
     Args:
         fields: List of field names relevant to the current page. If ``None``,
@@ -417,17 +418,30 @@ def render_followups_for(fields: list[str] | None = None) -> None:
             st.session_state["followup_questions"] = followups
         else:
             st.session_state["auto_mode"] = False
+            done_msg = (
+                "All critical fields are now filled."
+                if lang != "de"
+                else "Alle wichtigen Felder sind nun ausgefüllt."
+            )
+            st.success(done_msg)
+            return
+
+    if st.session_state.get("auto_mode"):
+        info_msg = (
+            "The AI will now ask follow-up questions one by one to collect missing details."
+            if lang != "de"
+            else "Die KI stellt nun der Reihe nach Rückfragen, um alle fehlenden Angaben zu erheben."
+        )
+        st.info(info_msg)
+        stop_label = "⏹ Stop Auto-Ask" if lang != "de" else "⏹ Auto-Modus stoppen"
+        if st.button(stop_label, key="stop_auto_mode"):
+            st.session_state["auto_mode"] = False
+            st.session_state["followup_questions"] = []
+            return
 
     if st.session_state.get("auto_mode") and len(followups) > 1:
         followups = followups[:1]
         st.session_state["followup_questions"] = followups
-
-    if st.session_state.get("auto_mode"):
-        st.caption(
-            "Automatic follow-ups enabled..."
-            if lang != "de"
-            else "Automatische Rückfragen aktiviert..."
-        )
 
     if not followups:
         return


### PR DESCRIPTION
## Summary
- inform users when Auto-Ask runs and allow them to stop the loop
- disable Auto-Ask after completion with success notice
- document new controls in README

## Testing
- `ruff check wizard.py tests/test_auto_reask_loop.py`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689db3fdfa888320a9d0b1d1c2925c16