### PR TITLE
ci: run checks on Python 3.11 and 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -110,7 +110,11 @@ def call_chat_api(
 
     fc = getattr(msg, "function_call", None)
     if fc is not None and not isinstance(fc, dict):
-        fc = getattr(fc, "model_dump", getattr(fc, "__dict__", lambda: {}))()
+        convert = getattr(fc, "model_dump", None)
+        if callable(convert):
+            fc = convert()
+        else:
+            fc = getattr(fc, "__dict__", {})
 
     usage_obj = getattr(response, "usage", {}) or {}
     usage: dict


### PR DESCRIPTION
## Summary
- expand CI to run against Python 3.11 and 3.12
- fix function call handling in `call_chat_api`

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `VACAYSER_OFFLINE=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a263f0ad88832082b3d80bda00a088