### PR TITLE
feat: add unified json config loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,10 @@ export VECTOR_STORE_ID=vs_XXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
 If `VECTOR_STORE_ID` is unset or empty, Vacalyser runs without RAG.
+
+## Configuration
+
+Core JSON schemas like `vacalyser_schema.json`, `critical_fields.json`,
+`tone_presets.json` and `role_field_map.json` are loaded via
+`config_loader.load_json`, which falls back to safe defaults and logs a warning
+if a file is missing or malformed.

--- a/app.py
+++ b/app.py
@@ -1,12 +1,12 @@
 # app.py — Vacalyser (clean entrypoint, single source of truth)
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
 import streamlit as st
 
 from components.salary_dashboard import render_salary_dashboard
+from config_loader import load_json
 from utils.i18n import tr
 
 # --- Page config early (keine doppelten Titel/Icon-Resets) ---
@@ -20,22 +20,12 @@ st.set_page_config(
 ROOT = Path(__file__).parent
 
 
-def _load_json(path: Path, fallback: dict | None = None) -> dict:
-    try:
-        with path.open("r", encoding="utf-8") as f:
-            return json.load(f)
-    except Exception:
-        return fallback or {}
-
-
-SCHEMA = _load_json(ROOT / "vacalyser_schema.json", fallback={})
+SCHEMA = load_json("vacalyser_schema.json", fallback={})
 CRITICAL = set(
-    _load_json(ROOT / "critical_fields.json", fallback={"critical": []}).get(
-        "critical", []
-    )
+    load_json("critical_fields.json", fallback={"critical": []}).get("critical", [])
 )
-TONE = _load_json(ROOT / "tone_presets.json", fallback={"en": {}, "de": {}})
-ROLE_FIELD_MAP = _load_json(ROOT / "role_field_map.json", fallback={})
+TONE = load_json("tone_presets.json", fallback={"en": {}, "de": {}})
+ROLE_FIELD_MAP = load_json("role_field_map.json", fallback={})
 
 
 # --- Session Defaults (einheitliche Keys) ---

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,0 +1,28 @@
+"""Utility functions for loading JSON configuration files."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).parent
+
+
+def load_json(name: str, fallback: Any = None) -> Any:
+    """Load a JSON file from the project root.
+
+    Args:
+        name: Filename of the JSON file located in the project root.
+        fallback: Value to return if loading fails.
+
+    Returns:
+        Parsed JSON content or the provided ``fallback`` when loading fails.
+    """
+    try:
+        with (ROOT / name).open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as exc:  # pragma: no cover - defensive
+        logging.warning("Failed to load %s: %s", name, exc)
+        return fallback

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -104,13 +104,19 @@ def call_chat_api(
         if isinstance(call, dict):
             tool_calls.append(call)
         else:
-            tool_calls.append(
-                getattr(call, "model_dump", getattr(call, "__dict__", lambda: {}))()
-            )
+            dump = getattr(call, "model_dump", None)
+            if callable(dump):
+                tool_calls.append(dump())
+            else:
+                tool_calls.append(getattr(call, "__dict__", {}))
 
     fc = getattr(msg, "function_call", None)
     if fc is not None and not isinstance(fc, dict):
-        fc = getattr(fc, "model_dump", getattr(fc, "__dict__", lambda: {}))()
+        dump = getattr(fc, "model_dump", None)
+        if callable(dump):
+            fc = dump()
+        else:
+            fc = getattr(fc, "__dict__", {})
 
     usage_obj = getattr(response, "usage", {}) or {}
     usage: dict


### PR DESCRIPTION
## Summary
- centralize loading of JSON config files via `config_loader.load_json`
- use shared loader in `app.py` and document configuration behavior
- guard non-callable attributes when serializing OpenAI responses

## Testing
- `ruff check .`
- `black config_loader.py app.py openai_utils.py --check`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a263a16ca083208c65f344c1b05c87