### PR TITLE
feat: expand intro step heading and critical fields

### DIFF
--- a/critical_fields.json
+++ b/critical_fields.json
@@ -1,4 +1,8 @@
 {
   "critical": [
+    "company.name",
+    "position.job_title",
+    "position.role_summary",
+    "location.country"
   ]
 }

--- a/wizard.py
+++ b/wizard.py
@@ -885,7 +885,17 @@ def run_wizard():
 
     # Stepbar
     steps = [
-        (tr("Intro", "Intro"), _step_intro),
+        (
+            tr(
+                "Erstellen Sie eine umfassende Informationssammlung zu Ihrer Vakanz "
+                "und nutzen Sie diese Informationen zur Optimierung aller folgenden "
+                "Schritte Ihres Recruitment-Prozesses",
+                "Create a comprehensive information collection for your vacancy and "
+                "use this information to optimize all subsequent steps of your "
+                "recruitment process",
+            ),
+            _step_intro,
+        ),
         (tr("Quelle", "Source"), lambda: _step_source(schema)),
         (tr("Unternehmen", "Company"), _step_company),
         (tr("Position", "Position"), _step_position),


### PR DESCRIPTION
## Summary
- expand the wizard's first step heading with a detailed description
- define default critical fields for missing-field checks

## Testing
- `black wizard.py`
- `ruff check wizard.py`
- `mypy wizard.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ada868a0c48320aa56ea761aefa6ea