### PR TITLE
feat: extend company step with brand and contact details

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 - **Glassmorphic theme**: browser-optimized design with a hero background
 - **Expanded skills section**: enter certifications, language requirements, and tools & technologies alongside hard and soft skills
   - **Schema-aligned benefits**: benefit inputs bind directly to schema keys, merging health and retirement perks so all appear automatically
-- **Company insights**: specify headquarters location and company size for clearer context
+- **Company insights**: specify headquarters location, company size, brand and contact details for clearer context
 - **Domain-specific suggestions**: built-in lists of programming languages, frameworks, databases, cloud providers and DevOps tools help guide inputs
 - **LLM skill proposals**: AI suggests relevant hard skills, soft skills and IT technologies based on the job title
 

--- a/models/need_analysis.py
+++ b/models/need_analysis.py
@@ -14,12 +14,16 @@ class Company(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: Optional[str] = None
+    brand_name: Optional[str] = None
     industry: Optional[str] = None
     hq_location: Optional[str] = None
     size: Optional[str] = None
     website: Optional[str] = None
     mission: Optional[str] = None
     culture: Optional[str] = None
+    contact_name: Optional[str] = None
+    contact_email: Optional[str] = None
+    contact_phone: Optional[str] = None
 
 
 class Position(BaseModel):

--- a/tests/test_company_fields.py
+++ b/tests/test_company_fields.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from models.need_analysis import Company, NeedAnalysisProfile
+
+
+def test_company_additional_fields() -> None:
+    profile = NeedAnalysisProfile(
+        company=Company(
+            name="Acme Corp",
+            brand_name="Acme Robotics",
+            contact_name="Jane Doe",
+            contact_email="jane@example.com",
+            contact_phone="+49 30 1234567",
+        )
+    )
+    assert profile.company.brand_name == "Acme Robotics"
+    assert profile.company.contact_name == "Jane Doe"
+    assert profile.company.contact_email == "jane@example.com"
+    assert profile.company.contact_phone == "+49 30 1234567"

--- a/wizard.py
+++ b/wizard.py
@@ -525,12 +525,18 @@ def _step_company():
     )
     data = st.session_state[StateKeys.PROFILE]
 
-    c1, c2 = st.columns(2)
-    data["company"]["name"] = c1.text_input(
+    data["company"]["name"] = st.text_input(
         tr("Firma *", "Company *"),
         value=data["company"].get("name", ""),
         placeholder=tr("z. B. ACME GmbH", "e.g., ACME Corp"),
         help=tr("Offizieller Firmenname", "Official company name"),
+    )
+
+    c1, c2 = st.columns(2)
+    data["company"]["brand_name"] = c1.text_input(
+        tr("Marke/Tochterunternehmen", "Brand/Subsidiary"),
+        value=data["company"].get("brand_name", ""),
+        placeholder=tr("z. B. ACME Robotics", "e.g., ACME Robotics"),
     )
     data["company"]["industry"] = c2.text_input(
         tr("Branche", "Industry"),
@@ -550,29 +556,49 @@ def _step_company():
         placeholder=tr("z. B. 50-100", "e.g., 50-100"),
     )
 
-    c5, c6 = st.columns(2)
-    data["company"]["website"] = c5.text_input(
-        tr("Website", "Website"),
-        value=data["company"].get("website", ""),
-        placeholder="https://example.com",
-    )
-    data["company"]["mission"] = c6.text_input(
-        tr("Mission", "Mission"),
-        value=data["company"].get("mission", ""),
-        placeholder=tr(
-            "z. B. Nachhaltige Mobilität fördern",
-            "e.g., Promote sustainable mobility",
-        ),
-    )
+    with st.expander(tr("Weitere Unternehmensdetails", "Additional company details")):
+        c5, c6 = st.columns(2)
+        data["company"]["website"] = c5.text_input(
+            tr("Website", "Website"),
+            value=data["company"].get("website", ""),
+            placeholder="https://example.com",
+        )
+        data["company"]["mission"] = c6.text_input(
+            tr("Mission", "Mission"),
+            value=data["company"].get("mission", ""),
+            placeholder=tr(
+                "z. B. Nachhaltige Mobilität fördern",
+                "e.g., Promote sustainable mobility",
+            ),
+        )
 
-    data["company"]["culture"] = st.text_area(
-        tr("Kultur", "Culture"),
-        value=data["company"].get("culture", ""),
-        placeholder=tr(
-            "z. B. flache Hierarchien, Remote-First",
-            "e.g., flat hierarchies, remote-first",
-        ),
-    )
+        data["company"]["culture"] = st.text_area(
+            tr("Kultur", "Culture"),
+            value=data["company"].get("culture", ""),
+            placeholder=tr(
+                "z. B. flache Hierarchien, Remote-First",
+                "e.g., flat hierarchies, remote-first",
+            ),
+        )
+
+        st.markdown("---")
+        st.markdown(tr("Kontakt", "Contact"))
+        c7, c8 = st.columns(2)
+        data["company"]["contact_name"] = c7.text_input(
+            tr("Ansprechpartner", "Contact Name"),
+            value=data["company"].get("contact_name", ""),
+            placeholder=tr("z. B. Max Mustermann", "e.g., Jane Doe"),
+        )
+        data["company"]["contact_email"] = c8.text_input(
+            tr("Kontakt-E-Mail", "Contact Email"),
+            value=data["company"].get("contact_email", ""),
+            placeholder="email@example.com",
+        )
+        data["company"]["contact_phone"] = st.text_input(
+            tr("Kontakt-Telefon", "Contact Phone"),
+            value=data["company"].get("contact_phone", ""),
+            placeholder="+49 30 1234567",
+        )
 
     # Inline follow-up questions for Company section
     if StateKeys.FOLLOWUPS in st.session_state:


### PR DESCRIPTION
## Summary
- add optional company brand and contact fields to need analysis schema
- collapse ancillary company inputs into an expander
- document new company insights in README and cover with unit test

## Testing
- `ruff check .`
- `black .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aed1eb764c83208e4eb8c11d8f96e2