### PR TITLE
feat: enforce closed schema for function calling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ tenacity>=8.2
 typing-extensions>=4.8
 streamlit-sortables>=0.3.1
 types-requests
+jsonschema>=4.0
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 import llm.client as client
 
 
@@ -53,3 +55,17 @@ def test_extract_json_smoke(monkeypatch):
     monkeypatch.setattr(client.OPENAI_CLIENT.chat.completions, "create", fake_create)
     out = client.extract_json("text")
     assert isinstance(out, str) and out != ""
+
+
+def test_assert_closed_schema_raises() -> None:
+    """The helper should detect foreign key references."""
+
+    with pytest.raises(ValueError):
+        client._assert_closed_schema({"$ref": "#/foo"})
+
+
+def test_generate_error_report_missing_required() -> None:
+    """Missing required fields should appear in the error report."""
+
+    report = client._generate_error_report({"position": {"job_title": "x"}})
+    assert "company" in report


### PR DESCRIPTION
## Summary
- validate function-calling schema to disallow foreign key references
- log detailed error reports when extraction responses violate the schema
- cover schema validation helpers with unit tests

## Testing
- `ruff check llm/client.py tests/test_llm_client.py`
- `mypy llm/client.py tests/test_llm_client.py`
- `PYTHONPATH=. pytest tests/test_llm_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1edc770d083209175ff0030c07155