### PR TITLE
feat: return full chat messages from API helper

### DIFF
--- a/components/salary_dashboard.py
+++ b/components/salary_dashboard.py
@@ -12,7 +12,8 @@ def _call_chat_api(messages: list[dict], **kwargs: Any) -> str:
     """Lazy import wrapper around ``openai_utils.call_chat_api``."""
     from openai_utils import call_chat_api
 
-    return call_chat_api(messages, **kwargs)
+    res = call_chat_api(messages, **kwargs)
+    return (res.content or "") if hasattr(res, "content") else str(res)
 
 
 SENIORITY_FACTOR = {"junior": 0.8, "mid": 1.0, "senior": 1.3}

--- a/question_logic.py
+++ b/question_logic.py
@@ -211,27 +211,6 @@ def _priority_for(field: str, is_missing_esco_skill: bool = False) -> str:
     return "normal"
 
 
-def ask_followups(payload: dict, *, model: str = "gpt-4o-mini", vector_store_id: Optional[str] = None) -> dict:
-    tools, tool_choice, extra = [], None, {}
-    if vector_store_id:
-        tools = [{"type": "file_search", "file_search": {"vector_store_ids": [vector_store_id]}}]
-        tool_choice = "auto"
-    res = call_chat_api(
-        [
-            {"role": "system", "content": "Return ONLY a JSON object with follow-up questions and short answer suggestions."},
-            {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
-        ],
-        model=model,
-        temperature=0.2,
-        json_strict=True,
-        tools=tools,
-        tool_choice=tool_choice,
-        extra=extra,
-        max_tokens=800,
-    )
-    return json.loads(res.content or "{}")
-  
-
 def _collect_missing_fields(extracted: Dict[str, Any], fields: List[str]) -> List[str]:
     missing = []
     for f in fields:
@@ -272,14 +251,14 @@ def _rag_suggestions(
         {"role": "user", "content": json.dumps(user, ensure_ascii=False)},
     ]
     try:
-        answer = call_chat_api(
+        res = call_chat_api(
             messages,
             model=model,
             temperature=0,
             json_strict=True,
             tools=[{"type": "file_search", "vector_store_ids": [vector_store_id]}],
         )
-        data = json.loads(answer or "{}")
+        data = json.loads(_normalize_chat_content(res) or "{}")
         out: Dict[str, List[str]] = {}
         for f in missing_fields:
             vals = data.get(f) or data.get(f.replace("_", " ")) or []
@@ -326,16 +305,29 @@ def _normalize_chat_content(res: Any) -> str:
     # Fallback
     return ""
 
-def ask_followups(payload: dict, *, model: str = "gpt-4o-mini", vector_store_id: Optional[str] = None) -> dict:
-    tools, tool_choice, extra = [], None, {}
+
+def ask_followups(
+    payload: dict, *, model: str = "gpt-4o-mini", vector_store_id: Optional[str] = None
+) -> dict:
+    tools: list[Any] = []
+    tool_choice: Optional[str] = None
+    extra: dict[str, Any] = {}
     if vector_store_id:
         # Hinweis: Nur aktivieren, wenn deine call_chat_api/Backend diese Tool-Form unterstützt
-        tools = [{"type": "file_search", "file_search": {"vector_store_ids": [vector_store_id]}}]
+        tools = [
+            {
+                "type": "file_search",
+                "file_search": {"vector_store_ids": [vector_store_id]},
+            }
+        ]
         tool_choice = "auto"
 
     res = call_chat_api(
         [
-            {"role": "system", "content": "Return ONLY a JSON object with follow-up questions and short answer suggestions."},
+            {
+                "role": "system",
+                "content": "Return ONLY a JSON object with follow-up questions and short answer suggestions.",
+            },
             {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
         ],
         model=model,
@@ -352,6 +344,7 @@ def ask_followups(payload: dict, *, model: str = "gpt-4o-mini", vector_store_id:
     # Defensive: Falls der Provider trotz json_strict Codefences zurückgibt
     if content.startswith("```"):
         import re
+
         m = re.search(r"```(?:json)?\s*(.*?)```", content, re.S | re.I)
         if m:
             content = m.group(1).strip()
@@ -361,8 +354,8 @@ def ask_followups(payload: dict, *, model: str = "gpt-4o-mini", vector_store_id:
     except json.JSONDecodeError:
         # Hard fallback: leeres Objekt statt Exception (UI bleibt stabil)
         return {}
-      
-  
+
+
 def generate_followup_questions(
     extracted: Dict[str, Any],
     num_questions: Optional[int] = None,

--- a/tests/test_ask_followups.py
+++ b/tests/test_ask_followups.py
@@ -1,0 +1,20 @@
+import json
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+import question_logic
+from question_logic import ask_followups
+
+
+def test_ask_followups_parses_message(monkeypatch):
+    """ask_followups should parse JSON content from call_chat_api result."""
+
+    class _FakeMessage:
+        def __init__(self) -> None:
+            self.content = json.dumps({"questions": [{"field": "f", "question": "?"}]})
+
+    monkeypatch.setattr(question_logic, "call_chat_api", lambda *a, **k: _FakeMessage())
+    out = ask_followups({})
+    assert out == {"questions": [{"field": "f", "question": "?"}]}


### PR DESCRIPTION
## Summary
- return `ChatCompletionMessage` from `call_chat_api`
- adapt extraction and follow-up helpers to new message return type
- add tests for extraction and follow-up flows

## Testing
- `ruff check openai_utils.py question_logic.py components/salary_dashboard.py tests/test_openai_utils.py tests/test_ask_followups.py`
- `mypy openai_utils.py question_logic.py components/salary_dashboard.py tests/test_openai_utils.py tests/test_ask_followups.py`
- `pytest` *(fails: ImportError: cannot import name 'FIELD_SECTION_MAP' from 'wizard'; ImportError: cannot import name 'render_followups_for' from 'wizard')*

------
https://chatgpt.com/codex/tasks/task_e_68a20a56f38c832086b8dabd786485b1