### PR TITLE
feat: add structured profile extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,6 @@ Core JSON schemas like `vacalyser_schema.json`, `critical_fields.json`,
 `tone_presets.json` and `role_field_map.json` are loaded via
 `config_loader.load_json`, which falls back to safe defaults and logs a warning
 if a file is missing or malformed.
+
+The OpenAI model can be overridden with the `OPENAI_MODEL` environment
+variable; by default the project uses `o4-mini`.

--- a/config.py
+++ b/config.py
@@ -12,7 +12,7 @@ except ImportError:
 
 STREAMLIT_ENV = os.getenv("STREAMLIT_ENV", "development")
 DEFAULT_LANGUAGE = os.getenv("LANGUAGE", "en")
-DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "gpt-3.5-turbo")
+DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "o4-mini")
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "").strip()
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", DEFAULT_MODEL)

--- a/llm/extract_profile.py
+++ b/llm/extract_profile.py
@@ -1,0 +1,110 @@
+"""Structured vacancy profile extraction via OpenAI Responses API."""
+
+from typing import Any, Dict, Optional
+import os
+
+from openai import OpenAI
+from pydantic import BaseModel, Field
+from tenacity import retry, wait_exponential_jitter, stop_after_attempt
+
+
+class VacancyProfile(BaseModel):
+    """Structured representation of a job vacancy."""
+
+    title: str = ""
+    company: str = ""
+    location: str = ""
+    employment_type: str = ""
+    responsibilities: list[str] = Field(default_factory=list)
+    requirements: list[str] = Field(default_factory=list)
+    nice_to_have: list[str] = Field(default_factory=list)
+    salary: Optional[str] = ""
+    work_policy: Optional[str] = ""
+    skills_hard: list[str] = Field(default_factory=list)
+    skills_soft: list[str] = Field(default_factory=list)
+    tools: list[str] = Field(default_factory=list)
+    languages: list[str] = Field(default_factory=list)
+
+
+class ChatCallResult(BaseModel):
+    """Return type for extraction calls."""
+
+    ok: bool
+    profile: VacancyProfile
+    usage: Dict[str, Any] = Field(default_factory=dict)
+    raw: Dict[str, Any] = Field(default_factory=dict)
+    error: Optional[str] = None
+
+
+# Tenacity's type hints omit ``initial`` keyword.
+_WAIT = wait_exponential_jitter(initial=1, max=8)
+
+
+@retry(wait=_WAIT, stop=stop_after_attempt(3))
+def extract_profile_from_text(jd_text: str, lang: str = "en") -> ChatCallResult:
+    """Extract a :class:`VacancyProfile` from plain text.
+
+    Args:
+        jd_text: Raw job description text.
+        lang: Language code of the text.
+
+    Returns:
+        ChatCallResult: Outcome of the API call with parsed profile.
+
+    Raises:
+        AssertionError: If ``jd_text`` is empty.
+    """
+    assert jd_text.strip(), "empty JD text"
+    client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+    model = os.environ.get("OPENAI_MODEL", "o4-mini")
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "emit_profile",
+            "description": "Return a structured vacancy profile extracted from the job description.",
+            "parameters": VacancyProfile.model_json_schema(),
+        },
+    }
+
+    prompt = f"""You extract structured vacancy data from raw job descriptions.
+Return only via the provided function tool 'emit_profile'. Language: {lang}.
+Text:
+{jd_text}"""
+
+    resp = client.responses.create(  # type: ignore[call-overload]
+        model=model,
+        input=prompt,
+        tools=[tool],
+        tool_choice={"type": "function", "function": {"name": "emit_profile"}},
+        temperature=0.2,
+    )
+
+    fcall = None
+    for item in resp.output if hasattr(resp, "output") else []:
+        if (
+            getattr(item, "type", "") == "tool_call"
+            and item.tool_call.function.name == "emit_profile"
+        ):
+            fcall = item.tool_call
+            break
+    if (
+        not fcall
+        and hasattr(resp, "output")
+        and len(resp.output)
+        and getattr(resp.output[0], "type", "") == "tool_call"
+    ):
+        fcall = resp.output[0].tool_call
+
+    if not fcall:
+        return ChatCallResult(
+            ok=False,
+            profile=VacancyProfile(),
+            error="No tool_call found",
+            raw=resp.model_dump(),
+        )
+
+    args = fcall.function.arguments
+    prof = VacancyProfile.model_validate(args)
+    usage = getattr(resp, "usage", {}) or {}
+    return ChatCallResult(ok=True, profile=prof, usage=usage, raw=resp.model_dump())

--- a/tests/test_extract_profile.py
+++ b/tests/test_extract_profile.py
@@ -1,0 +1,55 @@
+"""Tests for vacancy profile extraction via Responses API."""
+
+import llm.extract_profile as ep
+
+
+def test_extract_profile_parses_tool_output(monkeypatch):
+    """Structured tool output should validate into VacancyProfile."""
+
+    class _FakeFunction:
+        def __init__(self) -> None:
+            self.name = "emit_profile"
+            self.arguments = {"title": "Engineer"}
+
+    class _FakeToolCall:
+        def __init__(self) -> None:
+            self.function = _FakeFunction()
+
+    class _FakeOutput:
+        def __init__(self) -> None:
+            self.type = "tool_call"
+            self.tool_call = _FakeToolCall()
+
+    class _FakeResponse:
+        def __init__(self) -> None:
+            self.output = [_FakeOutput()]
+            self.usage: dict = {}
+
+        def model_dump(self) -> dict:
+            return {
+                "output": [
+                    {
+                        "tool_call": {
+                            "function": {
+                                "name": "emit_profile",
+                                "arguments": {"title": "Engineer"},
+                            }
+                        }
+                    }
+                ]
+            }
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        class responses:
+            @staticmethod
+            def create(**kwargs):
+                return _FakeResponse()
+
+    monkeypatch.setattr(ep, "OpenAI", _FakeClient)
+
+    result = ep.extract_profile_from_text("dummy")
+    assert result.ok
+    assert result.profile.title == "Engineer"


### PR DESCRIPTION
## Summary
- add `llm.extract_profile` to parse job descriptions into `VacancyProfile`
- migrate OpenAI helper to Responses API with function-tool support
- default model now configurable via `OPENAI_MODEL` (default `o4-mini`)

## Testing
- `python -m black llm/extract_profile.py openai_utils.py config.py tests/test_openai_utils.py tests/test_extract_profile.py`
- `ruff check llm/extract_profile.py openai_utils.py config.py tests/test_openai_utils.py tests/test_extract_profile.py`
- `mypy llm/extract_profile.py openai_utils.py config.py tests/test_openai_utils.py tests/test_extract_profile.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a383d652348320970b713b4d9ae4b0