### PR TITLE
fix: call welcome page at top level

### DIFF
--- a/wizard.py
+++ b/wizard.py
@@ -818,6 +818,9 @@ def start_discovery_page() -> None:  # pragma: no cover - compatibility alias
     welcome_page()
 
 
+welcome_page()
+
+
 def company_information_page():
     """Company Info page: Gather basic company information and optionally auto-fetch details from website."""
     lang = st.session_state.get("lang", "en")


### PR DESCRIPTION
## Summary
- Show upload step first by calling `welcome_page()` at module load

## Testing
- `black wizard.py`
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e5691f03883208f84dd1d8c338515