### PR TITLE
fix: migrate legacy session keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,11 @@ Core JSON schemas like `vacalyser_schema.json`, `critical_fields.json`,
 `tone_presets.json` and `role_field_map.json` are loaded via
 `config_loader.load_json`, which falls back to safe defaults and logs a warning
 if a file is missing or malformed.
+
+## Session State & Migration
+
+Streamlit session keys are now namespaced to keep business data separate from
+UI widget state. Values under `data.*` hold the vacancy profile, while `ui.*`
+keys act as "shadow" keys for widgets. Older sessions that used plain keys like
+`jd_text` or `jd_text_input` are automatically migrated on startup so existing
+drafts remain intact.

--- a/tests/test_session_migration.py
+++ b/tests/test_session_migration.py
@@ -1,0 +1,29 @@
+import streamlit as st
+
+from utils.session import bootstrap_session, migrate_legacy_keys, DataKeys, UIKeys
+
+
+def test_migrate_legacy_jd_text() -> None:
+    """Legacy ``jd_text`` key is moved to ``data.jd_text``."""
+    st.session_state.clear()
+    st.session_state["jd_text"] = "legacy"
+    bootstrap_session()
+    migrate_legacy_keys()
+    assert st.session_state.get(DataKeys.JD_TEXT) == "legacy"
+    assert "jd_text" not in st.session_state
+
+
+def test_migrate_legacy_ui_keys() -> None:
+    """Legacy UI keys are promoted to namespaced ``ui.*`` variants."""
+    st.session_state.clear()
+    st.session_state["jd_text_input"] = "txt"
+    st.session_state["jd_file_uploader"] = object()
+    st.session_state["jd_url_input"] = "https://example.com"
+    bootstrap_session()
+    migrate_legacy_keys()
+    assert st.session_state.get(UIKeys.JD_TEXT_INPUT) == "txt"
+    assert st.session_state.get(UIKeys.JD_FILE_UPLOADER) is not None
+    assert st.session_state.get(UIKeys.JD_URL_INPUT) == "https://example.com"
+    assert "jd_text_input" not in st.session_state
+    assert "jd_file_uploader" not in st.session_state
+    assert "jd_url_input" not in st.session_state


### PR DESCRIPTION
## Summary
- migrate plain session keys to `data.*` and `ui.*` namespaces and drop deprecated entries
- document session state namespacing and migration
- add tests covering legacy session key migration

## Testing
- `ruff check utils/session.py tests/test_session_migration.py`
- `black --check utils/session.py tests/test_session_migration.py`
- `mypy utils/session.py tests/test_session_migration.py` *(no output)*
- `pytest` *(hangs at tests/test_openai_utils.py; interrupted)*
- `PYTHONPATH=. pytest tests/test_session_migration.py tests/test_wizard_source.py`


------
https://chatgpt.com/codex/tasks/task_e_68a38f75140c8320bda2cba16cd1cb65