### PR TITLE
feat: add manual input and extraction feedback in wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 ## Highlights
 - **Dynamic Wizard**: multi‑step, bilingual (EN/DE), low‑friction inputs with tabbed text/upload/URL choices and auto-start analysis
+- **Manual entry option**: skip the upload step and start with an empty profile
+- **Extraction feedback**: review detected base data before continuing
+- **Guided error messages**: clear hints when uploads or URLs fail
 - **Upfront language switch**: choose German or English before entering any data
 - **Advantages page**: explore key benefits and jump straight into the wizard via a dedicated button
 - **One‑hop extraction**: Parse PDFs/DOCX/URLs into 20+ fields

--- a/constants/keys.py
+++ b/constants/keys.py
@@ -19,3 +19,4 @@ class StateKeys:
     BOOLEAN_STR = "data.boolean_str"
     INTERVIEW_GUIDE_MD = "data.interview_md"
     SKILL_SUGGESTIONS = "skill_suggestions"
+    EXTRACTION_SUMMARY = "extraction_summary"

--- a/state/ensure_state.py
+++ b/state/ensure_state.py
@@ -22,6 +22,8 @@ def ensure_state() -> None:
         st.session_state[StateKeys.RAW_TEXT] = ""
     if StateKeys.STEP not in st.session_state:
         st.session_state[StateKeys.STEP] = 0
+    if StateKeys.EXTRACTION_SUMMARY not in st.session_state:
+        st.session_state[StateKeys.EXTRACTION_SUMMARY] = {}
     if "lang" not in st.session_state:
         st.session_state["lang"] = "de"
     if "model" not in st.session_state:


### PR DESCRIPTION
## Summary
- allow continuing without a job description and keep editing an empty profile
- show a brief summary of extracted fields before moving on
- expand validation errors with hints for manual entry

## Testing
- `black constants/keys.py state/ensure_state.py wizard.py tests/test_wizard_source.py`
- `ruff check constants/keys.py state/ensure_state.py wizard.py tests/test_wizard_source.py`
- `mypy constants/keys.py`
- `PYTHONPATH=. pytest tests/test_wizard_source.py`


------
https://chatgpt.com/codex/tasks/task_e_68aecf12a18883209970fc657c31efe7