### PR TITLE
feat: add language option for benefit suggestions

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -248,6 +248,7 @@ def suggest_benefits(
     job_title: str,
     industry: str = "",
     existing_benefits: str = "",
+    lang: str = "en",
     model: str | None = None,
 ) -> list[str]:
     """Suggest common benefits/perks for the given role.
@@ -256,6 +257,7 @@ def suggest_benefits(
         job_title: Target role title.
         industry: Optional industry context.
         existing_benefits: Benefits already provided by the user.
+        lang: Output language ("en" or "de").
         model: Optional OpenAI model override.
 
     Returns:
@@ -264,29 +266,23 @@ def suggest_benefits(
     job_title = job_title.strip()
     if not job_title:
         return []
-    prompt = f"List 5 benefits or perks commonly offered for a {job_title} role"
-    if industry:
-        prompt += f" in the {industry} industry"
-    prompt += ". Avoid mentioning any benefit that's already listed below.\n"
-    if existing_benefits:
-        prompt += f"Already listed: {existing_benefits}"
-    # If the interface language is German, request output in German
-    # (We infer language from existing_benefits text as a simple heuristic or use a global if set)
-    try:
-        ui_lang = (
-            "de"
-            if "lang" in existing_benefits.lower() or "Vorteil" in existing_benefits
-            else "en"
+    if lang.startswith("de"):
+        prompt = (
+            f"Nenne 5 Vorteile oder Zusatzleistungen, die für eine Stelle als {job_title} "
+            "üblich sind"
         )
-    except Exception:
-        ui_lang = "en"
-    if ui_lang == "de":
-        prompt = f"Nenne 5 Vorteile oder Zusatzleistungen, die für eine Stelle als {job_title} üblich sind"
         if industry:
             prompt += f" in der Branche {industry}"
         prompt += ". Vermeide Vorteile, die bereits in der Liste unten stehen.\n"
         if existing_benefits:
             prompt += f"Bereits aufgelistet: {existing_benefits}"
+    else:
+        prompt = f"List 5 benefits or perks commonly offered for a {job_title} role"
+        if industry:
+            prompt += f" in the {industry} industry"
+        prompt += ". Avoid mentioning any benefit that's already listed below.\n"
+        if existing_benefits:
+            prompt += f"Already listed: {existing_benefits}"
     messages = [{"role": "user", "content": prompt}]
     max_tokens = 150 if not model or "gpt-3.5" in model else 200
     answer = call_chat_api(

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -25,6 +25,6 @@ def test_suggest_benefits_model(monkeypatch):
         return "- BenefitA\n- BenefitB"
 
     monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
-    out = openai_utils.suggest_benefits("Engineer", model="gpt-4")
+    out = openai_utils.suggest_benefits("Engineer", lang="en", model="gpt-4")
     assert captured["model"] == "gpt-4"
     assert out == ["BenefitA", "BenefitB"]

--- a/tests/test_suggest_benefits_language.py
+++ b/tests/test_suggest_benefits_language.py
@@ -1,0 +1,27 @@
+import openai_utils
+
+
+def test_suggest_benefits_english(monkeypatch):
+    captured = {}
+
+    def fake_call_chat_api(messages, model=None, **kwargs):
+        captured["prompt"] = messages[0]["content"]
+        return "- Health insurance\n- Gym membership"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+    out = openai_utils.suggest_benefits("Engineer", lang="en")
+    assert "benefits or perks" in captured["prompt"]
+    assert out == ["Health insurance", "Gym membership"]
+
+
+def test_suggest_benefits_german(monkeypatch):
+    captured = {}
+
+    def fake_call_chat_api(messages, model=None, **kwargs):
+        captured["prompt"] = messages[0]["content"]
+        return "- Gesundheitsversicherung\n- Firmenwagen"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+    out = openai_utils.suggest_benefits("Ingenieur", lang="de")
+    assert "Vorteile oder Zusatzleistungen" in captured["prompt"]
+    assert out == ["Gesundheitsversicherung", "Firmenwagen"]


### PR DESCRIPTION
## Summary
- extend `suggest_benefits` with a `lang` argument to force English or German prompts
- cover benefit suggestion prompts for English and German in tests

## Testing
- `python -m black openai_utils.py tests/test_model_selection.py tests/test_suggest_benefits_language.py`
- `ruff check openai_utils.py tests/test_model_selection.py tests/test_suggest_benefits_language.py`
- `python -m mypy openai_utils.py tests/test_model_selection.py tests/test_suggest_benefits_language.py --no-site-packages`
- `PYTHONPATH=. pytest tests/test_model_selection.py tests/test_suggest_benefits_language.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1f87f6e508320868b3fac477bb733