### PR TITLE
feat: separate required and optional skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - **Salary analytics dashboard**: live sidebar estimate with optional factor explanations
 - **Branding options**: upload a company logo, provide style‑guide hints and toggle between dark and light themes
 - **Glassmorphic theme**: browser-optimized design with a hero background
-- **Expanded skills section**: enter certifications, language requirements, and tools & technologies alongside hard and soft skills
+- **Expanded skills section**: distinguish must-have and nice-to-have hard/soft skills, plus certifications, language requirements, and tools & technologies
   - **Schema-aligned benefits**: benefit inputs bind directly to schema keys, merging health and retirement perks so all appear automatically
 - **Company insights**: specify headquarters location, company size, brand and contact details for clearer context
 - **Detailed role setup**: capture desired start date, direct reports, contract type and optional KPIs or key projects via an expandable section

--- a/components/salary_dashboard.py
+++ b/components/salary_dashboard.py
@@ -81,8 +81,12 @@ def render_salary_dashboard(session_state: Any) -> None:
         session_state: Streamlit session state used to fetch vacancy data.
     """
 
-    must_skills = _session_list(session_state, "requirements.hard_skills")
-    nice_skills = _session_list(session_state, "requirements.soft_skills")
+    must_skills = _session_list(
+        session_state, "requirements.hard_skills_required"
+    ) + _session_list(session_state, "requirements.soft_skills_required")
+    nice_skills = _session_list(
+        session_state, "requirements.hard_skills_optional"
+    ) + _session_list(session_state, "requirements.soft_skills_optional")
     seniority = session_state.get("position.seniority_level", "")
     location = session_state.get("location.primary_city", "")
     job_type = session_state.get("employment.job_type", "permanent")

--- a/core/schema.py
+++ b/core/schema.py
@@ -49,7 +49,11 @@ ALL_FIELDS, LIST_FIELDS = _collect_fields(NeedAnalysisProfile)
 # Alias map for backward compatibility with legacy field names
 # Using MappingProxyType to prevent accidental mutation.
 ALIASES: Mapping[str, str] = MappingProxyType(
-    {"date_of_employment_start": "meta.target_start_date"}
+    {
+        "date_of_employment_start": "meta.target_start_date",
+        "requirements.hard_skills": "requirements.hard_skills_required",
+        "requirements.soft_skills": "requirements.soft_skills_required",
+    }
 )
 
 

--- a/models/need_analysis.py
+++ b/models/need_analysis.py
@@ -65,14 +65,17 @@ class Responsibilities(BaseModel):
 
 
 class Requirements(BaseModel):
-    """Required skills and qualifications."""
+    """Required and optional skills and qualifications."""
 
     model_config = ConfigDict(extra="forbid")
 
-    hard_skills: List[str] = Field(default_factory=list)
-    soft_skills: List[str] = Field(default_factory=list)
+    hard_skills_required: List[str] = Field(default_factory=list)
+    hard_skills_optional: List[str] = Field(default_factory=list)
+    soft_skills_required: List[str] = Field(default_factory=list)
+    soft_skills_optional: List[str] = Field(default_factory=list)
     tools_and_technologies: List[str] = Field(default_factory=list)
     languages_required: List[str] = Field(default_factory=list)
+    languages_optional: List[str] = Field(default_factory=list)
     certifications: List[str] = Field(default_factory=list)
     language_level_english: Optional[str] = None
 

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -759,8 +759,26 @@ def generate_job_ad(
         ),
         ("position.role_summary", "Role Summary", "Rollenbeschreibung"),
         ("responsibilities.items", "Key Responsibilities", "Wichtigste Aufgaben"),
-        ("requirements.hard_skills", "Hard Skills", "Technische Fähigkeiten"),
-        ("requirements.soft_skills", "Soft Skills", "Soziale Fähigkeiten"),
+        (
+            "requirements.hard_skills_required",
+            "Hard Skills (Must-have)",
+            "Technische Fähigkeiten (Muss)",
+        ),
+        (
+            "requirements.hard_skills_optional",
+            "Hard Skills (Nice-to-have)",
+            "Technische Fähigkeiten (Optional)",
+        ),
+        (
+            "requirements.soft_skills_required",
+            "Soft Skills (Must-have)",
+            "Soziale Fähigkeiten (Muss)",
+        ),
+        (
+            "requirements.soft_skills_optional",
+            "Soft Skills (Nice-to-have)",
+            "Soziale Fähigkeiten (Optional)",
+        ),
         ("compensation.benefits", "Benefits", "Leistungen"),
         (
             "learning_opportunities",

--- a/question_logic.py
+++ b/question_logic.py
@@ -171,8 +171,10 @@ ROLE_QUESTION_MAP: Dict[str, List[Dict[str, str]]] = {
 }
 
 SKILL_FIELDS: Set[str] = {
-    "requirements.hard_skills",
-    "requirements.soft_skills",
+    "requirements.hard_skills_required",
+    "requirements.hard_skills_optional",
+    "requirements.soft_skills_required",
+    "requirements.soft_skills_optional",
     "requirements.tools_and_technologies",
 }
 
@@ -393,8 +395,10 @@ def generate_followup_questions(
             [
                 str(extracted.get("responsibilities.items") or ""),
                 str(extracted.get("position.role_summary") or ""),
-                str(extracted.get("requirements.hard_skills") or ""),
-                str(extracted.get("requirements.soft_skills") or ""),
+                str(extracted.get("requirements.hard_skills_required") or ""),
+                str(extracted.get("requirements.hard_skills_optional") or ""),
+                str(extracted.get("requirements.soft_skills_required") or ""),
+                str(extracted.get("requirements.soft_skills_optional") or ""),
                 str(extracted.get("requirements.tools_and_technologies") or ""),
             ]
         ).lower()

--- a/role_field_map.json
+++ b/role_field_map.json
@@ -1,12 +1,12 @@
 {
-  "Information and communications technology professionals": [
-    "requirements.tools_and_technologies",
-    "requirements.hard_skills"
-  ],
-  "Sales, marketing and public relations professionals": [
-    "requirements.soft_skills"
-  ],
-  "Health professionals": [
-    "requirements.certifications"
-  ]
+    "Information and communications technology professionals": [
+        "requirements.tools_and_technologies",
+        "requirements.hard_skills_required"
+    ],
+    "Sales, marketing and public relations professionals": [
+        "requirements.soft_skills_required"
+    ],
+    "Health professionals": [
+        "requirements.certifications"
+    ]
 }

--- a/schema/need_analysis.schema.json
+++ b/schema/need_analysis.schema.json
@@ -1,103 +1,251 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "NeedAnalysisProfile",
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "company": {
-      "type": "object", "additionalProperties": false,
-      "properties": {
-        "name": {"type": "string"},
-        "industry": {"type": "string"},
-        "hq_location": {"type": "string"},
-        "size": {"type": "string"},
-        "website": {"type": "string"},
-        "mission": {"type": "string"},
-        "culture": {"type": "string"}
-      }
-    },
-    "position": {
-      "type": "object", "additionalProperties": false,
-      "properties": {
-        "job_title": {"type": "string"},
-        "seniority_level": {"type": "string"},
-        "department": {"type": "string"},
-        "team_structure": {"type": "string"},
-        "reporting_line": {"type": "string"},
-        "role_summary": {"type": "string"},
-        "occupation_label": {"type": "string"},
-        "occupation_uri": {"type": "string"},
-        "occupation_group": {"type": "string"},
-        "supervises": {"type": "integer"},
-        "performance_indicators": {"type": "string"},
-        "decision_authority": {"type": "string"},
-        "key_projects": {"type": "string"}
-      }
-    },
-    "location": {
-      "type": "object", "additionalProperties": false,
-      "properties": {
-        "primary_city": {"type": "string"},
-        "country": {"type": "string"},
-        "onsite_ratio": {"type": "string"}
-      }
-    },
-    "responsibilities": {
-      "type": "object", "additionalProperties": false,
-      "properties": {
-        "items": {"type": "array", "items": {"type": "string"}}
-      }
-    },
-    "requirements": {
-      "type": "object", "additionalProperties": false,
-      "properties": {
-        "hard_skills": {"type": "array", "items": {"type": "string"}},
-        "soft_skills": {"type": "array", "items": {"type": "string"}},
-        "tools_and_technologies": {"type": "array", "items": {"type": "string"}},
-        "languages_required": {"type": "array", "items": {"type": "string"}},
-        "certifications": {"type": "array", "items": {"type": "string"}},
-        "language_level_english": {"type": "string"}
-      }
-    },
-    "employment": {
-      "type": "object", "additionalProperties": false,
-      "properties": {
-        "job_type": {"type": "string"},
-        "work_policy": {"type": "string"},
-        "contract_type": {"type": "string"},
-        "travel_required": {"type": "boolean"},
-        "overtime_expected": {"type": "boolean"},
-        "relocation_support": {"type": "boolean"},
-        "visa_sponsorship": {"type": "boolean"},
-        "security_clearance_required": {"type": "boolean"},
-        "shift_work": {"type": "boolean"}
-      }
-    },
-    "compensation": {
-      "type": "object", "additionalProperties": false,
-      "properties": {
-        "salary_min": {"type": "number"},
-        "salary_max": {"type": "number"},
-        "currency": {"type": "string"},
-        "period": {"type": "string"},
-        "variable_pay": {"type": "boolean"},
-        "equity_offered": {"type": "boolean"},
-        "benefits": {"type": "array", "items": {"type": "string"}}
-      }
-    },
-    "process": {
-      "type": "object", "additionalProperties": false,
-      "properties": {
-        "interview_stages": {"type": "integer"},
-        "process_notes": {"type": "string"}
-      }
-    },
-    "meta": {
-      "type": "object", "additionalProperties": false,
-      "properties": {
-        "target_start_date": {"type": "string"},
-        "application_deadline": {"type": "string"}
-      }
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "NeedAnalysisProfile",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "company": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "industry": {
+                    "type": "string"
+                },
+                "hq_location": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "string"
+                },
+                "website": {
+                    "type": "string"
+                },
+                "mission": {
+                    "type": "string"
+                },
+                "culture": {
+                    "type": "string"
+                }
+            }
+        },
+        "position": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "job_title": {
+                    "type": "string"
+                },
+                "seniority_level": {
+                    "type": "string"
+                },
+                "department": {
+                    "type": "string"
+                },
+                "team_structure": {
+                    "type": "string"
+                },
+                "reporting_line": {
+                    "type": "string"
+                },
+                "role_summary": {
+                    "type": "string"
+                },
+                "occupation_label": {
+                    "type": "string"
+                },
+                "occupation_uri": {
+                    "type": "string"
+                },
+                "occupation_group": {
+                    "type": "string"
+                },
+                "supervises": {
+                    "type": "integer"
+                },
+                "performance_indicators": {
+                    "type": "string"
+                },
+                "decision_authority": {
+                    "type": "string"
+                },
+                "key_projects": {
+                    "type": "string"
+                }
+            }
+        },
+        "location": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primary_city": {
+                    "type": "string"
+                },
+                "country": {
+                    "type": "string"
+                },
+                "onsite_ratio": {
+                    "type": "string"
+                }
+            }
+        },
+        "responsibilities": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "requirements": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hard_skills_required": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hard_skills_optional": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "soft_skills_required": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "soft_skills_optional": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "tools_and_technologies": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "languages_required": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "languages_optional": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "certifications": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "language_level_english": {
+                    "type": "string"
+                }
+            }
+        },
+        "employment": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "job_type": {
+                    "type": "string"
+                },
+                "work_policy": {
+                    "type": "string"
+                },
+                "contract_type": {
+                    "type": "string"
+                },
+                "travel_required": {
+                    "type": "boolean"
+                },
+                "overtime_expected": {
+                    "type": "boolean"
+                },
+                "relocation_support": {
+                    "type": "boolean"
+                },
+                "visa_sponsorship": {
+                    "type": "boolean"
+                },
+                "security_clearance_required": {
+                    "type": "boolean"
+                },
+                "shift_work": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "compensation": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "salary_min": {
+                    "type": "number"
+                },
+                "salary_max": {
+                    "type": "number"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "period": {
+                    "type": "string"
+                },
+                "variable_pay": {
+                    "type": "boolean"
+                },
+                "equity_offered": {
+                    "type": "boolean"
+                },
+                "benefits": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "process": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "interview_stages": {
+                    "type": "integer"
+                },
+                "process_notes": {
+                    "type": "string"
+                }
+            }
+        },
+        "meta": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "target_start_date": {
+                    "type": "string"
+                },
+                "application_deadline": {
+                    "type": "string"
+                }
+            }
+        }
     }
-  }
 }

--- a/tests/test_boolean_search.py
+++ b/tests/test_boolean_search.py
@@ -6,8 +6,8 @@ def test_build_boolean_search() -> None:
     profile = NeedAnalysisProfile(
         position=Position(job_title="Data Scientist"),
         requirements=Requirements(
-            hard_skills=["Python"],
-            soft_skills=["Communication"],
+            hard_skills_required=["Python"],
+            soft_skills_required=["Communication"],
             tools_and_technologies=["SQL", "Python"],
         ),
     )

--- a/tests/test_generate_job_ad.py
+++ b/tests/test_generate_job_ad.py
@@ -18,7 +18,7 @@ def test_generate_job_ad_includes_optional_fields(monkeypatch):
         "responsibilities.items": ["Develop features"],
         "compensation.benefits": ["Stock options"],
         "learning_opportunities": "Annual training budget",
-        "requirements.hard_skills": ["Python experience"],
+        "requirements.hard_skills_required": ["Python experience"],
         "employment.work_policy": "Remote",
         "employment.work_schedule": "Mon-Fri",
         "employment.relocation_support": True,
@@ -34,7 +34,7 @@ def test_generate_job_ad_includes_optional_fields(monkeypatch):
 
     openai_utils.generate_job_ad(session, tone="formal and straightforward")
     prompt = captured["prompt"]
-    assert "Hard Skills: Python experience" in prompt
+    assert "Hard Skills (Must-have): Python experience" in prompt
     assert "Work Policy: Remote" in prompt
     assert "Work Schedule: Mon-Fri" in prompt
     assert "Relocation Assistance: Yes" in prompt

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,8 +5,10 @@ from core.schema import coerce_and_fill, LIST_FIELDS
 def test_list_fields_contains_base_lists() -> None:
     base_lists = {
         "responsibilities.items",
-        "requirements.hard_skills",
-        "requirements.soft_skills",
+        "requirements.hard_skills_required",
+        "requirements.hard_skills_optional",
+        "requirements.soft_skills_required",
+        "requirements.soft_skills_optional",
         "requirements.certifications",
         "compensation.benefits",
         "requirements.languages_required",
@@ -19,7 +21,7 @@ def test_coerce_and_fill_basic() -> None:
     data = {
         "company": {"name": "Acme"},
         "position": {"job_title": "Engineer", "supervises": 3},
-        "requirements": {"hard_skills": ["Python"]},
+        "requirements": {"hard_skills_required": ["Python"]},
         "responsibilities": {"items": ["Code apps"]},
         "employment": {"job_type": "full time", "contract_type": "permanent"},
         "compensation": {"benefits": ["Gym", "Gym"]},
@@ -32,7 +34,7 @@ def test_coerce_and_fill_basic() -> None:
     assert jd.responsibilities is not None
     assert jd.employment is not None
     assert jd.compensation is not None
-    assert jd.requirements.hard_skills == ["Python"]
+    assert jd.requirements.hard_skills_required == ["Python"]
     assert jd.responsibilities.items == ["Code apps"]
     assert jd.employment.job_type == "full time"
     assert jd.employment.contract_type == "permanent"
@@ -46,7 +48,7 @@ def test_default_insertion() -> None:
     jd = coerce_and_fill({})
     assert jd.position.job_title is None
     assert jd.company.name is None
-    assert jd.requirements.hard_skills == []
+    assert jd.requirements.hard_skills_required == []
 
 
 def test_job_type_invalid() -> None:

--- a/tests/test_wizard_source.py
+++ b/tests/test_wizard_source.py
@@ -134,7 +134,7 @@ def test_step_source_merges_esco_skills(monkeypatch: pytest.MonkeyPatch) -> None
     st.session_state[UIKeys.JD_TEXT_INPUT] = sample_text
     sample_data = {
         "position": {"job_title": "Engineer"},
-        "requirements": {"hard_skills": ["Python"]},
+        "requirements": {"hard_skills_required": ["Python"]},
     }
     _setup_common(monkeypatch)
     analyze_label = t("analyze", st.session_state.lang)
@@ -165,7 +165,7 @@ def test_step_source_merges_esco_skills(monkeypatch: pytest.MonkeyPatch) -> None
     data = st.session_state[StateKeys.PROFILE]
     assert data["position"]["occupation_label"] == "software developer"
     assert data["position"]["occupation_uri"] == "http://example.com/occ"
-    assert data["requirements"]["hard_skills"] == [
+    assert data["requirements"]["hard_skills_required"] == [
         "Project management",
         "Python",
     ]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -87,8 +87,10 @@ def build_boolean_search(data: Mapping[str, Any] | NeedAnalysisProfile) -> str:
     )
     job_title = profile.position.job_title or ""
     combined = (
-        profile.requirements.hard_skills
-        + profile.requirements.soft_skills
+        profile.requirements.hard_skills_required
+        + profile.requirements.hard_skills_optional
+        + profile.requirements.soft_skills_required
+        + profile.requirements.soft_skills_optional
         + profile.requirements.tools_and_technologies
     )
     skills: list[str] = []

--- a/wizard.py
+++ b/wizard.py
@@ -140,8 +140,8 @@ FIELD_SECTION_MAP = {
     "position.job_title": 1,
     "position.role_summary": 2,
     "location.country": 2,
-    "requirements.hard_skills": 3,
-    "requirements.soft_skills": 3,
+    "requirements.hard_skills_required": 3,
+    "requirements.soft_skills_required": 3,
 }
 
 
@@ -447,9 +447,11 @@ def _step_source(schema: dict) -> None:
                         occ.get("uri") or "",
                         st.session_state.lang or "en",
                     )
-                    current_skills = set(profile.requirements.hard_skills or [])
+                    current_skills = set(
+                        profile.requirements.hard_skills_required or []
+                    )
                     merged = sorted(current_skills.union(skills or []))
-                    profile.requirements.hard_skills = merged
+                    profile.requirements.hard_skills_required = merged
                 st.session_state[StateKeys.PROFILE] = profile.model_dump()
                 summary = {}
                 if profile.position.job_title:
@@ -754,15 +756,25 @@ def _step_requirements():
         st.session_state[StateKeys.SKILL_SUGGESTIONS] = stored
     suggestions = st.session_state.get(StateKeys.SKILL_SUGGESTIONS, {})
 
-    data["requirements"]["hard_skills"] = _chip_multiselect(
-        "Hard Skills",
-        options=data["requirements"].get("hard_skills", []),
-        values=data["requirements"].get("hard_skills", []),
+    data["requirements"]["hard_skills_required"] = _chip_multiselect(
+        "Hard Skills (Must-have)",
+        options=data["requirements"].get("hard_skills_required", []),
+        values=data["requirements"].get("hard_skills_required", []),
     )
-    data["requirements"]["soft_skills"] = _chip_multiselect(
-        "Soft Skills",
-        options=data["requirements"].get("soft_skills", []),
-        values=data["requirements"].get("soft_skills", []),
+    data["requirements"]["hard_skills_optional"] = _chip_multiselect(
+        "Hard Skills (Nice-to-have)",
+        options=data["requirements"].get("hard_skills_optional", []),
+        values=data["requirements"].get("hard_skills_optional", []),
+    )
+    data["requirements"]["soft_skills_required"] = _chip_multiselect(
+        "Soft Skills (Must-have)",
+        options=data["requirements"].get("soft_skills_required", []),
+        values=data["requirements"].get("soft_skills_required", []),
+    )
+    data["requirements"]["soft_skills_optional"] = _chip_multiselect(
+        "Soft Skills (Nice-to-have)",
+        options=data["requirements"].get("soft_skills_optional", []),
+        values=data["requirements"].get("soft_skills_optional", []),
     )
     data["requirements"]["tools_and_technologies"] = _chip_multiselect(
         "Tools & Tech",
@@ -773,6 +785,11 @@ def _step_requirements():
         tr("Sprachen", "Languages"),
         options=data["requirements"].get("languages_required", []),
         values=data["requirements"].get("languages_required", []),
+    )
+    data["requirements"]["languages_optional"] = _chip_multiselect(
+        tr("Optionale Sprachen", "Optional languages"),
+        options=data["requirements"].get("languages_optional", []),
+        values=data["requirements"].get("languages_optional", []),
     )
     data["requirements"]["certifications"] = _chip_multiselect(
         tr("Zertifizierungen", "Certifications"),
@@ -803,30 +820,30 @@ def _step_requirements():
         options=[
             s
             for s in suggestions.get("hard_skills", [])
-            if s not in data["requirements"].get("hard_skills", [])
+            if s not in data["requirements"].get("hard_skills_required", [])
         ],
         key="ms_sugg_hard",
     )
     if sugg_hard:
         merged = sorted(
-            set(data["requirements"].get("hard_skills", [])).union(sugg_hard)
+            set(data["requirements"].get("hard_skills_required", [])).union(sugg_hard)
         )
-        data["requirements"]["hard_skills"] = merged
+        data["requirements"]["hard_skills_required"] = merged
 
     sugg_soft = st.multiselect(
         tr("Vorgeschlagene Soft Skills", "Suggested Soft Skills"),
         options=[
             s
             for s in suggestions.get("soft_skills", [])
-            if s not in data["requirements"].get("soft_skills", [])
+            if s not in data["requirements"].get("soft_skills_required", [])
         ],
         key="ms_sugg_soft",
     )
     if sugg_soft:
         merged = sorted(
-            set(data["requirements"].get("soft_skills", [])).union(sugg_soft)
+            set(data["requirements"].get("soft_skills_required", [])).union(sugg_soft)
         )
-        data["requirements"]["soft_skills"] = merged
+        data["requirements"]["soft_skills_required"] = merged
 
     # Inline follow-up questions for Requirements section
     if StateKeys.FOLLOWUPS in st.session_state:
@@ -1175,25 +1192,40 @@ def _summary_requirements() -> None:
 
     data = st.session_state[StateKeys.PROFILE]
 
-    hard = st.text_area(
-        "Hard Skills",
-        value=", ".join(data["requirements"].get("hard_skills", [])),
-        key="ui.summary.requirements.hard_skills",
+    hard_req = st.text_area(
+        "Hard Skills (Must-have)",
+        value=", ".join(data["requirements"].get("hard_skills_required", [])),
+        key="ui.summary.requirements.hard_skills_required",
     )
-    soft = st.text_area(
-        "Soft Skills",
-        value=", ".join(data["requirements"].get("soft_skills", [])),
-        key="ui.summary.requirements.soft_skills",
+    hard_opt = st.text_area(
+        "Hard Skills (Nice-to-have)",
+        value=", ".join(data["requirements"].get("hard_skills_optional", [])),
+        key="ui.summary.requirements.hard_skills_optional",
+    )
+    soft_req = st.text_area(
+        "Soft Skills (Must-have)",
+        value=", ".join(data["requirements"].get("soft_skills_required", [])),
+        key="ui.summary.requirements.soft_skills_required",
+    )
+    soft_opt = st.text_area(
+        "Soft Skills (Nice-to-have)",
+        value=", ".join(data["requirements"].get("soft_skills_optional", [])),
+        key="ui.summary.requirements.soft_skills_optional",
     )
     tools = st.text_area(
         "Tools & Tech",
         value=", ".join(data["requirements"].get("tools_and_technologies", [])),
         key="ui.summary.requirements.tools",
     )
-    languages = st.text_area(
+    languages_req = st.text_area(
         tr("Sprachen", "Languages"),
         value=", ".join(data["requirements"].get("languages_required", [])),
-        key="ui.summary.requirements.languages",
+        key="ui.summary.requirements.languages_required",
+    )
+    languages_opt = st.text_area(
+        tr("Optionale Sprachen", "Optional languages"),
+        value=", ".join(data["requirements"].get("languages_optional", [])),
+        key="ui.summary.requirements.languages_optional",
     )
     certs = st.text_area(
         tr("Zertifizierungen", "Certifications"),
@@ -1202,12 +1234,20 @@ def _summary_requirements() -> None:
     )
 
     _update_profile(
-        "requirements.hard_skills",
-        [s.strip() for s in hard.split(",") if s.strip()],
+        "requirements.hard_skills_required",
+        [s.strip() for s in hard_req.split(",") if s.strip()],
     )
     _update_profile(
-        "requirements.soft_skills",
-        [s.strip() for s in soft.split(",") if s.strip()],
+        "requirements.hard_skills_optional",
+        [s.strip() for s in hard_opt.split(",") if s.strip()],
+    )
+    _update_profile(
+        "requirements.soft_skills_required",
+        [s.strip() for s in soft_req.split(",") if s.strip()],
+    )
+    _update_profile(
+        "requirements.soft_skills_optional",
+        [s.strip() for s in soft_opt.split(",") if s.strip()],
     )
     _update_profile(
         "requirements.tools_and_technologies",
@@ -1215,7 +1255,11 @@ def _summary_requirements() -> None:
     )
     _update_profile(
         "requirements.languages_required",
-        [s.strip() for s in languages.split(",") if s.strip()],
+        [s.strip() for s in languages_req.split(",") if s.strip()],
+    )
+    _update_profile(
+        "requirements.languages_optional",
+        [s.strip() for s in languages_opt.split(",") if s.strip()],
     )
     _update_profile(
         "requirements.certifications",
@@ -1456,8 +1500,10 @@ def _step_summary(schema: dict, critical: list[str]):
                 guide_md = generate_interview_guide(
                     job_title=profile.position.job_title or "",
                     responsibilities="\n".join(profile.responsibilities.items),
-                    hard_skills=profile.requirements.hard_skills,
-                    soft_skills=profile.requirements.soft_skills,
+                    hard_skills=profile.requirements.hard_skills_required
+                    + profile.requirements.hard_skills_optional,
+                    soft_skills=profile.requirements.soft_skills_required
+                    + profile.requirements.soft_skills_optional,
                     lang=st.session_state.lang,
                     tone=st.session_state.get("tone"),
                     num_questions=5,
@@ -1503,7 +1549,9 @@ def _step_summary(schema: dict, critical: list[str]):
             st.write(tr("**Vorgeschlagene Fragen:**", "**Suggested questions:**"))
             fu = st.session_state["followups"]
             for item in fu.get("questions", []):
-                key = item.get("key")  # dot key, z.B. "requirements.hard_skills"
+                key = item.get(
+                    "key"
+                )  # dot key, z.B. "requirements.hard_skills_required"
                 q = item.get("question")
                 if not key or not q:
                     continue


### PR DESCRIPTION
## Summary
- differentiate must-have and nice-to-have skills in schema and models
- extend wizard UI to capture optional skills and languages
- adjust utilities, salary dashboard, and tests for new fields

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aedfb06a7c8320a76659792b57f974