### PR TITLE
feat: add step navigation and validation

### DIFF
--- a/components/stepper.py
+++ b/components/stepper.py
@@ -1,0 +1,18 @@
+"""Simple progress stepper for wizard navigation."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+def render_stepper(current: int, total: int) -> None:
+    """Render a progress bar indicating wizard progress.
+
+    Args:
+        current: Current step index (0-based).
+        total: Total number of steps.
+    """
+
+    if total <= 0:
+        return
+    st.progress((current + 1) / total)

--- a/tests/test_wizard_source.py
+++ b/tests/test_wizard_source.py
@@ -104,7 +104,7 @@ def test_step_source_merges_esco_skills(monkeypatch: pytest.MonkeyPatch) -> None
     st.session_state.clear()
     st.session_state.lang = "en"
     st.session_state.model = "gpt"
-    st.session_state.step = 0
+    st.session_state[DataKeys.STEP] = 0
     sample_text = "Job text"
     st.session_state[DataKeys.JD_TEXT] = sample_text
     st.session_state[UIKeys.JD_TEXT_INPUT] = sample_text

--- a/utils/session.py
+++ b/utils/session.py
@@ -15,7 +15,7 @@ __all__ = [
 DEFAULTS: Dict[str, Any] = {
     DataKeys.JD_TEXT: "",
     DataKeys.PROFILE: {},
-    DataKeys.STEP: 1,
+    DataKeys.STEP: 0,
 }
 
 


### PR DESCRIPTION
## Summary
- track wizard progress via `DataKeys.STEP` with `next_step`/`prev_step`
- render new progress bar component and gate navigation on missing critical fields
- default session step starts at 0 and tests updated accordingly

## Testing
- `ruff check utils/session.py wizard.py components/stepper.py tests/test_wizard_source.py`
- `mypy wizard.py components/stepper.py utils/session.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a386867a548320bd4b388d3809e7c2