### PR TITLE
feat: add LLM skill suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
   - **Schema-aligned benefits**: benefit inputs bind directly to schema keys, merging health and retirement perks so all appear automatically
 - **Company insights**: specify headquarters location and company size for clearer context
 - **Domain-specific suggestions**: built-in lists of programming languages, frameworks, databases, cloud providers and DevOps tools help guide inputs
+- **LLM skill proposals**: AI suggests relevant hard skills, soft skills and IT technologies based on the job title
 
 ---
 

--- a/constants/keys.py
+++ b/constants/keys.py
@@ -17,3 +17,4 @@ class StateKeys:
     JOB_AD_MD = "data.job_ad_md"
     BOOLEAN_STR = "data.boolean_str"
     INTERVIEW_GUIDE_MD = "data.interview_md"
+    SKILL_SUGGESTIONS = "skill_suggestions"

--- a/tests/test_skill_suggestions.py
+++ b/tests/test_skill_suggestions.py
@@ -1,0 +1,39 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+import openai_utils
+from openai_utils import ChatCallResult, suggest_skills_for_role
+
+
+def fake_call(messages, **kwargs):
+    payload = json.dumps(
+        {
+            "tools_and_technologies": [f"T{i}" for i in range(1, 12)],
+            "hard_skills": ["H1", "H1", "H2"],
+            "soft_skills": ["S1", "S2"],
+        }
+    )
+    return ChatCallResult(payload, [], None, {})
+
+
+def test_suggest_skills_for_role(monkeypatch):
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call)
+    monkeypatch.setattr(
+        "core.esco_utils.normalize_skills", lambda skills, lang="en": skills
+    )
+    out = suggest_skills_for_role("Engineer")
+    assert out["tools_and_technologies"] == [f"T{i}" for i in range(1, 11)]
+    assert out["hard_skills"] == ["H1", "H2"]
+    assert out["soft_skills"] == ["S1", "S2"]
+
+
+def test_suggest_skills_for_role_empty():
+    out = suggest_skills_for_role("")
+    assert out == {
+        "tools_and_technologies": [],
+        "hard_skills": [],
+        "soft_skills": [],
+    }


### PR DESCRIPTION
## Summary
- generate tools, hard skills and soft skills from LLM for a given job title
- expose suggested skills in requirements step and store selections in profile
- document and test skill suggestion helper

## Testing
- `ruff check constants/keys.py openai_utils.py wizard.py tests/test_skill_suggestions.py`
- `mypy constants/keys.py openai_utils.py wizard.py tests/test_skill_suggestions.py`
- `pytest tests/test_skill_suggestions.py`


------
https://chatgpt.com/codex/tasks/task_e_68adb0b8760c8320befc202e0961f3df