### PR TITLE
fix: replace stray wizard strings with comments

### DIFF
--- a/wizard.py
+++ b/wizard.py
@@ -89,7 +89,7 @@ FIELD_SECTION_MAP: dict[str, int] = {
     "compensation.salary_min": 4,
     "compensation.salary_max": 4,
 }
-"""Map critical field names to wizard section indices for navigation."""
+# Map critical field names to wizard section indices for navigation
 
 
 FIELD_LABELS: dict[str, tuple[str, str]] = {
@@ -122,7 +122,7 @@ FIELD_LABELS: dict[str, tuple[str, str]] = {
     "compensation.salary_min": ("Salary Minimum", "Mindestgehalt"),
     "compensation.salary_max": ("Salary Maximum", "Höchstgehalt"),
 }
-"""Human-friendly labels for critical wizard fields."""
+# Human-friendly labels for critical wizard fields
 
 
 def get_field_label(field: str, lang: str) -> str:


### PR DESCRIPTION
## Summary
- replace module-level triple-quoted strings in `wizard.py` with comments
- ensure no stray top-level strings remain to be rendered unintentionally

## Testing
- `ruff check wizard.py`
- `black wizard.py`
- `mypy wizard.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e39c1e71c8320bb0d1dad3cbe6c4d