### PR TITLE
feat: add basic i18n for wizard labels

### DIFF
--- a/cli/extract.py
+++ b/cli/extract.py
@@ -40,7 +40,8 @@ def main() -> None:
     if not file_path.exists():
         raise SystemExit(f"File not found: {file_path}")
 
-    text = extract_text_from_file(file_path.read_bytes(), file_path.name)
+    with file_path.open("rb") as fh:
+        text = extract_text_from_file(fh)
     if not text:
         raise SystemExit("No text could be extracted from the file.")
 

--- a/i18n.py
+++ b/i18n.py
@@ -1,0 +1,32 @@
+"""Core translation utilities for Vacalyser."""
+
+from __future__ import annotations
+
+STR = {
+    "de": {
+        "intro_title": "Vacalyser — Wizard",
+        "source": "Quelle",
+        "analyze": "🔎 Automatisch analysieren (LLM)",
+        "missing": "Es fehlen noch kritische Felder:",
+    },
+    "en": {
+        "intro_title": "Vacalyser — Wizard",
+        "source": "Source",
+        "analyze": "🔎 Analyze automatically (LLM)",
+        "missing": "Critical fields still missing:",
+    },
+}
+
+
+def t(key: str, lang: str) -> str:
+    """Translate ``key`` into the requested ``lang``.
+
+    Args:
+        key: Lookup key in the translation dictionary.
+        lang: Language code (``"de"`` or ``"en"``).
+
+    Returns:
+        The localized string if present, otherwise ``key`` itself.
+    """
+
+    return STR.get(lang, {}).get(key, key)

--- a/wizard.py
+++ b/wizard.py
@@ -8,6 +8,7 @@ from typing import List
 import streamlit as st
 
 from utils.i18n import tr
+from i18n import t
 
 # LLM/ESCO und Follow-ups
 from openai_utils import extract_with_function  # nutzt deine neue Definition
@@ -192,7 +193,7 @@ def _step_intro():
         None
     """
 
-    st.title("Vacalyser — Wizard")
+    st.title(t("intro_title", st.session_state.lang))
     st.write(
         tr(
             "Dieser Assistent führt dich in wenigen Schritten zu einem vollständigen, strukturierten Stellenprofil.",
@@ -213,7 +214,7 @@ def _step_intro():
 def _step_source(schema: dict):
     """Render the source step where users choose text, file, or URL."""
 
-    st.subheader(tr("Quelle", "Source"))
+    st.subheader(t("source", st.session_state.lang))
     tab_text, tab_file, tab_url = st.tabs(
         [tr("Text", "Text"), tr("Datei", "File"), tr("URL", "URL")]
     )
@@ -252,10 +253,7 @@ def _step_source(schema: dict):
             )
 
     text_for_extract = st.session_state.get("jd_text") or jd_text
-    if st.button(
-        tr("🔎 Automatisch analysieren (LLM)", "🔎 Analyze automatically (LLM)"),
-        type="primary",
-    ):
+    if st.button(t("analyze", st.session_state.lang), type="primary"):
         if not (text_for_extract or "").strip():
             st.warning(
                 tr(
@@ -740,9 +738,7 @@ def _step_summary(schema: dict, critical: list[str]):
     data = st.session_state.data
     missing = missing_keys(data, critical)
     if missing:
-        st.warning(
-            f"{tr('Es fehlen noch kritische Felder', 'Critical fields are still missing')}: {', '.join(missing)}"
-        )
+        st.warning(f"{t('missing', st.session_state.lang)} {', '.join(missing)}")
 
     st.json(data)
 


### PR DESCRIPTION
## Summary
- add central string translations via new `t` helper
- translate wizard intro title, source section, analyze button, and missing-field alert
- open files in CLI extractor using binary handle for mypy compatibility

## Testing
- `ruff check .`
- `black --check cli/extract.py wizard.py i18n.py`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a25323c1e88320b4468d57a3caf72f