### PR TITLE
chore: set mypy python version to 3.12

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -104,13 +104,15 @@ def call_chat_api(
         if isinstance(call, dict):
             tool_calls.append(call)
         else:
-            tool_calls.append(
-                getattr(call, "model_dump", getattr(call, "__dict__", lambda: {}))()
+            call_obj: Any = getattr(
+                call, "model_dump", getattr(call, "__dict__", lambda: {})
             )
+            tool_calls.append(call_obj() if callable(call_obj) else call_obj)
 
     fc = getattr(msg, "function_call", None)
     if fc is not None and not isinstance(fc, dict):
-        fc = getattr(fc, "model_dump", getattr(fc, "__dict__", lambda: {}))()
+        fc_obj: Any = getattr(fc, "model_dump", getattr(fc, "__dict__", lambda: {}))
+        fc = fc_obj() if callable(fc_obj) else fc_obj
 
     usage_obj = getattr(response, "usage", {}) or {}
     usage: dict

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ max-line-length = 120
 extend-ignore = E203,W503
 
 [mypy]
-python_version = 3.13
+python_version = 3.12
 ignore_missing_imports = True
 warn_redundant_casts = True
 warn_unused_ignores = True


### PR DESCRIPTION
## Summary
- bump mypy python_version to 3.12
- handle non-callable function_call objects in chat API helper

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a263d8052483208143047cbc8c8378