### PR TITLE
feat: robust JD text extraction

### DIFF
--- a/ingest/__init__.py
+++ b/ingest/__init__.py
@@ -1,3 +1,10 @@
 """Utilities for ingesting job description text."""
 
-__all__ = ["read_job_text"]
+from .extractors import extract_text_from_file, extract_text_from_url
+from .reader import read_job_text
+
+__all__ = [
+    "read_job_text",
+    "extract_text_from_file",
+    "extract_text_from_url",
+]

--- a/ingest/extractors.py
+++ b/ingest/extractors.py
@@ -1,0 +1,76 @@
+import io
+import re
+import requests
+from requests import Response
+
+
+def _fetch_url(url: str, timeout: float = 15.0) -> str:
+    """Fetch raw HTML from ``url`` with timeout and custom user agent.
+
+    Args:
+        url: HTTP(S) URL to download.
+        timeout: Timeout in seconds for the request.
+
+    Returns:
+        The response body as text.
+
+    Raises:
+        AssertionError: If the URL is invalid.
+        requests.RequestException: If the request fails.
+    """
+    assert url and re.match(r"^https?://", url), "Invalid URL"
+    resp: Response = requests.get(
+        url, timeout=timeout, headers={"User-Agent": "Vacalyser/1.0"}
+    )
+    resp.raise_for_status()
+    return resp.text
+
+
+def extract_text_from_url(url: str) -> str:
+    """Extract readable text content from ``url``.
+
+    Args:
+        url: HTTP(S) URL.
+
+    Returns:
+        Extracted text without markup.
+    """
+    try:
+        import trafilatura
+    except ImportError:  # pragma: no cover - optional dependency
+        from bs4 import BeautifulSoup
+
+        html = _fetch_url(url)
+        soup = BeautifulSoup(html, "lxml")
+        return soup.get_text("\n", strip=True)
+    html = _fetch_url(url)
+    text = trafilatura.extract(html, include_comments=False, include_tables=False) or ""
+    return text.strip()
+
+
+def extract_text_from_file(file) -> str:
+    """Extract text from an uploaded file (PDF, DOCX, or TXT).
+
+    Args:
+        file: File-like object supporting ``read`` and ``seek``.
+
+    Returns:
+        Extracted text content.
+    """
+    name = getattr(file, "name", "").lower()
+    data = file.read()
+    file.seek(0)
+    if name.endswith(".pdf"):
+        from pypdf import PdfReader
+
+        reader = PdfReader(io.BytesIO(data))
+        return "\n".join([p.extract_text() or "" for p in reader.pages]).strip()
+    if name.endswith(".docx"):
+        import docx
+
+        doc = docx.Document(io.BytesIO(data))
+        return "\n".join([p.text for p in doc.paragraphs]).strip()
+    try:
+        return data.decode("utf-8", errors="ignore")
+    except Exception:
+        return ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ types-requests
 jsonschema>=4.0
 backoff>=2.2
 httpx>=0.24
+trafilatura>=1.0
+pypdf>=4.0

--- a/tests/test_wizard_source.py
+++ b/tests/test_wizard_source.py
@@ -1,12 +1,7 @@
-"""Tests for the wizard's source step."""
-
-from __future__ import annotations
-
 import pytest
 import streamlit as st
-from streamlit.errors import StreamlitAPIException
 
-from wizard import _step_source
+from wizard import _step_source, on_file_uploaded, on_url_changed
 from utils.session import DataKeys, UIKeys
 
 
@@ -16,226 +11,110 @@ class DummyTab:
     def __enter__(self):
         return None
 
-    def __exit__(self, exc_type, exc, tb):
-        return False
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
 
 
-def test_step_source_file_upload_sets_jd_text(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Uploading a file should set ``data.jd_text`` and populate the text area."""
+def _setup_common(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch common Streamlit functions used in tests."""
+
+    monkeypatch.setattr(st, "tabs", lambda labels: (DummyTab(), DummyTab(), DummyTab()))
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
+    monkeypatch.setattr(st, "success", lambda *a, **k: None)
+    monkeypatch.setattr(st, "warning", lambda *a, **k: None)
+    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+    monkeypatch.setattr(st, "rerun", lambda: None)
+    st.session_state.setdefault("data", {})
+
+
+def test_on_file_uploaded_populates_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Uploading a file populates JD text and text input state."""
 
     st.session_state.clear()
     st.session_state.lang = "en"
-    st.session_state.model = "gpt"
     sample_text = "from file"
+    _setup_common(monkeypatch)
+    monkeypatch.setattr("wizard.extract_text_from_file", lambda _f: sample_text)
+    st.session_state[UIKeys.JD_FILE_UPLOADER] = object()
 
-    monkeypatch.setattr(st, "tabs", lambda labels: (DummyTab(), DummyTab(), DummyTab()))
-    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
-    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+    on_file_uploaded()
 
-    button_calls = iter([True, False])
-    monkeypatch.setattr(st, "button", lambda *a, **k: next(button_calls))
-    monkeypatch.setattr(st, "file_uploader", lambda *a, **k: object())
-    monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
-    monkeypatch.setattr(
-        st,
-        "text_area",
-        lambda *a, **k: st.session_state.get(UIKeys.JD_TEXT_INPUT, ""),
-    )
-    monkeypatch.setattr(
-        "utils.pdf_utils.extract_text_from_file", lambda _f: sample_text
-    )
-
-    reran: dict[str, bool] = {"called": False}
-    monkeypatch.setattr(st, "rerun", lambda: reran.update(called=True))
-
-    try:
-        _step_source({})
-    except StreamlitAPIException as e:  # pragma: no cover - defensive
-        pytest.fail(f"StreamlitAPIException raised: {e}")
-
-    assert st.session_state[DataKeys.JD_TEXT] == sample_text
-    assert UIKeys.JD_TEXT_INPUT not in st.session_state
-    assert reran["called"]
-
-    button_calls = iter([False])
-    monkeypatch.setattr(st, "button", lambda *a, **k: next(button_calls, False))
-    monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
-    monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
-
-    captured: dict[str, str] = {}
-
-    def text_area_capture(*_a, **_k):
-        captured["value"] = st.session_state.get(UIKeys.JD_TEXT_INPUT, "")
-        return captured["value"]
-
-    monkeypatch.setattr(st, "text_area", text_area_capture)
-
-    _step_source({})
-
-    assert captured["value"] == sample_text
-    assert st.session_state[DataKeys.JD_TEXT] == sample_text
+    assert st.session_state.get(DataKeys.JD_TEXT) == sample_text
+    assert st.session_state.get(UIKeys.JD_TEXT_INPUT) == sample_text
 
 
-def test_step_source_url_upload_sets_jd_text(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Uploading via URL should set ``data.jd_text`` and populate the text area."""
+def test_on_url_changed_populates_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Entering a URL populates JD text and text input state."""
 
     st.session_state.clear()
     st.session_state.lang = "en"
-    st.session_state.model = "gpt"
     sample_text = "from url"
+    _setup_common(monkeypatch)
+    monkeypatch.setattr("wizard.extract_text_from_url", lambda _u: sample_text)
+    st.session_state[UIKeys.JD_URL_INPUT] = "https://example.com"
 
-    monkeypatch.setattr(st, "tabs", lambda labels: (DummyTab(), DummyTab(), DummyTab()))
-    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
-    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+    on_url_changed()
 
-    button_calls = iter([True, False])
-    monkeypatch.setattr(st, "button", lambda *a, **k: next(button_calls))
-    monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
-    monkeypatch.setattr(st, "text_input", lambda *a, **k: "https://example.com")
-    monkeypatch.setattr(
-        st,
-        "text_area",
-        lambda *a, **k: st.session_state.get(UIKeys.JD_TEXT_INPUT, ""),
-    )
-    monkeypatch.setattr("utils.url_utils.extract_text_from_url", lambda _u: sample_text)
-
-    reran: dict[str, bool] = {"called": False}
-    monkeypatch.setattr(st, "rerun", lambda: reran.update(called=True))
-
-    try:
-        _step_source({})
-    except StreamlitAPIException as e:  # pragma: no cover - defensive
-        pytest.fail(f"StreamlitAPIException raised: {e}")
-
-    assert st.session_state[DataKeys.JD_TEXT] == sample_text
-    assert UIKeys.JD_TEXT_INPUT not in st.session_state
-    assert reran["called"]
-
-    button_calls = iter([False])
-    monkeypatch.setattr(st, "button", lambda *a, **k: next(button_calls, False))
-    monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
-    monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
-
-    captured: dict[str, str] = {}
-
-    def text_area_capture(*_a, **_k):
-        captured["value"] = st.session_state.get(UIKeys.JD_TEXT_INPUT, "")
-        return captured["value"]
-
-    monkeypatch.setattr(st, "text_area", text_area_capture)
-
-    _step_source({})
-
-    assert captured["value"] == sample_text
-    assert st.session_state[DataKeys.JD_TEXT] == sample_text
+    assert st.session_state.get(DataKeys.JD_TEXT) == sample_text
+    assert st.session_state.get(UIKeys.JD_TEXT_INPUT) == sample_text
 
 
 @pytest.mark.parametrize("mode", ["text", "file", "url"])
 def test_step_source_populates_data(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
     """The source step should fill ``session_state.data`` after analysis."""
+
     st.session_state.clear()
     st.session_state.lang = "en"
     st.session_state.model = "gpt"
     sample_text = "Job text"
     sample_data = {"position": {"job_title": "Engineer"}}
-
-    # Streamlit UI stubs
-    monkeypatch.setattr(st, "tabs", lambda labels: (DummyTab(), DummyTab(), DummyTab()))
-    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
-    monkeypatch.setattr(st, "success", lambda *a, **k: None)
-    monkeypatch.setattr(st, "warning", lambda *a, **k: None)
-    monkeypatch.setattr(st, "error", lambda *a, **k: None)
-    monkeypatch.setattr(st, "rerun", lambda: None)
-
-    # Extraction helpers
+    _setup_common(monkeypatch)
+    monkeypatch.setattr(st, "button", lambda *a, **k: True)
     monkeypatch.setattr(
         "wizard.extract_with_function", lambda _t, _s, model=None: sample_data
     )
     monkeypatch.setattr("wizard.classify_occupation", lambda _t, _l: None)
 
-    if mode == "text":
+    if mode == "file":
+        monkeypatch.setattr("wizard.extract_text_from_file", lambda _f: sample_text)
+        st.session_state[UIKeys.JD_FILE_UPLOADER] = object()
+        on_file_uploaded()
+    elif mode == "url":
+        monkeypatch.setattr("wizard.extract_text_from_url", lambda _u: sample_text)
+        st.session_state[UIKeys.JD_URL_INPUT] = "https://example.com"
+        on_url_changed()
+    else:
         st.session_state[DataKeys.JD_TEXT] = sample_text
-        monkeypatch.setattr(st, "button", lambda *a, **k: True)
-        monkeypatch.setattr(st, "text_area", lambda *a, **k: sample_text)
-        monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
-        monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
-        _step_source({})
-    elif mode == "file":
-        button_calls = iter([True, False])
-        monkeypatch.setattr(st, "button", lambda *a, **k: next(button_calls))
-        monkeypatch.setattr(st, "text_area", lambda *a, **k: "")
-        monkeypatch.setattr(st, "file_uploader", lambda *a, **k: object())
-        monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
-        monkeypatch.setattr(
-            "utils.pdf_utils.extract_text_from_file", lambda _f: sample_text
-        )
-        _step_source({})
+        st.session_state[UIKeys.JD_TEXT_INPUT] = sample_text
 
-        button_calls = iter([True])
-        monkeypatch.setattr(st, "button", lambda *a, **k: next(button_calls, False))
-        monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
-        monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
-        monkeypatch.setattr(
-            st,
-            "text_area",
-            lambda *a, **k: st.session_state.get(UIKeys.JD_TEXT_INPUT, ""),
-        )
-        _step_source({})
-    else:  # url
-        button_calls = iter([True, False])
-        monkeypatch.setattr(st, "button", lambda *a, **k: next(button_calls))
-        monkeypatch.setattr(st, "text_area", lambda *a, **k: "")
-        monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
-        monkeypatch.setattr(st, "text_input", lambda *a, **k: "https://example.com")
-        monkeypatch.setattr(
-            "utils.url_utils.extract_text_from_url", lambda _u: sample_text
-        )
-        _step_source({})
+    monkeypatch.setattr(
+        st, "text_area", lambda *a, **k: st.session_state.get(UIKeys.JD_TEXT_INPUT, "")
+    )
 
-        button_calls = iter([True])
-        monkeypatch.setattr(st, "button", lambda *a, **k: next(button_calls, False))
-        monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
-        monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
-        monkeypatch.setattr(
-            st,
-            "text_area",
-            lambda *a, **k: st.session_state.get(UIKeys.JD_TEXT_INPUT, ""),
-        )
-        _step_source({})
+    _step_source({})
 
     assert st.session_state.data == sample_data
 
 
 def test_step_source_merges_esco_skills(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Essential skills from ESCO are merged into hard skills without dups."""
+    """Essential skills from ESCO are merged into hard skills without duplicates."""
+
     st.session_state.clear()
     st.session_state.lang = "en"
     st.session_state.model = "gpt"
     st.session_state.step = 0
     sample_text = "Job text"
     st.session_state[DataKeys.JD_TEXT] = sample_text
+    st.session_state[UIKeys.JD_TEXT_INPUT] = sample_text
     sample_data = {
         "position": {"job_title": "Engineer"},
         "requirements": {"hard_skills": ["Python"]},
     }
-
-    # Streamlit stubs
-    monkeypatch.setattr(st, "tabs", lambda labels: (DummyTab(), DummyTab(), DummyTab()))
-    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
-    monkeypatch.setattr(st, "success", lambda *a, **k: None)
-    monkeypatch.setattr(st, "warning", lambda *a, **k: None)
-    monkeypatch.setattr(st, "error", lambda *a, **k: None)
-    monkeypatch.setattr(st, "rerun", lambda: None)
+    _setup_common(monkeypatch)
     monkeypatch.setattr(st, "button", lambda *a, **k: True)
     monkeypatch.setattr(st, "text_area", lambda *a, **k: sample_text)
-    monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
-    monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
-
-    # Extraction and ESCO helpers
     monkeypatch.setattr(
         "wizard.extract_with_function", lambda _t, _s, model=None: sample_data
     )
@@ -264,47 +143,33 @@ def test_step_source_merges_esco_skills(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 @pytest.mark.parametrize("mode", ["file", "url"])
-def test_step_source_handles_extraction_errors(
+def test_on_change_handles_extraction_errors(
     monkeypatch: pytest.MonkeyPatch, mode: str
 ) -> None:
-    """Extraction errors should show a message and keep ``data.jd_text`` unchanged."""
+    """Extraction errors should show a message and keep JD text unchanged."""
 
     st.session_state.clear()
     st.session_state.lang = "en"
-    st.session_state.model = "gpt"
-    st.session_state[DataKeys.JD_TEXT] = ""
+    _setup_common(monkeypatch)
     errors: list[str] = []
-
-    monkeypatch.setattr(st, "tabs", lambda labels: (DummyTab(), DummyTab(), DummyTab()))
-    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
-    monkeypatch.setattr(st, "warning", lambda *a, **k: None)
-    monkeypatch.setattr(st, "rerun", lambda: None)
-    monkeypatch.setattr(st, "button", lambda *a, **k: True)
     monkeypatch.setattr(st, "error", lambda msg, *a, **k: errors.append(str(msg)))
 
     if mode == "file":
-        monkeypatch.setattr(st, "text_area", lambda *a, **k: "")
-        monkeypatch.setattr(st, "file_uploader", lambda *a, **k: object())
-        monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
 
-        def raise_value_error(_f):  # pragma: no cover - test stub
+        def raise_err(_f):
             raise ValueError("bad file")
 
-        monkeypatch.setattr("utils.pdf_utils.extract_text_from_file", raise_value_error)
-    else:  # url
-        monkeypatch.setattr(st, "text_area", lambda *a, **k: "")
-        monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
-        monkeypatch.setattr(st, "text_input", lambda *a, **k: "https://example.com")
+        monkeypatch.setattr("wizard.extract_text_from_file", raise_err)
+        st.session_state[UIKeys.JD_FILE_UPLOADER] = object()
+        on_file_uploaded()
+    else:
 
-        def raise_value_error(_u):  # pragma: no cover - test stub
+        def raise_err(_u):
             raise ValueError("bad url")
 
-        monkeypatch.setattr("utils.url_utils.extract_text_from_url", raise_value_error)
+        monkeypatch.setattr("wizard.extract_text_from_url", raise_err)
+        st.session_state[UIKeys.JD_URL_INPUT] = "https://example.com"
+        on_url_changed()
 
-    monkeypatch.setattr("wizard.extract_with_function", lambda _t, _s, model=None: {})
-    monkeypatch.setattr("wizard.classify_occupation", lambda _t, _l: None)
-
-    _step_source({})
-
-    assert st.session_state[DataKeys.JD_TEXT] == ""
+    assert st.session_state.get(DataKeys.JD_TEXT, "") == ""
     assert errors, "Expected st.error to be called"


### PR DESCRIPTION
## Summary
- add extractor utilities for PDF, DOCX, TXT, and URLs
- wire file/URL inputs with callbacks that populate JD text automatically
- include optional dependencies for text extraction

## Testing
- `ruff check ingest/extractors.py ingest/__init__.py wizard.py tests/test_wizard_source.py`
- `mypy ingest/extractors.py wizard.py ingest/__init__.py tests/test_wizard_source.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3807cf79c8320bac51103ea628af1