### PR TITLE
feat: enrich hard skills with ESCO essentials

### DIFF
--- a/wizard.py
+++ b/wizard.py
@@ -277,7 +277,7 @@ def _step_source(schema: dict):
                     set_in(
                         st.session_state.data,
                         "position.occupation_label",
-                        occ.get("label"),
+                        occ.get("preferredLabel"),
                     )
                     set_in(
                         st.session_state.data,
@@ -296,7 +296,7 @@ def _step_source(schema: dict):
                         get_in(st.session_state.data, "requirements.hard_skills", [])
                         or []
                     )
-                    merged = sorted(current.union(skills))
+                    merged = sorted(current.union(set(skills)))
                     set_in(st.session_state.data, "requirements.hard_skills", merged)
                 st.session_state.step = 2
                 st.rerun()


### PR DESCRIPTION
## Summary
- handle localized labels and dedupe in `get_essential_skills`
- enrich extracted profiles with ESCO occupation info and essential skills
- test merging of ESCO essentials into hard skills

## Testing
- `ruff check .`
- `black . --check`
- `mypy .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2555321608320ae639cf82dbc2641