### PR TITLE
feat: add wizard navigation button

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ## Highlights
 - **Dynamic Wizard**: multi‑step, bilingual (EN/DE), low‑friction inputs with auto-start analysis on upload/URL
+- **Advantages page**: explore key benefits and jump straight into the wizard via a dedicated button
 - **One‑hop extraction**: Parse PDFs/DOCX/URLs into 20+ fields
 - **Structured output**: function calling/JSON mode ensures valid responses
 - **Instant overview**: review extracted fields in a compact tabbed table before continuing

--- a/pages/advantages.py
+++ b/pages/advantages.py
@@ -358,6 +358,13 @@ with tabs[2]:
 st.markdown(finish_de if lang == "Deutsch" else finish_en)
 
 # ---------------------------------------------------------------------------
+# Navigation: Wizard Button
+# ---------------------------------------------------------------------------
+button_label = "🚀 Wizard starten" if lang == "Deutsch" else "🚀 Start Wizard"
+if st.button(button_label):
+    st.switch_page("wizard.py")
+
+# ---------------------------------------------------------------------------
 # Footer Hinweis
 # ---------------------------------------------------------------------------
 footer_de = "Hinweis: Passe die Listen in *pages/advantages.py* frei an, um sie zu kürzen oder zu erweitern."


### PR DESCRIPTION
## Summary
- add wizard start button to Advantages page
- document Advantages page in README

## Testing
- `python -m black pages/advantages.py`
- `python -m ruff check pages/advantages.py`
- `python -m mypy pages/advantages.py` *(fails: command produced no output and was interrupted)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f987645248320ace4d1a17dd13732