### PR TITLE
feat: cache ESCO calls and track token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts, HR software for human resource professionals, engineering tools for civil engineers, cuisine specialties for chefs).
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **Offline-ready ESCO**: set `VACAYSER_OFFLINE=1` to use cached occupations and skills without API calls
+- **Cached ESCO calls**: Streamlit caching avoids repeated API requests
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **Cost‑aware**: GPT‑3.5 by default and minimal re‑asks
 - **Model**: optimized for GPT‑3.5 for suggestions and outputs

--- a/core/esco_utils.py
+++ b/core/esco_utils.py
@@ -7,13 +7,13 @@ essential skill lookup and skill normalization utilities.
 
 from __future__ import annotations
 
-import functools
 import logging
 import re
 from typing import Dict, List, Optional
 
 import backoff
 import requests
+import streamlit as st
 
 _ESO = "https://ec.europa.eu/esco/api"
 _HEADERS = {"User-Agent": "Vacalyser/1.0"}
@@ -39,7 +39,7 @@ def _get(path: str, **params) -> dict:
     return resp.json()
 
 
-@functools.lru_cache(maxsize=2048)
+@st.cache_data(show_spinner=False, max_entries=2048)
 def classify_occupation(title: str, lang: str = "en") -> Optional[Dict[str, str]]:
     """Return best matching ESCO occupation for a job title."""
 
@@ -79,7 +79,7 @@ def classify_occupation(title: str, lang: str = "en") -> Optional[Dict[str, str]
     }
 
 
-@functools.lru_cache(maxsize=4096)
+@st.cache_data(show_spinner=False, max_entries=4096)
 def get_essential_skills(occupation_uri: str, lang: str = "en") -> List[str]:
     """Return essential skill labels for a given occupation.
 
@@ -112,7 +112,7 @@ def get_essential_skills(occupation_uri: str, lang: str = "en") -> List[str]:
     return sorted(set(skills))
 
 
-@functools.lru_cache(maxsize=4096)
+@st.cache_data(show_spinner=False, max_entries=4096)
 def lookup_esco_skill(name: str, lang: str = "en") -> Dict[str, str]:
     """Lookup a skill and return its ESCO metadata."""
 

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -15,8 +15,10 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 import backoff
 from openai import OpenAI
+import streamlit as st
 
 from config import OPENAI_API_KEY
+from constants.keys import StateKeys
 
 
 @dataclass
@@ -126,6 +128,14 @@ def call_chat_api(
         )()
     else:
         usage = usage_obj if isinstance(usage_obj, dict) else {}
+
+    if StateKeys.USAGE in st.session_state:
+        st.session_state[StateKeys.USAGE]["input_tokens"] += usage.get(
+            "prompt_tokens", 0
+        )
+        st.session_state[StateKeys.USAGE]["output_tokens"] += usage.get(
+            "completion_tokens", 0
+        )
 
     return ChatCallResult(content, tool_calls, fc, usage)
 


### PR DESCRIPTION
## Summary
- cache ESCO classification and skill lookups with `st.cache_data`
- record OpenAI token usage in session state
- document ESCO caching in README

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3b199dd6c8320a71ce011f17a71a2