### PR TITLE
feat: raise follow-up cap and default to GPT-3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 - **Structured output**: function calling/JSON mode ensures valid responses
 - **Instant overview**: review extracted fields in a compact tabbed table before continuing
 - **API helper**: `call_chat_api` supports OpenAI function calls for reliable extraction
-- **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance, shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
+- **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance (now up to 12 by default), shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
 - **Auto re‑ask loop**: optional toggle that keeps asking follow-up questions automatically until all critical fields are filled, with clear progress messages and a stop button for user control.
 - **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts, HR software for human resource professionals, engineering tools for civil engineers, cuisine specialties for chefs).
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **No system OCR deps**: uses **OpenAI Vision** (set `OCR_BACKEND=none` to disable)
-- **Cost‑aware**: hybrid models (4o‑mini default), minimal re‑asks
-- **Model toggle**: choose GPT‑3.5 (fast, cheap) or GPT‑4 (accurate) for suggestions and outputs
+- **Cost‑aware**: GPT‑3.5 by default and minimal re‑asks
+- **Model**: optimized for GPT‑3.5 for suggestions and outputs
 - **Inline refinement**: adjust generated documents with custom instructions and instantly update the view
 - **Robust error handling**: user-facing alerts for API or network issues
 - **Cross-field deduplication**: avoids repeating the same information across multiple fields

--- a/components/model_selector.py
+++ b/components/model_selector.py
@@ -16,7 +16,7 @@ def model_selector(key: str = "llm_model") -> str:
     Returns:
         The chosen model identifier.
     """
-    models = ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"]
+    models = ["gpt-3.5-turbo"]
     default = st.session_state.get(key, OPENAI_MODEL)
     if default not in models:
         default = models[0]

--- a/llm/client.py
+++ b/llm/client.py
@@ -15,7 +15,7 @@ from utils.json_parse import parse_extraction
 from utils.retry import retry
 
 MODE = os.getenv("LLM_MODE", "plain").lower()
-MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
 OPENAI_CLIENT = OpenAI(api_key=os.getenv("OPENAI_API_KEY", ""))
 
 

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -69,7 +69,7 @@ def extract_structured_from_text(
         RuntimeError: If no valid JSON could be parsed from the model responses.
     """
 
-    mdl = model if model is not None else os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+    mdl = model if model is not None else os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
     sys_msg = (
         "You are a strict extraction engine. "
         "Return ONLY structured data matching the provided function schema. "
@@ -160,8 +160,8 @@ def extract_structured_from_text(
 def call_chat_api(
     messages: list[dict],
     model: str | None = None,
-    max_tokens: int = 500,
-    temperature: float = 0.5,
+    max_tokens: int = 800,
+    temperature: float = 0.7,
     *,
     functions: list[dict] | None = None,
     function_call: dict | None = None,

--- a/question_logic.py
+++ b/question_logic.py
@@ -46,7 +46,7 @@ except Exception:  # pragma: no cover
     OpenAI = None  # type: ignore[assignment, misc]
     _HAS_RESPONSES = False
 
-DEFAULT_LOW_COST_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+DEFAULT_LOW_COST_MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
 # Optional OpenAI vector store ID for RAG suggestions; set via env/secrets.
 # If unset or blank, RAG lookups are skipped.
 RAG_VECTOR_STORE_ID = os.getenv("VECTOR_STORE_ID", "").strip()
@@ -485,7 +485,7 @@ def generate_followup_questions(
         critical_missing = [f for f in missing_fields if f in CRITICAL_FIELDS]
         optional_missing = [f for f in missing_fields if f not in CRITICAL_FIELDS]
         base_num = len(critical_missing) + min(len(optional_missing), 3)
-        num_questions = min(max(base_num, 3), 7)
+        num_questions = min(max(base_num, 3), 12)
         num_questions += len(role_questions_cfg)  # include predefined role-specific Qs
     # 3) (Optional) Get suggestions via RAG for missing fields
     suggestions_map: Dict[str, List[str]] = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ requests>=2.31
 tenacity>=8.2
 typing-extensions>=4.8
 streamlit-sortables>=0.3.1
+types-requests
 


### PR DESCRIPTION
## Summary
- expand follow-up question limit to 12
- standardize default model to GPT-3.5 and expose in selector
- bump chat defaults for richer responses and add types-requests

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1a45233208320aefa19023aea6f86