### PR TITLE
chore: add backoff dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ typing-extensions>=4.8
 streamlit-sortables>=0.3.1
 types-requests
 jsonschema>=4.0
-
+backoff>=2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     requests>=2.31
     tenacity>=8.2
     typing-extensions>=4.8
+    backoff>=2.2
 
 [options.extras_require]
 


### PR DESCRIPTION
## Summary
- add backoff requirement
- include backoff in setup install_requires

## Testing
- `ruff check core/esco_utils.py openai_utils.py utils/retry.py` (fails: Undefined name `build_extraction_function`)
- `black --check .` (fails: would reformat app.py, question_logic.py, openai_utils.py, wizard.py)
- `mypy .` (fails: Name "build_extraction_function" is not defined and other type errors)
- `pytest` (fails: ImportError: cannot import name 'FIELD_SECTION_MAP' from 'wizard')

------
https://chatgpt.com/codex/tasks/task_e_68a1f7c3131c83208d798796b5d2e609