### PR TITLE
test: cover file and url uploads

### DIFF
--- a/tests/test_wizard_source.py
+++ b/tests/test_wizard_source.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import streamlit as st
 import pytest
+import streamlit as st
+from streamlit.errors import StreamlitAPIException
 
 from wizard import _step_source
 
@@ -16,6 +17,112 @@ class DummyTab:
 
     def __exit__(self, exc_type, exc, tb):
         return False
+
+
+def test_step_source_file_upload_sets_jd_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Uploading a file should set ``jd_text`` and populate the text area."""
+
+    st.session_state.clear()
+    st.session_state.lang = "en"
+    st.session_state.model = "gpt"
+    sample_text = "from file"
+
+    monkeypatch.setattr(st, "tabs", lambda labels: (DummyTab(), DummyTab(), DummyTab()))
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+
+    button_calls = iter([True, False])
+    monkeypatch.setattr(st, "button", lambda *a, **k: next(button_calls))
+    monkeypatch.setattr(st, "file_uploader", lambda *a, **k: object())
+    monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
+    monkeypatch.setattr(
+        st, "text_area", lambda *a, **k: st.session_state.get("jd_text", "")
+    )
+    monkeypatch.setattr(
+        "utils.pdf_utils.extract_text_from_file", lambda _f: sample_text
+    )
+
+    reran: dict[str, bool] = {"called": False}
+    monkeypatch.setattr(st, "rerun", lambda: reran.update(called=True))
+
+    try:
+        _step_source({})
+    except StreamlitAPIException as e:  # pragma: no cover - defensive
+        pytest.fail(f"StreamlitAPIException raised: {e}")
+
+    assert st.session_state["jd_text"] == sample_text
+    assert reran["called"]
+
+    button_calls = iter([False])
+    monkeypatch.setattr(st, "button", lambda *a, **k: next(button_calls, False))
+    monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
+
+    captured: dict[str, str] = {}
+
+    def text_area_capture(*_a, **_k):
+        captured["value"] = st.session_state.get("jd_text", "")
+        return captured["value"]
+
+    monkeypatch.setattr(st, "text_area", text_area_capture)
+
+    _step_source({})
+
+    assert captured["value"] == sample_text
+
+
+def test_step_source_url_upload_sets_jd_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Uploading via URL should set ``jd_text`` and populate the text area."""
+
+    st.session_state.clear()
+    st.session_state.lang = "en"
+    st.session_state.model = "gpt"
+    sample_text = "from url"
+
+    monkeypatch.setattr(st, "tabs", lambda labels: (DummyTab(), DummyTab(), DummyTab()))
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+
+    button_calls = iter([True, False])
+    monkeypatch.setattr(st, "button", lambda *a, **k: next(button_calls))
+    monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "text_input", lambda *a, **k: "https://example.com")
+    monkeypatch.setattr(
+        st, "text_area", lambda *a, **k: st.session_state.get("jd_text", "")
+    )
+    monkeypatch.setattr("utils.url_utils.extract_text_from_url", lambda _u: sample_text)
+
+    reran: dict[str, bool] = {"called": False}
+    monkeypatch.setattr(st, "rerun", lambda: reran.update(called=True))
+
+    try:
+        _step_source({})
+    except StreamlitAPIException as e:  # pragma: no cover - defensive
+        pytest.fail(f"StreamlitAPIException raised: {e}")
+
+    assert st.session_state["jd_text"] == sample_text
+    assert reran["called"]
+
+    button_calls = iter([False])
+    monkeypatch.setattr(st, "button", lambda *a, **k: next(button_calls, False))
+    monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
+
+    captured: dict[str, str] = {}
+
+    def text_area_capture(*_a, **_k):
+        captured["value"] = st.session_state.get("jd_text", "")
+        return captured["value"]
+
+    monkeypatch.setattr(st, "text_area", text_area_capture)
+
+    _step_source({})
+
+    assert captured["value"] == sample_text
 
 
 @pytest.mark.parametrize("mode", ["text", "file", "url"])


### PR DESCRIPTION
## Summary
- add regression tests covering file and URL uploads in wizard source step

## Testing
- `black tests/test_wizard_source.py`
- `ruff check tests/test_wizard_source.py`
- `mypy tests/test_wizard_source.py`
- `PYTHONPATH=. pytest tests/test_wizard_source.py`


------
https://chatgpt.com/codex/tasks/task_e_68a37102a11c83208cfa56d5ce6848bd