### PR TITLE
feat: enable job ad, boolean search, interview guide

### DIFF
--- a/constants/keys.py
+++ b/constants/keys.py
@@ -14,3 +14,6 @@ class StateKeys:
     STEP = "current_step"
     FOLLOWUPS = "followup_questions"
     USAGE = "api_usage"
+    JOB_AD_MD = "data.job_ad_md"
+    BOOLEAN_STR = "data.boolean_str"
+    INTERVIEW_GUIDE_MD = "data.interview_md"

--- a/state/ensure_state.py
+++ b/state/ensure_state.py
@@ -32,3 +32,10 @@ def ensure_state() -> None:
         st.session_state["auto_reask"] = True
     if StateKeys.USAGE not in st.session_state:
         st.session_state[StateKeys.USAGE] = {"input_tokens": 0, "output_tokens": 0}
+    for key in (
+        StateKeys.JOB_AD_MD,
+        StateKeys.BOOLEAN_STR,
+        StateKeys.INTERVIEW_GUIDE_MD,
+    ):
+        if key not in st.session_state:
+            st.session_state[key] = ""

--- a/tests/test_boolean_search.py
+++ b/tests/test_boolean_search.py
@@ -1,0 +1,15 @@
+from models.need_analysis import NeedAnalysisProfile, Position, Requirements
+from utils import build_boolean_search
+
+
+def test_build_boolean_search() -> None:
+    profile = NeedAnalysisProfile(
+        position=Position(job_title="Data Scientist"),
+        requirements=Requirements(
+            hard_skills=["Python"],
+            soft_skills=["Communication"],
+            tools_and_technologies=["SQL", "Python"],
+        ),
+    )
+    query = build_boolean_search(profile.model_dump())
+    assert query == '("Data Scientist") AND ("Python" OR "Communication" OR "SQL")'


### PR DESCRIPTION
## Summary
- add session keys and utilities for job ad, boolean string, and interview guide generation
- wire summary step buttons to generate content and flag biased language
- provide boolean search helper and tests

## Testing
- `ruff check constants/keys.py state/ensure_state.py utils/__init__.py wizard.py tests/test_boolean_search.py`
- `mypy constants/keys.py state/ensure_state.py utils/__init__.py wizard.py tests/test_boolean_search.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3b57ab54c8320a1c01f5c0318319a