### PR TITLE
feat: add unified need analysis schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If `VECTOR_STORE_ID` is unset or empty, Vacalyser runs without RAG.
 
 ## Configuration
 
-Core JSON schemas like `vacalyser_schema.json`, `critical_fields.json`,
+Core JSON schemas like `schema/need_analysis.schema.json`, `critical_fields.json`,
 `tone_presets.json` and `role_field_map.json` are loaded via
 `config_loader.load_json`, which falls back to safe defaults and logs a warning
 if a file is missing or malformed.

--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ ROOT = Path(__file__).parent
 bootstrap_session()
 migrate_legacy_keys()
 
-SCHEMA = load_json("vacalyser_schema.json", fallback={})
+SCHEMA = load_json("schema/need_analysis.schema.json", fallback={})
 CRITICAL = set(
     load_json("critical_fields.json", fallback={"critical": []}).get("critical", [])
 )
@@ -34,7 +34,7 @@ ROLE_FIELD_MAP = load_json("role_field_map.json", fallback={})
 # --- Session Defaults (einheitliche Keys) ---
 def _init_state():
     ss = st.session_state
-    ss.setdefault("data", {})  # entspricht vacalyser_schema.json
+    ss.setdefault("data", {})  # entspricht need_analysis.schema.json
     ss.setdefault("lang", "de")  # "de" | "en"
     ss.setdefault("model", os.getenv("OPENAI_MODEL", "gpt-4o-mini"))
     ss.setdefault("vector_store_id", os.getenv("VECTOR_STORE_ID") or "")

--- a/core/schema.py
+++ b/core/schema.py
@@ -1,180 +1,14 @@
-"""Pydantic models for the Vacalyser job description schema."""
+"""Utilities for the need analysis profile schema."""
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Tuple, Union, get_args, get_origin, Mapping
+from typing import Any, List, Mapping, Tuple, Union, get_args, get_origin
 
 from types import MappingProxyType
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel
 
-
-# --- Teilmodelle ---
-
-
-class Company(BaseModel):
-    """Details about the hiring company."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    name: str
-    industry: Optional[str] = None
-    hq_location: Optional[str] = None
-    size: Optional[str] = None
-    website: Optional[str] = None
-    mission: Optional[str] = None
-    culture: Optional[str] = None
-
-
-class Location(BaseModel):
-    """Primary location information for the role."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    primary_city: Optional[str] = None
-    country: Optional[str] = None
-    onsite_ratio: Optional[str] = None
-
-
-class Position(BaseModel):
-    """Information describing the open position."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    job_title: str
-    seniority_level: Optional[str] = None
-    department: Optional[str] = None
-    team_structure: Optional[str] = None
-    reporting_line: Optional[str] = None
-    role_summary: Optional[str] = None
-    # ESCO-Erweiterungen (optional)
-    occupation_label: Optional[str] = None
-    occupation_uri: Optional[str] = None
-    occupation_group: Optional[str] = None
-
-
-class Responsibilities(BaseModel):
-    """List of key responsibilities for the role."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    items: List[str] = Field(default_factory=list)
-
-
-class Requirements(BaseModel):
-    """Required skills and qualifications."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    hard_skills: List[str] = Field(default_factory=list)
-    soft_skills: List[str] = Field(default_factory=list)
-    tools_and_technologies: List[str] = Field(default_factory=list)
-    languages_required: List[str] = Field(default_factory=list)
-    certifications: List[str] = Field(default_factory=list)
-
-
-class Employment(BaseModel):
-    """Employment contract details."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    job_type: Optional[str] = None
-    work_policy: Optional[str] = None
-    travel_required: Optional[bool] = None
-    relocation_support: Optional[bool] = None
-    visa_sponsorship: Optional[bool] = None
-
-
-class Compensation(BaseModel):
-    """Salary and compensation information."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    salary_min: Optional[float] = None
-    salary_max: Optional[float] = None
-    currency: Optional[str] = None
-    period: Optional[str] = None
-    variable_pay: Optional[bool] = None
-    equity_offered: Optional[bool] = None
-    benefits: List[str] = Field(default_factory=list)
-
-
-class Process(BaseModel):
-    """Information about the hiring process."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    interview_stages: Optional[int] = None
-    process_notes: Optional[str] = None
-
-
-class Meta(BaseModel):
-    """Miscellaneous metadata about the vacancy."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    target_start_date: Optional[str] = None
-    application_deadline: Optional[str] = None
-
-
-# --- Aggregat (Top-Level) ---
-
-
-class VacalyserJD(BaseModel):
-    """Aggregate job description model for Vacalyser."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    company: Company
-    position: Position
-    # OPTION A (strikt optional, bleibt None bis gesetzt):
-    location: Optional[Location] = None
-    responsibilities: Optional[Responsibilities] = None
-    requirements: Optional[Requirements] = None
-    employment: Optional[Employment] = None
-    compensation: Optional[Compensation] = None
-    process: Optional[Process] = None
-    meta: Optional[Meta] = None
-
-    # OPTION B (auto-init leere Teilmodelle statt None):
-    # location: Location = Field(default_factory=Location)
-    # responsibilities: Responsibilities = Field(default_factory=Responsibilities)
-    # requirements: Requirements = Field(default_factory=Requirements)
-    # employment: Employment = Field(default_factory=Employment)
-    # compensation: Compensation = Field(default_factory=Compensation)
-    # process: Process = Field(default_factory=Process)
-    # meta: Meta = Field(default_factory=Meta)
-
-
-# Hilfsfunktion: „coerce_and_fill“ wie in deiner Extraktion referenziert
-def _deep_merge(base: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
-    """Recursively merge ``updates`` into ``base`` and return the result."""
-
-    merged = dict(base)
-    for key, value in updates.items():
-        if isinstance(value, dict) and key in merged and isinstance(merged[key], dict):
-            merged[key] = _deep_merge(merged[key], value)
-        else:
-            merged[key] = value
-    return merged
-
-
-def coerce_and_fill(data: dict[str, Any]) -> VacalyserJD:
-    """Validate ``data`` and ensure required fields are present.
-
-    The function inserts minimal default structures (e.g. empty company name and
-    job title) before validating the payload against :class:`VacalyserJD`.
-
-    Args:
-        data: Raw dictionary returned from the LLM.
-
-    Returns:
-        VacalyserJD: Validated model instance with defaults applied.
-    """
-
-    defaults: dict[str, Any] = {"company": {"name": ""}, "position": {"job_title": ""}}
-    merged = _deep_merge(defaults, data or {})
-    return VacalyserJD.model_validate(merged)
+from models.need_analysis import NeedAnalysisProfile
 
 
 def _strip_optional(tp: Any) -> Any:
@@ -210,8 +44,18 @@ def _collect_fields(
     return paths, list_fields
 
 
-ALL_FIELDS, LIST_FIELDS = _collect_fields(VacalyserJD)
+ALL_FIELDS, LIST_FIELDS = _collect_fields(NeedAnalysisProfile)
 
 # Empty alias map retained for compatibility with older code paths
 # Using MappingProxyType to prevent accidental mutation.
 ALIASES: Mapping[str, str] = MappingProxyType({})
+
+
+def coerce_and_fill(data: dict[str, Any]) -> NeedAnalysisProfile:
+    """Validate ``data`` and ensure required fields are present."""
+
+    return NeedAnalysisProfile.model_validate(data or {})
+
+
+# Backwards compatibility alias
+VacalyserJD = NeedAnalysisProfile

--- a/core/ss_bridge.py
+++ b/core/ss_bridge.py
@@ -1,10 +1,11 @@
 from typing import Any
 
-from .schema import ALL_FIELDS, ALIASES, LIST_FIELDS, VacalyserJD, coerce_and_fill
+from models.need_analysis import NeedAnalysisProfile
+from .schema import ALL_FIELDS, ALIASES, LIST_FIELDS, coerce_and_fill
 
 
-def to_session_state(jd: VacalyserJD, ss: dict) -> None:
-    """Populate session state dict with values from a VacalyserJD object."""
+def to_session_state(jd: NeedAnalysisProfile, ss: dict) -> None:
+    """Populate session state dict with values from a NeedAnalysisProfile object."""
 
     def _get(path: str) -> Any:
         cursor: Any = jd
@@ -23,8 +24,8 @@ def to_session_state(jd: VacalyserJD, ss: dict) -> None:
         ss.pop(alias, None)
 
 
-def from_session_state(ss: dict) -> VacalyserJD:
-    """Build a VacalyserJD model from the session state values."""
+def from_session_state(ss: dict) -> NeedAnalysisProfile:
+    """Build a NeedAnalysisProfile model from the session state values."""
     data: dict[str, Any] = {}
     for key, value in ss.items():
         target = ALIASES.get(key, key)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,5 @@
+"""Pydantic models for vacancy need analysis."""
+
+from .need_analysis import NeedAnalysisProfile
+
+__all__ = ["NeedAnalysisProfile"]

--- a/models/need_analysis.py
+++ b/models/need_analysis.py
@@ -1,0 +1,138 @@
+"""Pydantic models for the need analysis profile."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from typing import Any
+
+
+class Company(BaseModel):
+    """Details about the hiring company."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = ""
+    industry: Optional[str] = None
+    hq_location: Optional[str] = None
+    size: Optional[str] = None
+    website: Optional[str] = None
+    mission: Optional[str] = None
+    culture: Optional[str] = None
+
+
+class Position(BaseModel):
+    """Information describing the open position."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    job_title: str = ""
+    seniority_level: Optional[str] = None
+    department: Optional[str] = None
+    team_structure: Optional[str] = None
+    reporting_line: Optional[str] = None
+    role_summary: Optional[str] = None
+    occupation_label: Optional[str] = None
+    occupation_uri: Optional[str] = None
+    occupation_group: Optional[str] = None
+
+
+class Location(BaseModel):
+    """Primary location information for the role."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    primary_city: Optional[str] = None
+    country: Optional[str] = None
+    onsite_ratio: Optional[str] = None
+
+
+class Responsibilities(BaseModel):
+    """Key responsibilities for the role."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: List[str] = Field(default_factory=list)
+
+
+class Requirements(BaseModel):
+    """Required skills and qualifications."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    hard_skills: List[str] = Field(default_factory=list)
+    soft_skills: List[str] = Field(default_factory=list)
+    tools_and_technologies: List[str] = Field(default_factory=list)
+    languages_required: List[str] = Field(default_factory=list)
+    certifications: List[str] = Field(default_factory=list)
+    language_level_english: Optional[str] = None
+
+
+class Employment(BaseModel):
+    """Employment contract details."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    job_type: Optional[str] = None
+    work_policy: Optional[str] = None
+    travel_required: Optional[bool] = None
+    overtime_expected: Optional[bool] = None
+    relocation_support: Optional[bool] = None
+    visa_sponsorship: Optional[bool] = None
+    security_clearance_required: Optional[bool] = None
+    shift_work: Optional[bool] = None
+
+
+class Compensation(BaseModel):
+    """Salary and compensation information."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    salary_min: Optional[float] = None
+    salary_max: Optional[float] = None
+    currency: Optional[str] = None
+    period: Optional[str] = None
+    variable_pay: Optional[bool] = None
+    equity_offered: Optional[bool] = None
+    benefits: List[str] = Field(default_factory=list)
+
+
+class Process(BaseModel):
+    """Information about the hiring process."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    interview_stages: Optional[int] = None
+    process_notes: Optional[str] = None
+
+
+class Meta(BaseModel):
+    """Miscellaneous metadata about the vacancy."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_start_date: Optional[str] = None
+    application_deadline: Optional[str] = None
+
+
+class NeedAnalysisProfile(BaseModel):
+    """Aggregate need analysis profile model."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    company: Company = Field(default_factory=Company)
+    position: Position = Field(default_factory=Position)
+    location: Location = Field(default_factory=Location)
+    responsibilities: Responsibilities = Field(default_factory=Responsibilities)
+    requirements: Requirements = Field(default_factory=Requirements)
+    employment: Employment = Field(default_factory=Employment)
+    compensation: Compensation = Field(default_factory=Compensation)
+    process: Process = Field(default_factory=Process)
+    meta: Meta = Field(default_factory=Meta)
+
+    @field_validator("company", "position", mode="before")
+    @classmethod
+    def _ensure_required(cls, value: Any) -> dict | Company | Position:
+        """Ensure required nested objects are present."""
+        return {} if value is None else value

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -287,9 +287,10 @@ def extract_with_function(
             "Model returned invalid JSON in function_call.arguments"
         ) from e
 
-    from core.schema import VacalyserJD, coerce_and_fill
+    from models.need_analysis import NeedAnalysisProfile
+    from core.schema import coerce_and_fill
 
-    jd: VacalyserJD = coerce_and_fill(raw)
+    jd: NeedAnalysisProfile = coerce_and_fill(raw)
     return jd.model_dump()
 
 

--- a/questions/generate.py
+++ b/questions/generate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from core.schema import VacalyserJD
+from models.need_analysis import NeedAnalysisProfile
 
 from question_logic import (
     generate_followup_questions as _generate_followup_questions,
@@ -12,7 +12,7 @@ from question_logic import (
 
 
 def generate_followup_questions(
-    jd: VacalyserJD,
+    jd: NeedAnalysisProfile,
     num_questions: Optional[int] = None,
     lang: str = "en",
     use_rag: bool = True,

--- a/schema/need_analysis.schema.json
+++ b/schema/need_analysis.schema.json
@@ -1,12 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "VacalyserJD",
+  "title": "NeedAnalysisProfile",
   "type": "object",
   "additionalProperties": false,
   "properties": {
     "company": {
-      "type": "object",
-      "additionalProperties": false,
+      "type": "object", "additionalProperties": false,
       "properties": {
         "name": {"type": "string"},
         "industry": {"type": "string"},
@@ -18,81 +17,80 @@
       },
       "required": ["name"]
     },
-    "location": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "primary_city": {"type": "string"},
-        "country": {"type": "string"},
-        "onsite_ratio": {"type": "string"}
-      }
-    },
     "position": {
-      "type": "object",
-      "additionalProperties": false,
+      "type": "object", "additionalProperties": false,
       "properties": {
         "job_title": {"type": "string"},
         "seniority_level": {"type": "string"},
         "department": {"type": "string"},
         "team_structure": {"type": "string"},
         "reporting_line": {"type": "string"},
-        "role_summary": {"type": "string"}
+        "role_summary": {"type": "string"},
+        "occupation_label": {"type": "string"},
+        "occupation_uri": {"type": "string"},
+        "occupation_group": {"type": "string"}
       },
       "required": ["job_title"]
     },
+    "location": {
+      "type": "object", "additionalProperties": false,
+      "properties": {
+        "primary_city": {"type": "string"},
+        "country": {"type": "string"},
+        "onsite_ratio": {"type": "string"}
+      }
+    },
     "responsibilities": {
-      "type": "object",
-      "additionalProperties": false,
+      "type": "object", "additionalProperties": false,
       "properties": {
         "items": {"type": "array", "items": {"type": "string"}}
       }
     },
     "requirements": {
-      "type": "object",
-      "additionalProperties": false,
+      "type": "object", "additionalProperties": false,
       "properties": {
         "hard_skills": {"type": "array", "items": {"type": "string"}},
         "soft_skills": {"type": "array", "items": {"type": "string"}},
         "tools_and_technologies": {"type": "array", "items": {"type": "string"}},
         "languages_required": {"type": "array", "items": {"type": "string"}},
-        "certifications": {"type": "array", "items": {"type": "string"}}
+        "certifications": {"type": "array", "items": {"type": "string"}},
+        "language_level_english": {"type": "string"}
       }
     },
     "employment": {
-      "type": "object",
-      "additionalProperties": false,
+      "type": "object", "additionalProperties": false,
       "properties": {
-        "job_type": {"type": "string", "enum": ["full_time","part_time","contract","internship","temporary","other"]},
-        "work_policy": {"type": "string", "enum": ["onsite","hybrid","remote"]},
+        "job_type": {"type": "string"},
+        "work_policy": {"type": "string"},
         "travel_required": {"type": "boolean"},
+        "overtime_expected": {"type": "boolean"},
         "relocation_support": {"type": "boolean"},
-        "visa_sponsorship": {"type": "boolean"}
+        "visa_sponsorship": {"type": "boolean"},
+        "security_clearance_required": {"type": "boolean"},
+        "shift_work": {"type": "boolean"}
       }
     },
     "compensation": {
-      "type": "object",
-      "additionalProperties": false,
+      "type": "object", "additionalProperties": false,
       "properties": {
         "salary_min": {"type": "number"},
         "salary_max": {"type": "number"},
         "currency": {"type": "string"},
-        "period": {"type": "string", "enum": ["year","month","day","hour"]},
+        "period": {"type": "string"},
         "variable_pay": {"type": "boolean"},
         "equity_offered": {"type": "boolean"},
         "benefits": {"type": "array", "items": {"type": "string"}}
       }
     },
     "process": {
-      "type": "object",
-      "additionalProperties": false,
+      "type": "object", "additionalProperties": false,
       "properties": {
-        "interview_stages": {"type": "integer", "minimum": 0},
+        "interview_stages": {"type": "integer"},
         "process_notes": {"type": "string"}
       }
     },
     "meta": {
-      "type": "object",
-      "additionalProperties": false,
+      "type": "object", "additionalProperties": false,
       "properties": {
         "target_start_date": {"type": "string"},
         "application_deadline": {"type": "string"}

--- a/tests/test_generate_followups.py
+++ b/tests/test_generate_followups.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from core.schema import VacalyserJD  # noqa: E402
+from models.need_analysis import NeedAnalysisProfile  # noqa: E402
 from questions.generate import generate_followup_questions  # noqa: E402
 
 
@@ -28,7 +28,7 @@ def test_generate_followups_wrapper(monkeypatch):
         "questions.generate._generate_followup_questions", fake_generate
     )
 
-    jd = VacalyserJD(company={"name": ""}, position={"job_title": "Dev"})
+    jd = NeedAnalysisProfile()
     questions = generate_followup_questions(
         jd, num_questions=2, lang="de", use_rag=False
     )
@@ -47,5 +47,5 @@ def test_generate_followups_wrapper_empty(monkeypatch):
         "questions.generate._generate_followup_questions", fake_generate
     )
 
-    jd = VacalyserJD(company={"name": ""}, position={"job_title": "Dev"})
+    jd = NeedAnalysisProfile()
     assert generate_followup_questions(jd) == []

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,4 +1,5 @@
-from core.schema import VacalyserJD, coerce_and_fill, LIST_FIELDS
+from models.need_analysis import NeedAnalysisProfile
+from core.schema import coerce_and_fill, LIST_FIELDS
 
 
 def test_list_fields_contains_base_lists() -> None:
@@ -24,7 +25,7 @@ def test_coerce_and_fill_basic() -> None:
         "compensation": {"benefits": ["Gym", "Gym"]},
     }
     jd = coerce_and_fill(data)
-    assert isinstance(jd, VacalyserJD)
+    assert isinstance(jd, NeedAnalysisProfile)
     assert jd.position.job_title == "Engineer"
     assert jd.requirements is not None
     assert jd.responsibilities is not None
@@ -41,7 +42,7 @@ def test_default_insertion() -> None:
     jd = coerce_and_fill({})
     assert jd.position.job_title == ""
     assert jd.company.name == ""
-    assert jd.requirements is None
+    assert jd.requirements.hard_skills == []
 
 
 def test_job_type_invalid() -> None:

--- a/wizard.py
+++ b/wizard.py
@@ -910,7 +910,9 @@ def run_wizard():
     # Falls nicht durch app.py injiziert, lokal nachladen (failsafe)
     if not schema:
         try:
-            with (ROOT / "vacalyser_schema.json").open("r", encoding="utf-8") as f:
+            with (ROOT / "schema" / "need_analysis.schema.json").open(
+                "r", encoding="utf-8"
+            ) as f:
                 schema = json.load(f)
         except Exception:
             schema = {}


### PR DESCRIPTION
## Summary
- introduce `schema/need_analysis.schema.json` consolidating profile fields
- add Pydantic `NeedAnalysisProfile` with default nested models
- adjust app and wizard to load the new schema

## Testing
- `python -m black models/need_analysis.py core/schema.py llm/client.py utils/json_parse.py core/ss_bridge.py questions/generate.py tests/test_generate_followups.py tests/test_schema.py openai_utils.py app.py wizard.py`
- `ruff check models/need_analysis.py core/schema.py llm/client.py utils/json_parse.py core/ss_bridge.py questions/generate.py tests/test_generate_followups.py tests/test_schema.py openai_utils.py app.py wizard.py`
- `mypy models/need_analysis.py core/schema.py llm/client.py utils/json_parse.py core/ss_bridge.py questions/generate.py openai_utils.py tests/test_generate_followups.py tests/test_schema.py app.py wizard.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3966439a48320abae1e3ddc2c55b9