### PR TITLE
fix: wrap stylesheet in style tag

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ st.logo(
 
 # --- Load the futuristic CSS ---
 css_path = Path("styles/vacalyser.css")
-st.markdown(css_path.read_text(), unsafe_allow_html=True)
+st.markdown(f"<style>{css_path.read_text()}</style>", unsafe_allow_html=True)
 
 # --- Inject background image as a CSS variable (base64) ---
 bg_path = Path("images/AdobeStock_506577005.jpeg")


### PR DESCRIPTION
## Summary
- ensure custom CSS loads via `<style>` tag to prevent raw CSS text appearing

## Testing
- `streamlit run app.py --server.headless true --server.port 8501`
- `curl -s localhost:8501 | rg -- '--accent'`
- `ruff check .`
- `black .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e37f6320883209a8cf5957174724d