### PR TITLE
feat: pre-initialize streamlit session state

### DIFF
--- a/state/__init__.py
+++ b/state/__init__.py
@@ -1,0 +1,5 @@
+"""Session state utilities."""
+
+from .ensure_state import ensure_state
+
+__all__ = ["ensure_state"]

--- a/state/ensure_state.py
+++ b/state/ensure_state.py
@@ -1,0 +1,34 @@
+"""Helpers for initializing Streamlit session state."""
+
+from __future__ import annotations
+
+import os
+
+import streamlit as st
+
+from constants.keys import StateKeys
+from models.need_analysis import NeedAnalysisProfile
+
+
+def ensure_state() -> None:
+    """Initialize ``st.session_state`` with required keys.
+
+    Existing keys are preserved to respect user interactions or URL params.
+    """
+
+    if StateKeys.PROFILE not in st.session_state:
+        st.session_state[StateKeys.PROFILE] = NeedAnalysisProfile().model_dump()
+    if StateKeys.RAW_TEXT not in st.session_state:
+        st.session_state[StateKeys.RAW_TEXT] = ""
+    if StateKeys.STEP not in st.session_state:
+        st.session_state[StateKeys.STEP] = 0
+    if "lang" not in st.session_state:
+        st.session_state["lang"] = "de"
+    if "model" not in st.session_state:
+        st.session_state["model"] = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+    if "vector_store_id" not in st.session_state:
+        st.session_state["vector_store_id"] = os.getenv("VECTOR_STORE_ID", "")
+    if "auto_reask" not in st.session_state:
+        st.session_state["auto_reask"] = True
+    if StateKeys.USAGE not in st.session_state:
+        st.session_state[StateKeys.USAGE] = {"input_tokens": 0, "output_tokens": 0}

--- a/wizard.py
+++ b/wizard.py
@@ -12,7 +12,8 @@ import streamlit as st
 from utils.i18n import tr
 from i18n import t
 from constants.keys import UIKeys, StateKeys
-from utils.session import bind_textarea, bootstrap_session, migrate_legacy_keys
+from utils.session import bind_textarea
+from state.ensure_state import ensure_state
 from ingest.extractors import extract_text_from_file, extract_text_from_url
 from utils.errors import display_error
 
@@ -23,9 +24,7 @@ from core.esco_utils import classify_occupation, get_essential_skills
 from components.stepper import render_stepper
 
 ROOT = Path(__file__).parent
-
-bootstrap_session()
-migrate_legacy_keys()
+ensure_state()
 
 
 def next_step() -> None:


### PR DESCRIPTION
## Summary
- add `state.ensure_state` to populate required session keys with defaults
- invoke `ensure_state()` in `app.py` and `wizard.py` before widgets to drop legacy bootstrap logic

## Testing
- `black state/ensure_state.py`
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a39d9e3c948320974b8e9e5d7f34b9