### PR TITLE
fix: isolate widget state from data state

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import streamlit as st
 from components.salary_dashboard import render_salary_dashboard
 from config_loader import load_json
 from utils.i18n import tr
+from utils.session import bootstrap_session, migrate_legacy_keys
 
 # --- Page config early (keine doppelten Titel/Icon-Resets) ---
 st.set_page_config(
@@ -19,6 +20,8 @@ st.set_page_config(
 # --- Helpers zum Laden lokaler JSON-Configs ---
 ROOT = Path(__file__).parent
 
+bootstrap_session()
+migrate_legacy_keys()
 
 SCHEMA = load_json("vacalyser_schema.json", fallback={})
 CRITICAL = set(

--- a/config.py
+++ b/config.py
@@ -41,3 +41,19 @@ else:
 
 DATABASE_URL = os.getenv("DATABASE_URL", "")
 SECRET_KEY = os.getenv("SECRET_KEY", "replace-me")
+
+
+class UIKeys:
+    """Session keys for UI widgets."""
+
+    JD_TEXT_INPUT = "ui.jd_text_input"
+    JD_FILE_UPLOADER = "ui.jd_file_uploader"
+    JD_URL_INPUT = "ui.jd_url_input"
+
+
+class DataKeys:
+    """Session keys for business data."""
+
+    JD_TEXT = "data.jd_text"
+    PROFILE = "data.profile"
+    STEP = "data.step"

--- a/pages/advantages.py
+++ b/pages/advantages.py
@@ -8,7 +8,12 @@ entsprechenden Listen unten anpasst.
 """
 
 import streamlit as st
-from typing import List, Dict
+from typing import Dict, List
+
+from utils.session import bootstrap_session, migrate_legacy_keys
+
+bootstrap_session()
+migrate_legacy_keys()
 
 # ---------------------------------------------------------------------------
 # Page‑Config

--- a/pages/tech_overview.py
+++ b/pages/tech_overview.py
@@ -11,6 +11,11 @@ Stakeholder (Allgemein verständlich/General public) optimal angepasst werden.
 
 import streamlit as st
 
+from utils.session import bootstrap_session, migrate_legacy_keys
+
+bootstrap_session()
+migrate_legacy_keys()
+
 # ---------------------------------------------------------------------------
 # Language & audience toggle
 # ---------------------------------------------------------------------------

--- a/utils/session.py
+++ b/utils/session.py
@@ -1,0 +1,54 @@
+from typing import Any, Dict
+import streamlit as st
+
+from config import DataKeys, UIKeys
+
+__all__ = [
+    "UIKeys",
+    "DataKeys",
+    "bootstrap_session",
+    "bind_textarea",
+    "migrate_legacy_keys",
+]
+
+
+DEFAULTS: Dict[str, Any] = {
+    DataKeys.JD_TEXT: "",
+    DataKeys.PROFILE: {},
+    DataKeys.STEP: 1,
+}
+
+
+def bootstrap_session() -> None:
+    """Initialize data keys before any widget is created."""
+    for k, v in DEFAULTS.items():
+        if k not in st.session_state:
+            st.session_state[k] = v
+
+
+def bind_textarea(
+    label: str, ui_key: str, data_key: str, placeholder: str = ""
+) -> None:
+    """Render a text area bound to a data key.
+
+    The UI key mirrors the data key only on first run; subsequent updates go
+    through the `on_change` callback.
+    """
+
+    if ui_key not in st.session_state:
+        st.session_state[ui_key] = st.session_state.get(data_key, "")
+
+    def _on_change() -> None:
+        st.session_state[data_key] = st.session_state[ui_key]
+
+    st.text_area(label, key=ui_key, placeholder=placeholder, on_change=_on_change)
+
+
+def migrate_legacy_keys() -> None:
+    """Migrate legacy session keys for backward compatibility."""
+    if "jd_text" in st.session_state and DataKeys.JD_TEXT not in st.session_state:
+        st.session_state[DataKeys.JD_TEXT] = st.session_state["jd_text"]
+        try:
+            del st.session_state["jd_text"]
+        except Exception:  # pragma: no cover - defensive
+            pass


### PR DESCRIPTION
## Summary
- add session utilities to bootstrap keys and bind widgets without post-creation mutation
- refactor wizard JD source step to use separate UI/data keys and callbacks
- initialize session defaults in all pages and migrate legacy keys

## Testing
- `ruff check config.py utils/session.py app.py wizard.py pages/advantages.py pages/tech_overview.py tests/test_wizard_source.py`
- `mypy config.py utils/session.py app.py wizard.py pages/advantages.py pages/tech_overview.py tests/test_wizard_source.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a37dcbced8832085acb1bbe13474b0