### PR TITLE
feat: improve error UX and request safety

### DIFF
--- a/ingest/reader.py
+++ b/ingest/reader.py
@@ -32,9 +32,18 @@ def _read_pdf(path: Path) -> str:
         return "".join(page.get_text() for page in doc)
 
 
+_URL_RE = re.compile(r"^https?://[\w./-]+$")
+_HEADERS = {"User-Agent": "Vacalyser/1.0"}
+
+
 def _read_url(url: str) -> str:
-    response = requests.get(url, timeout=10)
-    response.raise_for_status()
+    if not url or not _URL_RE.match(url):
+        raise ValueError("Invalid URL")
+    try:
+        response = requests.get(url, timeout=15, headers=_HEADERS)
+        response.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - network
+        raise ValueError(f"Failed to fetch URL: {url}") from exc
     soup = BeautifulSoup(response.text, "html.parser")
     return soup.get_text(" ")
 

--- a/tests/test_esco_features.py
+++ b/tests/test_esco_features.py
@@ -9,7 +9,7 @@ from core.esco_utils import classify_occupation, normalize_skills  # noqa: E402
 def test_classify_occupation(monkeypatch):
     """Should return label, code and group from ESCO."""
 
-    def fake_get(url, params=None, timeout=5):
+    def fake_get(url, params=None, timeout=5, headers=None):
         class Resp:
             status_code = 200
 

--- a/tests/test_esco_utils.py
+++ b/tests/test_esco_utils.py
@@ -9,7 +9,7 @@ from core.esco_utils import classify_occupation, get_essential_skills  # noqa: E
 def test_classify_occupation(monkeypatch):
     """Classification should return label and group from ESCO."""
 
-    def fake_get(url, params=None, timeout=5):
+    def fake_get(url, params=None, timeout=5, headers=None):
         class Resp:
             status_code = 200
 
@@ -49,7 +49,7 @@ def test_classify_occupation(monkeypatch):
 def test_get_essential_skills(monkeypatch):
     """Essential skills are extracted from ESCO resource payload."""
 
-    def fake_get(url, params=None, timeout=5):
+    def fake_get(url, params=None, timeout=5, headers=None):
         class Resp:
             status_code = 200
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,7 +43,7 @@ def test_extract_text_from_url(monkeypatch):
         def raise_for_status(self) -> None:  # pragma: no cover - noop
             return None
 
-    def fake_get(_url, timeout):  # pragma: no cover - test stub
+    def fake_get(_url, timeout, headers=None):  # pragma: no cover - test stub
         return Resp()
 
     import requests

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,6 +7,7 @@ import re
 
 from .pdf_utils import extract_text_from_file as extract_text_from_file
 from .url_utils import extract_text_from_url as extract_text_from_url
+from .errors import display_error as display_error
 
 
 def merge_texts(*parts: str) -> str:

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -1,0 +1,16 @@
+"""Utility helpers for rendering error messages in Streamlit."""
+
+import streamlit as st
+
+
+def display_error(msg: str, detail: str | None = None) -> None:
+    """Render a user-facing error with optional debug details.
+
+    Args:
+        msg: Short error message for the user.
+        detail: Optional technical detail shown when debug mode is enabled.
+    """
+    st.error(msg)
+    if detail and st.session_state.get("debug"):
+        with st.expander("Details"):
+            st.code(detail)

--- a/utils/url_utils.py
+++ b/utils/url_utils.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import re
+
 import requests
 from bs4 import BeautifulSoup
+
+_URL_RE = re.compile(r"^https?://[\w./-]+$")
+_HEADERS = {"User-Agent": "Vacalyser/1.0"}
 
 
 def extract_text_from_url(url: str) -> str:
@@ -16,13 +21,16 @@ def extract_text_from_url(url: str) -> str:
         The extracted plain text.
 
     Raises:
-        ValueError: If the URL cannot be retrieved.
+        ValueError: If the URL is invalid or cannot be retrieved.
     """
 
+    if not url or not _URL_RE.match(url):
+        raise ValueError("Invalid URL")
+
     try:
-        response = requests.get(url, timeout=15)
+        response = requests.get(url, timeout=15, headers=_HEADERS)
         response.raise_for_status()
-    except requests.RequestException as exc:
+    except requests.RequestException as exc:  # pragma: no cover - network
         raise ValueError(f"Failed to fetch URL: {url}") from exc
     soup = BeautifulSoup(response.text, "html.parser")
     for sel in ["article", "main"]:


### PR DESCRIPTION
## Summary
- add `display_error` helper for debug-friendly UI messages
- sanitize URLs and enforce global User-Agent/timeouts for network requests
- handle ESCO/network errors without crashing

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a38b2f081c83209c4c93d990f0e467