### PR TITLE
feat: add upload and URL tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Vacalyser** turns messy job ads into a **complete, structured vacancy profile**, then asks only the *minimal* follow‑ups. It enriches with **ESCO** (skills/occupations) and your **OpenAI Vector Store** to propose **missing skills, benefits, tools, and tasks**. Finally, it generates a polished **job ad**, **interview guide**, and **boolean search string**.
 
 ## Highlights
-- **Dynamic Wizard**: multi‑step, bilingual (EN/DE), low‑friction inputs with auto-start analysis on upload/URL
+- **Dynamic Wizard**: multi‑step, bilingual (EN/DE), low‑friction inputs with tabbed text/upload/URL choices and auto-start analysis
 - **Advantages page**: explore key benefits and jump straight into the wizard via a dedicated button
 - **One‑hop extraction**: Parse PDFs/DOCX/URLs into 20+ fields
 - **Structured output**: function calling/JSON mode ensures valid responses


### PR DESCRIPTION
## Summary
- allow users to provide job text via tabs for text, file upload, or URL in source step
- document tabbed input options in README

## Testing
- `black wizard.py`
- `ruff check .`
- `mypy wizard.py` *(fails: command interrupted)*
- `pytest` *(fails: AttributeError in tests and KeyError for missing compensation field)*

------
https://chatgpt.com/codex/tasks/task_e_68a2263d31288320b7e705d16fd82240