### PR TITLE
fix: restore schema coercion and file search

### DIFF
--- a/question_logic.py
+++ b/question_logic.py
@@ -256,13 +256,13 @@ def _rag_suggestions(
             model=model,
             temperature=0,
             json_strict=True,
-            tools=[
-                {
-                    "type": "file_search",
-                    "file_search": {"vector_store_ids": [vector_store_id]},
-                }
-            ],
+            tools=[{"type": "custom", "name": "file_search"}],
             tool_choice="auto",
+            extra={
+                "tool_resources": {
+                    "file_search": {"vector_store_ids": [vector_store_id]}
+                }
+            },
         )
         data = json.loads(_normalize_chat_content(res) or "{}")
         out: Dict[str, List[str]] = {}
@@ -319,13 +319,10 @@ def ask_followups(
     tool_choice: Optional[str] = None
     extra: dict[str, Any] = {}
     if vector_store_id:
-        # Hinweis: Nur aktivieren, wenn deine call_chat_api/Backend diese Tool-Form unterstützt
-        tools = [
-            {
-                "type": "file_search",
-                "file_search": {"vector_store_ids": [vector_store_id]},
-            }
-        ]
+        tools = [{"type": "custom", "name": "file_search"}]
+        extra = {
+            "tool_resources": {"file_search": {"vector_store_ids": [vector_store_id]}}
+        }
         tool_choice = "auto"
 
     res = call_chat_api(

--- a/tests/test_question_logic.py
+++ b/tests/test_question_logic.py
@@ -95,13 +95,15 @@ def test_rag_suggestions_tool_payload(monkeypatch) -> None:
     def fake_call(messages, **kwargs):
         captured["tools"] = kwargs.get("tools")
         captured["tool_choice"] = kwargs.get("tool_choice")
+        captured["extra"] = kwargs.get("extra")
         return _Fake()
 
     monkeypatch.setattr("question_logic.call_chat_api", fake_call)
 
     _rag_suggestions("Engineer", "Tech", ["location"], vector_store_id="vs123")
 
-    assert captured["tools"] == [
-        {"type": "file_search", "file_search": {"vector_store_ids": ["vs123"]}}
-    ]
+    assert captured["tools"] == [{"type": "custom", "name": "file_search"}]
     assert captured["tool_choice"] == "auto"
+    assert captured["extra"] == {
+        "tool_resources": {"file_search": {"vector_store_ids": ["vs123"]}}
+    }


### PR DESCRIPTION
## Summary
- restore `coerce_and_fill` helper to accept raw data and apply defaults
- switch follow-up generator to `custom` file_search tool payload
- expose field section map and follow-up rendering helpers in `wizard`

## Testing
- `ruff check --fix wizard.py tests/test_followup_inline.py`
- `black wizard.py tests/test_followup_inline.py`
- `mypy core/schema.py question_logic.py wizard.py tests/test_question_logic.py tests/test_followup_inline.py`
- `pytest` *(fails: AttributeError, KeyError, ValidationError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a21fedc5f08320ab8ce44bae405c53