### PR TITLE
feat: revamp wizard welcome flow

### DIFF
--- a/tests/test_infogathering_flow.py
+++ b/tests/test_infogathering_flow.py
@@ -12,7 +12,7 @@ def test_info_gathering_flow(monkeypatch) -> None:
     """Simulate extraction, navigation, and generation without external services."""
     st.session_state.clear()
     st.session_state["uploaded_text"] = (
-        "ACME Corp is hiring a Software Engineer.\n" "Responsibilities: Build things."
+        "ACME Corp is hiring a Software Engineer.\nResponsibilities: Build things."
     )
     st.session_state["llm_model"] = "gpt-4"
     st.session_state["lang"] = "en"
@@ -62,24 +62,21 @@ def test_info_gathering_flow(monkeypatch) -> None:
         wizard, "build_extraction_function", lambda: {"name": "extract"}
     )
 
-    wizard._run_extraction("en")
+    def start_button(label, **_k):
+        return label.startswith("🚀")
 
+    monkeypatch.setattr(st, "button", start_button)
+    monkeypatch.setattr(st, "text_input", lambda _l, value="", **_k: value)
+    monkeypatch.setattr(st, "file_uploader", lambda *_a, **_k: None)
+
+    wizard.welcome_page()
+    assert st.session_state["current_section"] == 1
     assert st.session_state["company.name"] == "ACME Corp"
     assert st.session_state["position.job_title"] == "Software Engineer"
     assert st.session_state["responsibilities.items"] == "Build things"
 
-    st.session_state["extraction_complete"] = True
-
-    def start_button(label, **_k):
-        return label.startswith("🚀 Start Discovery")
-
-    monkeypatch.setattr(st, "button", start_button)
-    wizard.start_discovery_page()
-    assert st.session_state["current_section"] == 2
-
-    # Reset button to no-ops and stub inputs
+    # Reset button to no-ops and stub other inputs for later steps
     monkeypatch.setattr(st, "button", lambda *_a, **_k: False)
-    monkeypatch.setattr(st, "text_input", lambda _l, value="", **_k: value)
     monkeypatch.setattr(st, "text_area", lambda _l, value="", **_k: value)
     monkeypatch.setattr(
         st, "selectbox", lambda _l, options, index=0, **_k: options[index]

--- a/tests/test_wizard_flow.py
+++ b/tests/test_wizard_flow.py
@@ -4,16 +4,16 @@ import streamlit as st
 import wizard
 
 
-def test_normalise_state_populates_aliases() -> None:
+def test_normalise_state_serialises_without_aliases() -> None:
     st.session_state.clear()
     st.session_state["position.job_title"] = "Engineer"
     st.session_state["responsibilities.items"] = "Task A\nTask B"
     st.session_state["employment.job_type"] = "full time"
     st.session_state["employment.work_policy"] = "Remote"
     wizard.normalise_state()
-    assert st.session_state["tasks"] == "Task A\nTask B"
-    assert st.session_state["contract_type"] == "Full-time"
-    assert st.session_state["remote_policy"] == "Remote"
+    assert "tasks" not in st.session_state
+    assert "contract_type" not in st.session_state
+    assert "remote_policy" not in st.session_state
     jd = json.loads(st.session_state["validated_json"])
     assert jd["employment"]["job_type"] == "Full-time"
     assert jd["employment"]["work_policy"] == "Remote"
@@ -56,7 +56,4 @@ def test_run_extraction_flow(monkeypatch) -> None:
     assert st.session_state["position.job_title"] == "Engineer"
     assert st.session_state["employment.work_policy"] == "Remote"
     assert st.session_state["responsibilities.items"] == "Build things"
-    assert st.session_state["tasks"] == "Build things"
-    assert st.session_state["contract_type"] == "Full-time"
-    assert st.session_state["remote_policy"] == "Remote"
     assert st.session_state["extraction_success"] is True


### PR DESCRIPTION
## Summary
- consolidate intro and extraction into a single welcome_page with manual Start Discovery trigger
- map schema fields to wizard sections and drop legacy alias propagation
- adjust tests for new flow and section mapping

## Testing
- `python -m black wizard.py tests/test_wizard_flow.py tests/test_infogathering_flow.py`
- `ruff check wizard.py tests/test_wizard_flow.py tests/test_infogathering_flow.py`
- `python -m mypy wizard.py tests/test_wizard_flow.py tests/test_infogathering_flow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e4566e3548320bc4b1fe41f107c09