### PR TITLE
feat: inject background image and global css

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - **Responsive layout**: mobile-friendly columns and touch-sized buttons
 - **Salary analytics dashboard**: live sidebar estimate with optional factor explanations
 - **Branding options**: upload a company logo, provide style‑guide hints and toggle between dark and light themes
+- **Glassmorphic theme**: browser-optimized design with a hero background
 - **Expanded skills section**: enter certifications, language requirements, and tools & technologies alongside hard and soft skills
   - **Schema-aligned benefits**: benefit inputs bind directly to schema keys, merging health and retirement perks so all appear automatically
 - **Company insights**: specify headquarters location and company size for clearer context

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from base64 import b64encode
 
 import streamlit as st
 
@@ -20,6 +21,25 @@ st.set_page_config(
 # --- Helpers zum Laden lokaler JSON-Configs ---
 ROOT = Path(__file__).parent
 ensure_state()
+
+
+def inject_global_css() -> None:
+    """Inject the global stylesheet and background image.
+
+    Reads the CSS theme and background image, encodes the image in base64,
+    and sets the `--bg-image` variable so the app renders a hero background.
+    """
+
+    css = (ROOT / "styles" / "vacalyser.css").read_text(encoding="utf-8")
+    bg_bytes = (ROOT / "images" / "AdobeStock_506577005.jpeg").read_bytes()
+    encoded_bg = b64encode(bg_bytes).decode()
+    st.markdown(
+        f"<style>{css}\n:root {{ --bg-image: url('data:image/jpeg;base64,{encoded_bg}'); }}</style>",
+        unsafe_allow_html=True,
+    )
+
+
+inject_global_css()
 
 SCHEMA = load_json("schema/need_analysis.schema.json", fallback={})
 CRITICAL = set(


### PR DESCRIPTION
## Summary
- inject global stylesheet with hero background image
- document glassmorphic theme in README

## Testing
- `black app.py`
- `ruff check .`
- `mypy .`
- `pytest` *(fails: tests/test_missing_critical_fields.py::test_section_filtering, tests/test_question_logic.py::test_generate_followup_questions)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9003d1708320aa919d390074c7f0