### PR TITLE
feat: add OCR fallback for PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ pip install -r requirements.txt  # or: pip install -e .
 streamlit run app.py
 ```
 
+### Optional: OCR for scanned PDFs
+
+Vacalyser can perform OCR on PDF pages without embedded text. Install the
+dependencies and corresponding system packages:
+
+```bash
+pip install pdf2image pytesseract
+# Debian/Ubuntu
+sudo apt-get install poppler-utils tesseract-ocr
+```
+
 ### Optional: RAG vector store
 
 To enable retrieval-augmented suggestions, create an OpenAI vector store and

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ trafilatura>=1.0
 pypdf>=4.0
 chardet>=5.0
 langdetect>=1.0
+pdf2image>=1.17
+pytesseract>=0.3

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,4 +1,8 @@
 import io
+import sys
+import types
+from pypdf import PdfWriter
+
 from ingest.extractors import extract_text_from_file
 
 
@@ -13,3 +17,22 @@ def test_extract_txt_encoding_and_normalization() -> None:
     f = io.BytesIO(data)
     f.name = "b.txt"
     assert extract_text_from_file(f) == "Hällo\nWorld"
+
+
+def _blank_pdf() -> io.BytesIO:
+    writer = PdfWriter()
+    writer.add_blank_page(width=10, height=10)
+    buf = io.BytesIO()
+    writer.write(buf)
+    buf.seek(0)
+    buf.name = "c.pdf"
+    return buf
+
+
+def test_extract_pdf_with_ocr(monkeypatch) -> None:
+    f = _blank_pdf()
+    pdf2image = types.SimpleNamespace(convert_from_bytes=lambda *a, **k: [object()])
+    pytesseract = types.SimpleNamespace(image_to_string=lambda img: "OCR TEXT")
+    monkeypatch.setitem(sys.modules, "pdf2image", pdf2image)
+    monkeypatch.setitem(sys.modules, "pytesseract", pytesseract)
+    assert extract_text_from_file(f) == "OCR TEXT"


### PR DESCRIPTION
## Summary
- handle scanned PDFs by converting empty pages to images and running OCR
- add pdf2image and pytesseract dependencies and document installation steps
- cover OCR fallback with a unit test

## Testing
- `ruff check ingest/extractors.py tests/test_extractors.py`
- `mypy ingest/extractors.py tests/test_extractors.py`
- `PYTHONPATH=. pytest tests/test_extractors.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac398a6a508320b603e8ff59b66c48