### PR TITLE
feat: add intro heading and language switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ## Highlights
 - **Dynamic Wizard**: multi‑step, bilingual (EN/DE), low‑friction inputs with tabbed text/upload/URL choices and auto-start analysis
+- **Upfront language switch**: choose German or English before entering any data
 - **Advantages page**: explore key benefits and jump straight into the wizard via a dedicated button
 - **One‑hop extraction**: Parse PDFs/DOCX/URLs into 20+ fields
 - **Structured output**: function calling/JSON mode ensures valid responses

--- a/constants/keys.py
+++ b/constants/keys.py
@@ -4,6 +4,7 @@ class UIKeys:
     JD_TEXT_INPUT = "ui.jd_text_input"
     JD_FILE_UPLOADER = "ui.jd_file_uploader"
     JD_URL_INPUT = "ui.jd_url_input"
+    LANG_SELECT = "ui.lang_select"
 
 
 class StateKeys:

--- a/tests/test_wizard_intro.py
+++ b/tests/test_wizard_intro.py
@@ -1,0 +1,29 @@
+import streamlit as st
+import pytest
+
+from wizard import _step_intro
+from utils.session import bootstrap_session
+
+
+def test_step_intro_language_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Language radio should update ``st.session_state.lang``."""
+
+    st.session_state.clear()
+    bootstrap_session()
+    st.session_state.lang = "de"
+
+    def fake_radio(label, options, key, horizontal=False, on_change=None):
+        st.session_state[key] = "English"
+        if on_change:
+            on_change()
+        return "English"
+
+    monkeypatch.setattr(st, "radio", fake_radio)
+    monkeypatch.setattr(st, "header", lambda *a, **k: None)
+    monkeypatch.setattr(st, "write", lambda *a, **k: None)
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
+
+    _step_intro()
+
+    assert st.session_state.lang == "en"

--- a/wizard.py
+++ b/wizard.py
@@ -279,8 +279,39 @@ def _step_intro():
     Returns:
         None
     """
+    lang_labels = {"Deutsch": "de", "English": "en"}
+    if UIKeys.LANG_SELECT not in st.session_state:
+        st.session_state[UIKeys.LANG_SELECT] = (
+            "Deutsch" if st.session_state.get("lang", "de") == "de" else "English"
+        )
 
-    st.title(t("intro_title", st.session_state.lang))
+    def _on_lang_change() -> None:
+        st.session_state["lang"] = lang_labels[st.session_state[UIKeys.LANG_SELECT]]
+
+    st.radio(
+        "🌐 Sprache / Language",
+        list(lang_labels.keys()),
+        key=UIKeys.LANG_SELECT,
+        horizontal=True,
+        on_change=_on_lang_change,
+    )
+
+    st.header(
+        tr("Willkommen zum Recruiting-Wizard", "Welcome to the Recruiting Wizard")
+    )
+    st.write(
+        tr(
+            (
+                "Dieser Wizard hilft Ihnen, alle relevanten Stellenanforderungen zu sammeln und aufzubereiten. "
+                "Am Ende erhalten Sie ein strukturiertes Profil Ihrer Vakanz."
+            ),
+            (
+                "This wizard helps you collect and organize all relevant job requirements. "
+                "In the end, you'll receive a structured profile of your vacancy."
+            ),
+        )
+    )
+    st.subheader(t("intro_title", st.session_state.lang))
     st.write(
         tr(
             (


### PR DESCRIPTION
## Summary
- expand wizard intro with welcome heading and description
- add upfront DE/EN language selector
- document new language switch in README

## Testing
- `ruff check .`
- `black constants/keys.py tests/test_wizard_intro.py`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aecd5c84308320b4f78ae3124bfef3