### PR TITLE
chore: remove typing-extensions dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ beautifulsoup4>=4.12
 lxml>=4.9
 requests>=2.31
 tenacity>=8.2
-typing-extensions>=4.8
 streamlit-sortables>=0.3.1
 types-requests
 jsonschema>=4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ install_requires =
     lxml>=4.9
     requests>=2.31
     tenacity>=8.2
-    typing-extensions>=4.8
     backoff>=2.2
     streamlit-sortables>=0.3.1
     jsonschema>=4.0


### PR DESCRIPTION
## Summary
- drop `typing-extensions` from setup and requirements
- rebuild environment without direct `typing-extensions` dependency

## Testing
- `ruff check .`
- `black --check .`
- `mypy .` *(fails: ModuleNotFoundError: No module named 'typing_extensions')*
- `pytest` *(fails: No module named 'typing_extensions')*

------
https://chatgpt.com/codex/tasks/task_e_68a263e51a748320878207d3c92ffe9f