### PR TITLE
feat: nest file search tool in RAG suggestions

### DIFF
--- a/question_logic.py
+++ b/question_logic.py
@@ -256,7 +256,13 @@ def _rag_suggestions(
             model=model,
             temperature=0,
             json_strict=True,
-            tools=[{"type": "file_search", "vector_store_ids": [vector_store_id]}],
+            tools=[
+                {
+                    "type": "file_search",
+                    "file_search": {"vector_store_ids": [vector_store_id]},
+                }
+            ],
+            tool_choice="auto",
         )
         data = json.loads(_normalize_chat_content(res) or "{}")
         out: Dict[str, List[str]] = {}


### PR DESCRIPTION
## Summary
- use nested file search tool with auto selection in `_rag_suggestions`
- test that RAG suggestions send nested tool payload

## Testing
- `black question_logic.py tests/test_question_logic.py`
- `ruff check question_logic.py tests/test_question_logic.py`
- `mypy question_logic.py tests/test_question_logic.py`
- `pytest tests/test_question_logic.py`


------
https://chatgpt.com/codex/tasks/task_e_68a20e3d2d7883209097066ad98b4fa7