### PR TITLE
refactor: remove legacy alias keys

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -348,19 +348,15 @@ ALIASES: Dict[str, str] = {
     "job_title": "position.job_title",
     "location": "location.primary_city",
     "contract_type": "employment.job_type",
-    "remote_policy": "employment.work_policy",
     "experience_level": "position.seniority_level",
     "start_date": "position.target_start_date",
     "tasks": "responsibilities.items",
-    "travel_required": "employment.travel_required",
     "tools_technologies": "requirements.tools_and_technologies",
     "hiring_manager_phone": "contacts.hiring_manager.phone",
     "hr_phone": "contacts.hr.phone",
     "recruiter_phone": "contacts.recruiter.phone",
     "english_level": "requirements.language_level_english",
     "german_level": "requirements.language_level_german",
-    "company_mission": "company.mission",
-    "company_culture": "company.culture",
     # Note: "qualifications" field is removed; no direct alias for "requirements" group as a whole.
 }
 

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -656,7 +656,7 @@ def generate_job_ad(
         label = label_de if lang.startswith("de") else label_en
 
         if key == "employment.travel_required":
-            detail = str(data.get("travel_required", "")).strip()
+            detail = str(data.get("employment.travel_details", "")).strip()
             if detail:
                 formatted = detail
             else:
@@ -664,7 +664,7 @@ def generate_job_ad(
                     yes_no[0] if str(val).lower() in ["true", "yes", "1"] else yes_no[1]
                 )
         elif key == "employment.work_policy":
-            detail = str(data.get("remote_policy", "")).strip()
+            detail = str(data.get("employment.work_policy_details", "")).strip()
             if detail:
                 formatted = f"{formatted} ({detail})"
         elif key in boolean_fields:
@@ -691,8 +691,8 @@ def generate_job_ad(
                 salary_str = f"{max_sal or min_sal:,} {currency} per {period}"
             details.append(f"{salary_label}: {salary_str}")
     # Add mission or culture if provided (optional context)
-    mission = (data.get("company_mission") or data.get("company.mission", "")).strip()
-    culture = (data.get("company_culture") or data.get("company.culture", "")).strip()
+    mission = data.get("company.mission", "").strip()
+    culture = data.get("company.culture", "").strip()
     if lang.startswith("de"):
         prompt = (
             "Erstelle eine ansprechende, professionelle Stellenanzeige in Markdown-Format.\n"

--- a/tests/test_generate_job_ad.py
+++ b/tests/test_generate_job_ad.py
@@ -79,9 +79,9 @@ def test_generate_job_ad_formats_travel_and_remote(monkeypatch):
 
     session_en = {
         "employment.travel_required": True,
-        "travel_required": "Occasional (up to 10%)",
+        "employment.travel_details": "Occasional (up to 10%)",
         "employment.work_policy": "Hybrid",
-        "remote_policy": "3 days remote",
+        "employment.work_policy_details": "3 days remote",
         "lang": "en",
     }
     openai_utils.generate_job_ad(session_en)
@@ -90,9 +90,9 @@ def test_generate_job_ad_formats_travel_and_remote(monkeypatch):
 
     session_de = {
         "employment.travel_required": True,
-        "travel_required": "Gelegentlich (bis zu 10%)",
+        "employment.travel_details": "Gelegentlich (bis zu 10%)",
         "employment.work_policy": "Hybrid",
-        "remote_policy": "3 Tage remote",
+        "employment.work_policy_details": "3 Tage remote",
         "employment.relocation_support": True,
         "lang": "de",
     }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -66,7 +66,7 @@ def test_tasks_merge_without_duplicates() -> None:
     assert jd2.responsibilities.items == ["Task A"]
 
 
-def test_remote_policy_alias_priority() -> None:
+def test_remote_policy_extra_field_ignored() -> None:
     jd = coerce_and_fill(
         {
             "employment": {"work_policy": "Hybrid"},
@@ -92,7 +92,7 @@ def test_coerce_flat_aliases() -> None:
 
 def test_cross_field_dedupe() -> None:
     data = {
-        "remote_policy": "Fully remote",
+        "employment": {"work_policy": "Fully remote"},
         "responsibilities": {"items": ["Develop APIs", "Fully remote"]},
     }
     jd = coerce_and_fill(data)

--- a/wizard.py
+++ b/wizard.py
@@ -1384,13 +1384,13 @@ if sal_provided:
     )
     st.text_input(
         "Remote Work Policy" if lang != "de" else "Richtlinie für Fernarbeit",
-        st.session_state.get("remote_policy", ""),
-        key="remote_policy",
+        st.session_state.get("employment.work_policy_details", ""),
+        key="employment.work_policy_details",
     )
     st.text_input(
         "Travel Requirements" if lang != "de" else "Reisebereitschaft",
-        st.session_state.get("travel_required", ""),
-        key="travel_required",
+        st.session_state.get("employment.travel_details", ""),
+        key="employment.travel_details",
     )
     benefit_btn_col, benefit_model_col = st.columns([3, 2])
     with benefit_model_col:


### PR DESCRIPTION
## Summary
- standardize session dictionaries on nested keys for work policy and travel details
- drop support for legacy alias fields in schema
- ensure job ad generation reads company mission and culture only from nested keys

## Testing
- `black openai_utils.py wizard.py core/schema.py tests/test_generate_job_ad.py tests/test_schema.py`
- `ruff check openai_utils.py wizard.py core/schema.py tests/test_generate_job_ad.py tests/test_schema.py`
- `mypy openai_utils.py wizard.py core/schema.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1a7cdd7148320a3ed27d105a856c5