### PR TITLE
refactor: centralize env config for question logic

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,11 +16,13 @@ DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "gpt-3.5-turbo")
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "").strip()
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", DEFAULT_MODEL)
+VECTOR_STORE_ID = os.getenv("VECTOR_STORE_ID", "").strip()
 
 try:
     openai_secrets = st.secrets["openai"]
     OPENAI_API_KEY = openai_secrets.get("OPENAI_API_KEY", OPENAI_API_KEY)
     OPENAI_MODEL = openai_secrets.get("OPENAI_MODEL", OPENAI_MODEL)
+    VECTOR_STORE_ID = openai_secrets.get("VECTOR_STORE_ID", VECTOR_STORE_ID)
 except Exception:
     openai_secrets = None
 

--- a/question_logic.py
+++ b/question_logic.py
@@ -21,7 +21,6 @@ Outputs (for UI sorting and chips):
 
 from __future__ import annotations
 import json
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 from openai_utils import call_chat_api
@@ -32,12 +31,12 @@ from core.esco_utils import (
     get_essential_skills,
     normalize_skills,
 )
-from config import OPENAI_API_KEY
+from config import OPENAI_API_KEY, OPENAI_MODEL, VECTOR_STORE_ID
 
-DEFAULT_LOW_COST_MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+DEFAULT_LOW_COST_MODEL = OPENAI_MODEL
 # Optional OpenAI vector store ID for RAG suggestions; set via env/secrets.
 # If unset or blank, RAG lookups are skipped.
-RAG_VECTOR_STORE_ID = os.getenv("VECTOR_STORE_ID", "").strip()
+RAG_VECTOR_STORE_ID = VECTOR_STORE_ID
 
 _ROOT = Path(__file__).resolve().parent
 with open(_ROOT / "critical_fields.json", "r", encoding="utf-8") as _f:
@@ -428,7 +427,7 @@ def generate_followup_questions(
         num_questions += len(role_questions_cfg)  # include predefined role-specific Qs
     # 3) (Optional) Get suggestions via RAG for missing fields
     suggestions_map: Dict[str, List[str]] = {}
-    if use_rag and (OPENAI_API_KEY or os.getenv("OPENAI_API_KEY")):
+    if use_rag and OPENAI_API_KEY:
         try:
             suggestions_map = _rag_suggestions(
                 job_title, industry, missing_fields, lang=lang

--- a/tests/test_question_logic.py
+++ b/tests/test_question_logic.py
@@ -68,7 +68,7 @@ def test_rag_suggestions_merge(monkeypatch) -> None:
         "question_logic._rag_suggestions",
         lambda *a, **k: {"location.primary_city": ["Berlin"]},
     )
-    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setattr("question_logic.OPENAI_API_KEY", "test")
     out = generate_followup_questions({}, num_questions=1, use_rag=True)
     assert out[0]["field"] == "location.primary_city"
     assert out[0]["suggestions"] == ["Berlin"]


### PR DESCRIPTION
## Summary
- import OPENAI_MODEL and VECTOR_STORE_ID from config instead of reading environment variables directly
- expose VECTOR_STORE_ID in config
- adjust follow-up question tests to patch OPENAI_API_KEY directly

## Testing
- `black config.py question_logic.py tests/test_question_logic.py`
- `ruff check .`
- `mypy question_logic.py config.py tests/test_question_logic.py`
- `pytest tests/test_question_logic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a254bd68608320b4fd3ff0648195e8