### PR TITLE
refactor: simplify session defaults

### DIFF
--- a/wizard.py
+++ b/wizard.py
@@ -66,10 +66,9 @@ TONE_CHOICES = {
 }
 
 lang = st.session_state.get("lang", "en")
-if "current_section" not in st.session_state:
-    st.session_state["current_section"] = 0
-    st.session_state["extraction_complete"] = False
-    st.session_state["followup_questions"] = []
+st.session_state.setdefault("current_section", 0)
+st.session_state.setdefault("extraction_complete", False)
+st.session_state.setdefault("followup_questions", [])
 
 
 # Mapping of wizard sections to the schema fields they contain.  This drives the


### PR DESCRIPTION
## Summary
- streamline initialization of session_state keys using `setdefault`

## Testing
- `black wizard.py`
- `ruff check wizard.py`
- `mypy wizard.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f93841624832095cd3239e9974bdc