### PR TITLE
feat: add start date and contract details

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - **Expanded skills section**: enter certifications, language requirements, and tools & technologies alongside hard and soft skills
   - **Schema-aligned benefits**: benefit inputs bind directly to schema keys, merging health and retirement perks so all appear automatically
 - **Company insights**: specify headquarters location, company size, brand and contact details for clearer context
+- **Detailed role setup**: capture desired start date, direct reports, contract type and optional KPIs or key projects via an expandable section
 - **Domain-specific suggestions**: built-in lists of programming languages, frameworks, databases, cloud providers and DevOps tools help guide inputs
 - **LLM skill proposals**: AI suggests relevant hard skills, soft skills and IT technologies based on the job title
 

--- a/core/schema.py
+++ b/core/schema.py
@@ -46,9 +46,11 @@ def _collect_fields(
 
 ALL_FIELDS, LIST_FIELDS = _collect_fields(NeedAnalysisProfile)
 
-# Empty alias map retained for compatibility with older code paths
+# Alias map for backward compatibility with legacy field names
 # Using MappingProxyType to prevent accidental mutation.
-ALIASES: Mapping[str, str] = MappingProxyType({})
+ALIASES: Mapping[str, str] = MappingProxyType(
+    {"date_of_employment_start": "meta.target_start_date"}
+)
 
 
 def coerce_and_fill(data: dict[str, Any]) -> NeedAnalysisProfile:

--- a/models/need_analysis.py
+++ b/models/need_analysis.py
@@ -40,6 +40,10 @@ class Position(BaseModel):
     occupation_label: Optional[str] = None
     occupation_uri: Optional[str] = None
     occupation_group: Optional[str] = None
+    supervises: Optional[int] = None
+    performance_indicators: Optional[str] = None
+    decision_authority: Optional[str] = None
+    key_projects: Optional[str] = None
 
 
 class Location(BaseModel):
@@ -80,6 +84,7 @@ class Employment(BaseModel):
 
     job_type: Optional[str] = None
     work_policy: Optional[str] = None
+    contract_type: Optional[str] = None
     travel_required: Optional[bool] = None
     overtime_expected: Optional[bool] = None
     relocation_support: Optional[bool] = None

--- a/schema/need_analysis.schema.json
+++ b/schema/need_analysis.schema.json
@@ -27,7 +27,11 @@
         "role_summary": {"type": "string"},
         "occupation_label": {"type": "string"},
         "occupation_uri": {"type": "string"},
-        "occupation_group": {"type": "string"}
+        "occupation_group": {"type": "string"},
+        "supervises": {"type": "integer"},
+        "performance_indicators": {"type": "string"},
+        "decision_authority": {"type": "string"},
+        "key_projects": {"type": "string"}
       }
     },
     "location": {
@@ -60,6 +64,7 @@
       "properties": {
         "job_type": {"type": "string"},
         "work_policy": {"type": "string"},
+        "contract_type": {"type": "string"},
         "travel_required": {"type": "boolean"},
         "overtime_expected": {"type": "boolean"},
         "relocation_support": {"type": "boolean"},

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -18,11 +18,12 @@ def test_list_fields_contains_base_lists() -> None:
 def test_coerce_and_fill_basic() -> None:
     data = {
         "company": {"name": "Acme"},
-        "position": {"job_title": "Engineer"},
+        "position": {"job_title": "Engineer", "supervises": 3},
         "requirements": {"hard_skills": ["Python"]},
         "responsibilities": {"items": ["Code apps"]},
-        "employment": {"job_type": "full time"},
+        "employment": {"job_type": "full time", "contract_type": "permanent"},
         "compensation": {"benefits": ["Gym", "Gym"]},
+        "meta": {"target_start_date": "2024-01-01"},
     }
     jd = coerce_and_fill(data)
     assert isinstance(jd, NeedAnalysisProfile)
@@ -34,6 +35,9 @@ def test_coerce_and_fill_basic() -> None:
     assert jd.requirements.hard_skills == ["Python"]
     assert jd.responsibilities.items == ["Code apps"]
     assert jd.employment.job_type == "full time"
+    assert jd.employment.contract_type == "permanent"
+    assert jd.position.supervises == 3
+    assert jd.meta.target_start_date == "2024-01-01"
     assert jd.compensation.benefits == ["Gym", "Gym"]
     assert jd.company.name == "Acme"
 

--- a/wizard.py
+++ b/wizard.py
@@ -532,7 +532,7 @@ def _step_company():
         help=tr("Offizieller Firmenname", "Official company name"),
     )
 
-    c1, c2 = st.columns(2)
+    c1, c2, c3 = st.columns(3)
     data["company"]["brand_name"] = c1.text_input(
         tr("Marke/Tochterunternehmen", "Brand/Subsidiary"),
         value=data["company"].get("brand_name", ""),
@@ -635,7 +635,7 @@ def _step_position():
     )
     data = st.session_state[StateKeys.PROFILE]
 
-    c1, c2 = st.columns(2)
+    c1, c2, c3 = st.columns(3)
     data["position"]["job_title"] = c1.text_input(
         tr("Jobtitel *", "Job title *"),
         value=data["position"].get("job_title", ""),
@@ -673,11 +673,45 @@ def _step_position():
         height=120,
     )
 
+    c7, c8 = st.columns(2)
+    data["meta"]["target_start_date"] = c7.text_input(
+        tr("Gewünschtes Startdatum", "Desired start date"),
+        value=data["meta"].get("target_start_date", ""),
+        placeholder="YYYY-MM-DD",
+    )
+    data["position"]["supervises"] = c8.number_input(
+        tr("Anzahl unterstellter Mitarbeiter", "Direct reports"),
+        min_value=0,
+        value=data["position"].get("supervises", 0),
+        step=1,
+    )
+
+    with st.expander(tr("Weitere Rollen-Details", "Additional role details")):
+        data["position"]["performance_indicators"] = st.text_area(
+            tr("Leistungskennzahlen", "Performance indicators"),
+            value=data["position"].get("performance_indicators", ""),
+            height=80,
+        )
+        data["position"]["decision_authority"] = st.text_area(
+            tr("Entscheidungsbefugnisse", "Decision-making authority"),
+            value=data["position"].get("decision_authority", ""),
+            height=80,
+        )
+        data["position"]["key_projects"] = st.text_area(
+            tr("Schlüsselprojekte", "Key projects"),
+            value=data["position"].get("key_projects", ""),
+            height=80,
+        )
+
     # Inline follow-up questions for Position and Location section
     if StateKeys.FOLLOWUPS in st.session_state:
         for q in list(st.session_state[StateKeys.FOLLOWUPS]):
             field = q.get("field", "")
-            if field.startswith("position.") or field.startswith("location."):
+            if (
+                field.startswith("position.")
+                or field.startswith("location.")
+                or field.startswith("meta.")
+            ):
                 prompt = q.get("question", "")
                 if q.get("priority") == "critical":
                     st.markdown(
@@ -829,7 +863,7 @@ def _step_employment():
     )
     data = st.session_state[StateKeys.PROFILE]
 
-    c1, c2 = st.columns(2)
+    c1, c2, c3 = st.columns(3)
     job_options = [
         "full_time",
         "part_time",
@@ -856,16 +890,34 @@ def _step_employment():
         ),
     )
 
-    c3, c4, c5 = st.columns(3)
-    data["employment"]["travel_required"] = c3.toggle(
+    contract_options = {
+        "permanent": tr("Unbefristet", "Permanent"),
+        "fixed_term": tr("Befristet", "Fixed term"),
+        "contract": tr("Werkvertrag", "Contract"),
+        "other": tr("Sonstiges", "Other"),
+    }
+    current_contract = data["employment"].get("contract_type")
+    data["employment"]["contract_type"] = c3.selectbox(
+        tr("Vertragsart", "Contract type"),
+        options=list(contract_options.keys()),
+        format_func=lambda x: contract_options[x],
+        index=(
+            list(contract_options.keys()).index(current_contract)
+            if current_contract in contract_options
+            else 0
+        ),
+    )
+
+    c4, c5, c6 = st.columns(3)
+    data["employment"]["travel_required"] = c4.toggle(
         tr("Reisetätigkeit?", "Travel required?"),
         value=bool(data["employment"].get("travel_required")),
     )
-    data["employment"]["relocation_support"] = c4.toggle(
+    data["employment"]["relocation_support"] = c5.toggle(
         tr("Relocation?", "Relocation?"),
         value=bool(data["employment"].get("relocation_support")),
     )
-    data["employment"]["visa_sponsorship"] = c5.toggle(
+    data["employment"]["visa_sponsorship"] = c6.toggle(
         tr("Visum-Sponsoring?", "Visa sponsorship?"),
         value=bool(data["employment"].get("visa_sponsorship")),
     )


### PR DESCRIPTION
## Summary
- capture desired start date, direct reports and optional role details in the Position step
- add contract type selector to Employment step and support legacy start date field alias
- document enhanced role setup in README

## Testing
- `ruff check .`
- `black .`
- `pytest`
- `mypy .` *(fails: command hangs without output)*

------
https://chatgpt.com/codex/tasks/task_e_68aed47e2c1083208b41e7632f1d9168