### PR TITLE
fix: remove redundant rag check

### DIFF
--- a/question_logic.py
+++ b/question_logic.py
@@ -427,7 +427,7 @@ def generate_followup_questions(
         num_questions += len(role_questions_cfg)  # include predefined role-specific Qs
     # 3) (Optional) Get suggestions via RAG for missing fields
     suggestions_map: Dict[str, List[str]] = {}
-    if use_rag and use_rag and (OPENAI_API_KEY or os.getenv("OPENAI_API_KEY")):
+    if use_rag and (OPENAI_API_KEY or os.getenv("OPENAI_API_KEY")):
         try:
             suggestions_map = _rag_suggestions(
                 job_title, industry, missing_fields, lang=lang


### PR DESCRIPTION
## Summary
- simplify RAG suggestion activation to a single use_rag check

## Testing
- `ruff check question_logic.py`
- `black question_logic.py`
- `pytest tests/test_question_logic.py`
- `mypy question_logic.py` *(fails: process hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a210cdc9a88320a1d42e6499576e5e