### PR TITLE
feat: standardize chat call result

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **One‑hop extraction**: Parse PDFs/DOCX/URLs into 20+ fields
 - **Structured output**: function calling/JSON mode ensures valid responses
 - **Instant overview**: review extracted fields in a compact tabbed table before continuing
-- **API helper**: `call_chat_api` supports OpenAI function calls for reliable extraction
+- **API helper**: `call_chat_api` now returns a unified `ChatCallResult` and supports OpenAI function calls for reliable extraction
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance (now up to 12 by default), shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
 - **Auto re‑ask loop**: optional toggle that keeps asking follow-up questions automatically until all critical fields are filled, with clear progress messages and a stop button for user control.
 - **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts, HR software for human resource professionals, engineering tools for civil engineers, cuisine specialties for chefs).

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -39,7 +39,7 @@ def test_call_chat_api_function_call(monkeypatch):
 
     monkeypatch.setattr("openai_utils.client", _FakeClient(), raising=False)
     out = call_chat_api([], functions=[{}], function_call={"name": "fn"})
-    assert out.function_call.arguments == '{"job_title": "x"}'
+    assert out.function_call and out.function_call["arguments"] == '{"job_title": "x"}'
 
 
 def test_extract_with_function(monkeypatch):


### PR DESCRIPTION
## Summary
- add `ChatCallResult` dataclass and return it from `call_chat_api`
- document new unified return type in README
- adjust tests for new structure

## Testing
- `ruff check openai_utils.py tests/test_openai_utils.py`
- `mypy openai_utils.py tests/test_openai_utils.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a25ecabdd483208284ba806c093ba9