### PR TITLE
docs: add module docstring to openai utils

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -1,4 +1,10 @@
-# openai_utils.py
+"""Helpers for interacting with the OpenAI API.
+
+This module centralizes client configuration and common operations such as
+``call_chat_api`` for chat completions, ``extract_company_info`` for website
+analysis, and utilities for structured extraction and suggestion tasks.
+"""
+
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary
- add module-level Google-style docstring for openai_utils module

## Testing
- `ruff check openai_utils.py`
- `black openai_utils.py`
- `mypy openai_utils.py --follow-imports=skip --ignore-missing-imports`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a254a7faa483209f6edc493661ead7