### PR TITLE
fix: type extraction return

### DIFF
--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -53,8 +53,14 @@ def test_extract_with_function(monkeypatch):
     monkeypatch.setattr(openai_utils, "call_chat_api", lambda *a, **k: _FakeMessage())
     from core import schema as cs
 
-    monkeypatch.setattr(cs, "coerce_and_fill", lambda model, raw: raw)
-    monkeypatch.setattr(cs, "VacalyserJD", object())
+    class _FakeJD:
+        def __init__(self, data: dict[str, str]) -> None:
+            self._data = data
+
+        def model_dump(self) -> dict[str, str]:
+            return self._data
+
+    monkeypatch.setattr(cs, "coerce_and_fill", lambda data: _FakeJD(data))
 
     result = extract_with_function("text", {})
     assert result["job_title"] == "Dev"


### PR DESCRIPTION
## Summary
- type-safe `extract_with_function` output and remove casts
- adjust test for new `coerce_and_fill` signature

## Testing
- `ruff check openai_utils.py tests/test_openai_utils.py`
- `black openai_utils.py tests/test_openai_utils.py`
- `mypy openai_utils.py`
- `PYTHONPATH=. pytest tests/test_openai_utils.py::test_extract_with_function -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2463ea3288320b50140d4551087b6