### PR TITLE
feat: add editable tabbed summary view

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - **Inline refinement**: adjust generated documents with custom instructions and instantly update the view
 - **Robust error handling**: user-facing alerts for API or network issues
 - **Cross-field deduplication**: avoids repeating the same information across multiple fields
-- **Tabbed summary**: collected fields are editable in stage-based tabs for faster review
+- **Tabbed summary**: finalize all sections in inline-editable tabs and regenerate outputs instantly
 - **Missing info alerts**: highlights empty critical fields and blocks navigation until they're filled, letting you jump back to fix them
 - **Boolean Builder 2.0**: interactive search string with selectable skills and title synonyms
 - **Export**: clean JSON profile, job‑ad markdown, interview guide

--- a/tests/test_summary_update.py
+++ b/tests/test_summary_update.py
@@ -1,0 +1,22 @@
+"""Tests for editable summary helpers."""
+
+import streamlit as st
+
+from constants.keys import StateKeys
+from wizard import _update_profile
+
+
+def test_update_profile_clears_generated() -> None:
+    """Updating profile fields clears derived outputs."""
+    st.session_state.clear()
+    st.session_state[StateKeys.PROFILE] = {"company": {"name": "Old"}}
+    st.session_state[StateKeys.JOB_AD_MD] = "old"
+    st.session_state[StateKeys.BOOLEAN_STR] = "old"
+    st.session_state[StateKeys.INTERVIEW_GUIDE_MD] = "old"
+
+    _update_profile("company.name", "New")
+
+    assert st.session_state[StateKeys.PROFILE]["company"]["name"] == "New"
+    assert StateKeys.JOB_AD_MD not in st.session_state
+    assert StateKeys.BOOLEAN_STR not in st.session_state
+    assert StateKeys.INTERVIEW_GUIDE_MD not in st.session_state


### PR DESCRIPTION
## Summary
- replace raw JSON summary with tabbed sections for company, position, requirements, employment, compensation and process
- allow inline editing in summary tabs and reset derived outputs when data changes
- document tabbed summary and add regression test for profile updates

## Testing
- `ruff check wizard.py tests/test_summary_update.py`
- `black . --check`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb3addfc48320a7aaeb9ff60f517a