### PR TITLE
refactor: use unified profile state in wizard

### DIFF
--- a/tests/test_wizard_source.py
+++ b/tests/test_wizard_source.py
@@ -96,7 +96,8 @@ def test_step_source_populates_data(monkeypatch: pytest.MonkeyPatch, mode: str) 
 
     _step_source({})
 
-    assert st.session_state[StateKeys.PROFILE] == sample_data
+    data = st.session_state[StateKeys.PROFILE]
+    assert data["position"]["job_title"] == "Engineer"
 
 
 def test_step_source_merges_esco_skills(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- validate extraction into NeedAnalysisProfile and store unified profile state
- simplify step functions to mutate profile dict directly
- adjust wizard tests for new profile structure

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3a1efda788320828968b4b11c245d