### PR TITLE
docs: clarify Python 3.11/3.12 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,16 @@
 
 ## Quick Start
 
+Requires **Python 3.11 or 3.12**.
+
 ```bash
 git clone https://github.com/KleinerBaum/cognitivestaffing
 cd cognitivestaffing
+
+# create and activate a virtual environment (pick one Python version)
+python3.11 -m venv .venv  # or: python3.12 -m venv .venv
+source .venv/bin/activate
+
 pip install -r requirements.txt  # or: pip install -e .
 streamlit run app.py
 ```


### PR DESCRIPTION
## Summary
- document supported Python 3.11/3.12 versions
- add virtual environment setup instructions

## Testing
- `ruff check .`
- `black . --check`
- `mypy .`
- `pytest` *(failed: tests/test_openai_utils.py::test_call_chat_api_function_call)*

------
https://chatgpt.com/codex/tasks/task_e_68a2643003c883209db683e01df87cc3