### PR TITLE
feat: add file and URL source tabs

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,77 +1,12 @@
 """Utility helpers for the Vacalyser app."""
 
+from __future__ import annotations
+
 import os
 import re
-from io import BytesIO
 
-import fitz  # PyMuPDF
-
-
-def extract_text_from_file(file_bytes: bytes, file_name: str) -> str:
-    """Extract text content from an uploaded file.
-
-    Supports PDFs, DOCX/DOC documents and plain text files.
-
-    Args:
-        file_bytes: Raw file data.
-        file_name: Original filename used to infer the type.
-
-    Returns:
-        Extracted text content, stripped of leading/trailing whitespace.
-    """
-
-    if not file_bytes:
-        return ""
-    file_name = file_name.lower()
-    text = ""
-    try:
-        if file_name.endswith(".pdf"):
-            with fitz.open(stream=file_bytes, filetype="pdf") as doc:
-                for page in doc:
-                    page_text = page.get_text().strip()
-                    if page_text:
-                        text += page_text + "\n"
-        elif file_name.endswith(".docx") or file_name.endswith(".doc"):
-            import docx
-
-            doc = docx.Document(BytesIO(file_bytes))
-            full_text = [para.text for para in doc.paragraphs]
-            text = "\n".join(full_text)
-        else:
-            text = file_bytes.decode("utf-8", errors="ignore")
-    except Exception:
-        text = ""
-    lines = [line.strip() for line in text.splitlines() if line.strip()]
-    return "\n".join(lines)
-
-
-def extract_text_from_url(url: str) -> str:
-    """Fetch and clean the main textual content from a web page.
-
-    Args:
-        url: Web page URL.
-
-    Returns:
-        Cleaned textual content or an empty string if retrieval fails.
-    """
-
-    try:
-        from readability import Document
-        import requests
-        from bs4 import BeautifulSoup
-
-        response = requests.get(url, timeout=8)
-        if response.status_code != 200:
-            return ""
-        doc = Document(response.text)
-        soup = BeautifulSoup(doc.summary(), "lxml")
-        for tag in soup(["script", "style"]):
-            tag.decompose()
-        text = soup.get_text("\n")
-        lines = [line.strip() for line in text.splitlines() if line.strip()]
-        return "\n".join(lines)
-    except Exception:
-        return ""
+from .pdf_utils import extract_text_from_file as extract_text_from_file
+from .url_utils import extract_text_from_url as extract_text_from_url
 
 
 def merge_texts(*parts: str) -> str:
@@ -92,6 +27,8 @@ def merge_texts(*parts: str) -> str:
 
 
 def highlight_keywords(text: str, keywords: list[str]) -> str:
+    """Highlight keywords in ``text`` with Markdown bold markers."""
+
     if not text or not keywords:
         return text
     pattern = re.compile("|".join([re.escape(k) for k in keywords]), re.IGNORECASE)
@@ -133,6 +70,8 @@ def build_boolean_query(
 
 
 def seo_optimize(text: str, max_keywords: int = 5) -> dict:
+    """Basic SEO analysis returning keywords and a meta description."""
+
     result = {"keywords": [], "meta_description": ""}
     if not text:
         return result
@@ -153,7 +92,9 @@ def seo_optimize(text: str, max_keywords: int = 5) -> dict:
     return result
 
 
-def ensure_logs_dir():
+def ensure_logs_dir() -> None:
+    """Create the logs directory if it does not exist."""
+
     try:
         os.makedirs("logs", exist_ok=True)
     except Exception:

--- a/utils/pdf_utils.py
+++ b/utils/pdf_utils.py
@@ -1,0 +1,51 @@
+"""Utilities for extracting text from uploaded documents."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Any
+
+import docx
+import fitz  # PyMuPDF
+
+
+def extract_text_from_file(file: Any, name: str | None = None) -> str:
+    """Extract plain text from a PDF or DOCX file.
+
+    Accepts either a Streamlit ``UploadedFile`` object or raw bytes with an
+    explicit ``name``. The text is returned with empty lines removed.
+
+    Args:
+        file: Uploaded file object or raw bytes.
+        name: Optional filename when ``file`` is provided as bytes.
+
+    Returns:
+        The extracted text content or an empty string on failure.
+    """
+
+    if hasattr(file, "getvalue"):
+        data = file.getvalue()
+        filename = getattr(file, "name", "")
+    elif hasattr(file, "read"):
+        data = file.read()
+        filename = getattr(file, "name", "")
+    else:
+        data = file
+        filename = name or ""
+    if not data:
+        return ""
+    filename = filename.lower()
+    text = ""
+    try:
+        if filename.endswith(".pdf"):
+            with fitz.open(stream=data, filetype="pdf") as doc:
+                text = "".join(page.get_text() for page in doc)
+        elif filename.endswith(".docx") or filename.endswith(".doc"):
+            document = docx.Document(BytesIO(data))
+            text = "\n".join(p.text for p in document.paragraphs)
+        else:
+            text = data.decode("utf-8", errors="ignore")
+    except Exception:
+        return ""
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return "\n".join(lines)

--- a/utils/url_utils.py
+++ b/utils/url_utils.py
@@ -1,0 +1,33 @@
+"""Utilities for extracting text from web pages."""
+
+from __future__ import annotations
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def extract_text_from_url(url: str) -> str:
+    """Retrieve and clean textual content from a web page.
+
+    Args:
+        url: The target page URL.
+
+    Returns:
+        The cleaned text content or an empty string if fetching fails.
+    """
+
+    try:
+        response = requests.get(url, timeout=8)
+        if response.status_code != 200:
+            return ""
+        from readability import Document
+
+        doc = Document(response.text)
+        soup = BeautifulSoup(doc.summary(), "lxml")
+        for tag in soup(["script", "style"]):
+            tag.decompose()
+        text = soup.get_text("\n")
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        return "\n".join(lines)
+    except Exception:
+        return ""


### PR DESCRIPTION
## Summary
- allow source step to ingest text, PDF/DOCX uploads, or URLs
- factor out extraction helpers into `utils/pdf_utils.py` and `utils/url_utils.py`

## Testing
- `ruff check wizard.py utils/pdf_utils.py utils/url_utils.py utils/__init__.py`
- `mypy wizard.py utils/pdf_utils.py utils/url_utils.py utils/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a249d3f3d08320aa3e977eba5b5788