### PR TITLE
feat: add offline ESCO integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - **Auto re‑ask loop**: optional toggle that keeps asking follow-up questions automatically until all critical fields are filled, with clear progress messages and a stop button for user control.
 - **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts, HR software for human resource professionals, engineering tools for civil engineers, cuisine specialties for chefs).
 - **ESCO‑Power**: occupation classification + essential skill gaps
+- **Offline-ready ESCO**: set `VACAYSER_OFFLINE=1` to use cached occupations and skills without API calls
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **Cost‑aware**: GPT‑3.5 by default and minimal re‑asks
 - **Model**: optimized for GPT‑3.5 for suggestions and outputs

--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Integration layer for external services."""

--- a/integrations/esco.py
+++ b/integrations/esco.py
@@ -1,0 +1,61 @@
+"""ESCO integration wrapper with offline fallbacks."""
+
+import os
+from core import esco_utils
+
+OFFLINE = bool(os.getenv("VACAYSER_OFFLINE", False))
+
+
+def search_occupation(title: str, lang: str = "en") -> dict[str, str]:
+    """Search ESCO occupation by title.
+
+    Args:
+        title: Job title to classify.
+        lang: Two-letter language code.
+
+    Returns:
+        Mapping with occupation metadata. Empty if not found.
+    """
+    if not title:
+        return {}
+    if OFFLINE:
+        # Fallback: simple mapping for common titles (this would be loaded from a local JSON or hardcoded)
+        title_key = title.strip().lower()
+        data = _OFFLINE_OCCUPATIONS.get(title_key) or {}
+        return data
+    # Online mode: call actual ESCO API
+    return esco_utils.classify_occupation(title, lang) or {}
+
+
+def enrich_skills(occupation_uri: str, lang: str = "en") -> list[str]:
+    """Retrieve essential skills for an occupation.
+
+    Args:
+        occupation_uri: ESCO URI of the occupation.
+        lang: Two-letter language code.
+
+    Returns:
+        List of essential skill labels.
+    """
+    if not occupation_uri:
+        return []
+    if OFFLINE:
+        return _OFFLINE_SKILLS.get(occupation_uri, [])
+    return esco_utils.get_essential_skills(occupation_uri, lang)
+
+
+# Example offline fixture data (to be replaced with actual data or loaded from file)
+_OFFLINE_OCCUPATIONS = {
+    "software engineer": {
+        "preferredLabel": "Software developers",
+        "uri": "http://data.europa.eu/esco/occupation/12345",
+        "group": "Information and communications technology professionals",
+    }
+}
+_OFFLINE_SKILLS = {
+    "http://data.europa.eu/esco/occupation/12345": [
+        "Python",
+        "Agile methodologies",
+        "Version control",
+    ]
+}

--- a/tests/test_esco_integration.py
+++ b/tests/test_esco_integration.py
@@ -1,0 +1,42 @@
+"""Tests for ESCO integration wrapper with offline support."""
+
+import importlib
+
+
+def test_offline_fallback(monkeypatch):
+    """search_occupation and enrich_skills use fixtures when VACAYSER_OFFLINE is set."""
+    monkeypatch.setenv("VACAYSER_OFFLINE", "1")
+    module = importlib.import_module("integrations.esco")
+    importlib.reload(module)
+    occ = module.search_occupation("Software Engineer")
+    assert occ["uri"] == "http://data.europa.eu/esco/occupation/12345"
+    skills = module.enrich_skills(occ["uri"])
+    assert "Python" in skills
+
+
+def test_online_delegation(monkeypatch):
+    """Wrapper delegates to core.esco_utils when not offline."""
+    monkeypatch.delenv("VACAYSER_OFFLINE", raising=False)
+    module = importlib.import_module("integrations.esco")
+    importlib.reload(module)
+
+    calls = {}
+
+    def fake_classify(title: str, lang: str = "en") -> dict:
+        calls["classify"] = (title, lang)
+        return {"uri": "x"}
+
+    def fake_skills(uri: str, lang: str = "en") -> list[str]:
+        calls["skills"] = (uri, lang)
+        return ["A"]
+
+    monkeypatch.setattr(module.esco_utils, "classify_occupation", fake_classify)
+    monkeypatch.setattr(module.esco_utils, "get_essential_skills", fake_skills)
+
+    occ = module.search_occupation("Dev", "de")
+    skills = module.enrich_skills("u", "de")
+
+    assert calls["classify"] == ("Dev", "de")
+    assert calls["skills"] == ("u", "de")
+    assert occ == {"uri": "x"}
+    assert skills == ["A"]

--- a/tests/test_wizard_source.py
+++ b/tests/test_wizard_source.py
@@ -90,7 +90,7 @@ def test_step_source_populates_data(monkeypatch: pytest.MonkeyPatch, mode: str) 
     monkeypatch.setattr(
         "wizard.extract_with_function", lambda _t, _s, model=None: sample_data
     )
-    monkeypatch.setattr("wizard.classify_occupation", lambda _t, _l: None)
+    monkeypatch.setattr("wizard.search_occupation", lambda _t, _l: None)
 
     if mode == "file":
         monkeypatch.setattr("wizard.extract_text_from_file", lambda _f: sample_text)
@@ -135,7 +135,7 @@ def test_step_source_merges_esco_skills(monkeypatch: pytest.MonkeyPatch) -> None
         "wizard.extract_with_function", lambda _t, _s, model=None: sample_data
     )
     monkeypatch.setattr(
-        "wizard.classify_occupation",
+        "wizard.search_occupation",
         lambda _t, _l: {
             "preferredLabel": "software developer",
             "uri": "http://example.com/occ",
@@ -143,7 +143,7 @@ def test_step_source_merges_esco_skills(monkeypatch: pytest.MonkeyPatch) -> None
         },
     )
     monkeypatch.setattr(
-        "wizard.get_essential_skills",
+        "wizard.enrich_skills",
         lambda _u, _l: ["Python", "Project management"],
     )
 

--- a/wizard.py
+++ b/wizard.py
@@ -21,7 +21,7 @@ from models.need_analysis import NeedAnalysisProfile
 # LLM/ESCO und Follow-ups
 from openai_utils import extract_with_function  # nutzt deine neue Definition
 from question_logic import ask_followups, CRITICAL_FIELDS  # nutzt deine neue Definition
-from core.esco_utils import classify_occupation, get_essential_skills
+from integrations.esco import search_occupation, enrich_skills
 from components.stepper import render_stepper
 
 ROOT = Path(__file__).parent
@@ -312,7 +312,7 @@ def _step_source(schema: dict) -> None:
                 st.session_state[StateKeys.PROFILE] = profile.model_dump()
                 title = profile.position.job_title or ""
                 occ = (
-                    classify_occupation(title, st.session_state.lang or "en")
+                    search_occupation(title, st.session_state.lang or "en")
                     if title
                     else None
                 )
@@ -320,8 +320,9 @@ def _step_source(schema: dict) -> None:
                     profile.position.occupation_label = occ.get("preferredLabel") or ""
                     profile.position.occupation_uri = occ.get("uri") or ""
                     profile.position.occupation_group = occ.get("group") or ""
-                    skills = get_essential_skills(
-                        occ.get("uri"), st.session_state.lang or "en"
+                    skills = enrich_skills(
+                        occ.get("uri") or "",
+                        st.session_state.lang or "en",
                     )
                     current_skills = set(profile.requirements.hard_skills or [])
                     merged = sorted(current_skills.union(skills or []))


### PR DESCRIPTION
## Summary
- add ESCO integration wrapper with optional offline fixtures
- switch wizard to use wrapper for occupation and skill lookup
- document VACAYSER_OFFLINE usage and cover with tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3af3dec048320bbbaf51de66248a4