### PR TITLE
chore: use Python 3.12 devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Python 3",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
   "customizations": {
     "codespaces": {
       "openFiles": [


### PR DESCRIPTION
## Summary
- switch devcontainer to a Python 3.12 base image

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest` *(fails: TypeError: 'dict' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_68a263fd7b3483208d0b1efacf38de19