### PR TITLE
fix: make vacancy schema fields optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Core JSON schemas like `schema/need_analysis.schema.json`, `critical_fields.json
 `config_loader.load_json`, which falls back to safe defaults and logs a warning
 if a file is missing or malformed.
 
+The vacancy profile schema does not enforce any required properties; every field
+is optional and may be omitted.
+
 ## Session State & Migration
 
 Session keys are centralized in `constants/keys.py`. Business data uses flat

--- a/models/need_analysis.py
+++ b/models/need_analysis.py
@@ -13,7 +13,7 @@ class Company(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    name: str = ""
+    name: Optional[str] = None
     industry: Optional[str] = None
     hq_location: Optional[str] = None
     size: Optional[str] = None
@@ -27,7 +27,7 @@ class Position(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    job_title: str = ""
+    job_title: Optional[str] = None
     seniority_level: Optional[str] = None
     department: Optional[str] = None
     team_structure: Optional[str] = None
@@ -133,6 +133,6 @@ class NeedAnalysisProfile(BaseModel):
 
     @field_validator("company", "position", mode="before")
     @classmethod
-    def _ensure_required(cls, value: Any) -> dict | Company | Position:
-        """Ensure required nested objects are present."""
+    def _ensure_present(cls, value: Any) -> dict | Company | Position:
+        """Ensure nested objects are present."""
         return {} if value is None else value

--- a/schema/need_analysis.schema.json
+++ b/schema/need_analysis.schema.json
@@ -14,8 +14,7 @@
         "website": {"type": "string"},
         "mission": {"type": "string"},
         "culture": {"type": "string"}
-      },
-      "required": ["name"]
+      }
     },
     "position": {
       "type": "object", "additionalProperties": false,
@@ -29,8 +28,7 @@
         "occupation_label": {"type": "string"},
         "occupation_uri": {"type": "string"},
         "occupation_group": {"type": "string"}
-      },
-      "required": ["job_title"]
+      }
     },
     "location": {
       "type": "object", "additionalProperties": false,
@@ -96,6 +94,5 @@
         "application_deadline": {"type": "string"}
       }
     }
-  },
-  "required": ["company", "position"]
+  }
 }

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -65,7 +65,7 @@ def test_assert_closed_schema_raises() -> None:
 
 
 def test_generate_error_report_missing_required() -> None:
-    """Missing required fields should appear in the error report."""
+    """With no mandatory fields, the report should be empty."""
 
     report = client._generate_error_report({"position": {"job_title": "x"}})
-    assert "company" in report
+    assert report == ""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -40,8 +40,8 @@ def test_coerce_and_fill_basic() -> None:
 
 def test_default_insertion() -> None:
     jd = coerce_and_fill({})
-    assert jd.position.job_title == ""
-    assert jd.company.name == ""
+    assert jd.position.job_title is None
+    assert jd.company.name is None
     assert jd.requirements.hard_skills == []
 
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -85,7 +85,7 @@ def build_boolean_search(data: Mapping[str, Any] | NeedAnalysisProfile) -> str:
     profile = (
         data if isinstance(data, NeedAnalysisProfile) else NeedAnalysisProfile(**data)
     )
-    job_title = profile.position.job_title
+    job_title = profile.position.job_title or ""
     combined = (
         profile.requirements.hard_skills
         + profile.requirements.soft_skills

--- a/wizard.py
+++ b/wizard.py
@@ -779,7 +779,7 @@ def _step_summary(schema: dict, critical: list[str]):
             try:
                 profile = NeedAnalysisProfile(**data)
                 guide_md = generate_interview_guide(
-                    job_title=profile.position.job_title,
+                    job_title=profile.position.job_title or "",
                     responsibilities="\n".join(profile.responsibilities.items),
                     hard_skills=profile.requirements.hard_skills,
                     soft_skills=profile.requirements.soft_skills,


### PR DESCRIPTION
## Summary
- remove required fields from vacancy schema and models
- allow downstream code to handle missing job titles
- update tests and documentation for fully optional profiles

## Testing
- `ruff check .`
- `black .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ec8ada483208bf566c6a6c88414