### PR TITLE
feat: extend employment details

### DIFF
--- a/models/need_analysis.py
+++ b/models/need_analysis.py
@@ -88,9 +88,14 @@ class Employment(BaseModel):
     job_type: Optional[str] = None
     work_policy: Optional[str] = None
     contract_type: Optional[str] = None
+    work_schedule: Optional[str] = None
+    remote_percentage: Optional[int] = None
+    contract_end: Optional[str] = None
     travel_required: Optional[bool] = None
+    travel_details: Optional[str] = None
     overtime_expected: Optional[bool] = None
     relocation_support: Optional[bool] = None
+    relocation_details: Optional[str] = None
     visa_sponsorship: Optional[bool] = None
     security_clearance_required: Optional[bool] = None
     shift_work: Optional[bool] = None

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -810,7 +810,6 @@ def generate_job_ad(
     yes_no = ("Ja", "Nein") if lang.startswith("de") else ("Yes", "No")
     boolean_fields = {
         "employment.travel_required",
-        "employment.relocation_support",
         "employment.visa_sponsorship",
     }
 
@@ -833,8 +832,24 @@ def generate_job_ad(
                 )
         elif key == "employment.work_policy":
             detail = str(data.get("employment.work_policy_details", "")).strip()
+            if not detail:
+                perc = data.get("employment.remote_percentage")
+                if perc:
+                    detail = (
+                        f"{perc}% remote"
+                        if not lang.startswith("de")
+                        else f"{perc}% Home-Office"
+                    )
             if detail:
                 formatted = f"{formatted} ({detail})"
+        elif key == "employment.relocation_support":
+            detail = str(data.get("employment.relocation_details", "")).strip()
+            if detail:
+                formatted = detail
+            else:
+                formatted = (
+                    yes_no[0] if str(val).lower() in ["true", "yes", "1"] else yes_no[1]
+                )
         elif key in boolean_fields:
             formatted = (
                 yes_no[0] if str(val).lower() in ["true", "yes", "1"] else yes_no[1]

--- a/schema/need_analysis.schema.json
+++ b/schema/need_analysis.schema.json
@@ -8,244 +8,114 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "industry": {
-                    "type": "string"
-                },
-                "hq_location": {
-                    "type": "string"
-                },
-                "size": {
-                    "type": "string"
-                },
-                "website": {
-                    "type": "string"
-                },
-                "mission": {
-                    "type": "string"
-                },
-                "culture": {
-                    "type": "string"
-                }
-            }
+                "name": {"type": "string"},
+                "industry": {"type": "string"},
+                "hq_location": {"type": "string"},
+                "size": {"type": "string"},
+                "website": {"type": "string"},
+                "mission": {"type": "string"},
+                "culture": {"type": "string"},
+            },
         },
         "position": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "job_title": {
-                    "type": "string"
-                },
-                "seniority_level": {
-                    "type": "string"
-                },
-                "department": {
-                    "type": "string"
-                },
-                "team_structure": {
-                    "type": "string"
-                },
-                "reporting_line": {
-                    "type": "string"
-                },
-                "role_summary": {
-                    "type": "string"
-                },
-                "occupation_label": {
-                    "type": "string"
-                },
-                "occupation_uri": {
-                    "type": "string"
-                },
-                "occupation_group": {
-                    "type": "string"
-                },
-                "supervises": {
-                    "type": "integer"
-                },
-                "performance_indicators": {
-                    "type": "string"
-                },
-                "decision_authority": {
-                    "type": "string"
-                },
-                "key_projects": {
-                    "type": "string"
-                }
-            }
+                "job_title": {"type": "string"},
+                "seniority_level": {"type": "string"},
+                "department": {"type": "string"},
+                "team_structure": {"type": "string"},
+                "reporting_line": {"type": "string"},
+                "role_summary": {"type": "string"},
+                "occupation_label": {"type": "string"},
+                "occupation_uri": {"type": "string"},
+                "occupation_group": {"type": "string"},
+                "supervises": {"type": "integer"},
+                "performance_indicators": {"type": "string"},
+                "decision_authority": {"type": "string"},
+                "key_projects": {"type": "string"},
+            },
         },
         "location": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "primary_city": {
-                    "type": "string"
-                },
-                "country": {
-                    "type": "string"
-                },
-                "onsite_ratio": {
-                    "type": "string"
-                }
-            }
+                "primary_city": {"type": "string"},
+                "country": {"type": "string"},
+                "onsite_ratio": {"type": "string"},
+            },
         },
         "responsibilities": {
             "type": "object",
             "additionalProperties": false,
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
+            "properties": {"items": {"type": "array", "items": {"type": "string"}}},
         },
         "requirements": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "hard_skills_required": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "hard_skills_optional": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "soft_skills_required": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "soft_skills_optional": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
+                "hard_skills_required": {"type": "array", "items": {"type": "string"}},
+                "hard_skills_optional": {"type": "array", "items": {"type": "string"}},
+                "soft_skills_required": {"type": "array", "items": {"type": "string"}},
+                "soft_skills_optional": {"type": "array", "items": {"type": "string"}},
                 "tools_and_technologies": {
                     "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "items": {"type": "string"},
                 },
-                "languages_required": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "languages_optional": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "certifications": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "language_level_english": {
-                    "type": "string"
-                }
-            }
+                "languages_required": {"type": "array", "items": {"type": "string"}},
+                "languages_optional": {"type": "array", "items": {"type": "string"}},
+                "certifications": {"type": "array", "items": {"type": "string"}},
+                "language_level_english": {"type": "string"},
+            },
         },
         "employment": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "job_type": {
-                    "type": "string"
-                },
-                "work_policy": {
-                    "type": "string"
-                },
-                "contract_type": {
-                    "type": "string"
-                },
-                "travel_required": {
-                    "type": "boolean"
-                },
-                "overtime_expected": {
-                    "type": "boolean"
-                },
-                "relocation_support": {
-                    "type": "boolean"
-                },
-                "visa_sponsorship": {
-                    "type": "boolean"
-                },
-                "security_clearance_required": {
-                    "type": "boolean"
-                },
-                "shift_work": {
-                    "type": "boolean"
-                }
-            }
+                "job_type": {"type": "string"},
+                "work_policy": {"type": "string"},
+                "contract_type": {"type": "string"},
+                "work_schedule": {"type": "string"},
+                "remote_percentage": {"type": "number"},
+                "contract_end": {"type": "string"},
+                "travel_required": {"type": "boolean"},
+                "travel_details": {"type": "string"},
+                "overtime_expected": {"type": "boolean"},
+                "relocation_support": {"type": "boolean"},
+                "relocation_details": {"type": "string"},
+                "visa_sponsorship": {"type": "boolean"},
+                "security_clearance_required": {"type": "boolean"},
+                "shift_work": {"type": "boolean"},
+            },
         },
         "compensation": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "salary_min": {
-                    "type": "number"
-                },
-                "salary_max": {
-                    "type": "number"
-                },
-                "currency": {
-                    "type": "string"
-                },
-                "period": {
-                    "type": "string"
-                },
-                "variable_pay": {
-                    "type": "boolean"
-                },
-                "equity_offered": {
-                    "type": "boolean"
-                },
-                "benefits": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
+                "salary_min": {"type": "number"},
+                "salary_max": {"type": "number"},
+                "currency": {"type": "string"},
+                "period": {"type": "string"},
+                "variable_pay": {"type": "boolean"},
+                "equity_offered": {"type": "boolean"},
+                "benefits": {"type": "array", "items": {"type": "string"}},
+            },
         },
         "process": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "interview_stages": {
-                    "type": "integer"
-                },
-                "process_notes": {
-                    "type": "string"
-                }
-            }
+                "interview_stages": {"type": "integer"},
+                "process_notes": {"type": "string"},
+            },
         },
         "meta": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "target_start_date": {
-                    "type": "string"
-                },
-                "application_deadline": {
-                    "type": "string"
-                }
-            }
-        }
-    }
+                "target_start_date": {"type": "string"},
+                "application_deadline": {"type": "string"},
+            },
+        },
+    },
 }

--- a/tests/test_generate_job_ad.py
+++ b/tests/test_generate_job_ad.py
@@ -102,6 +102,24 @@ def test_generate_job_ad_formats_travel_and_remote(monkeypatch):
     assert "Umzugsunterstützung: Ja" in prompts[1]
 
 
+def test_generate_job_ad_uses_remote_percentage(monkeypatch):
+    prompts: list[str] = []
+
+    def fake_call_chat_api(messages, **kwargs):
+        prompts.append(messages[0]["content"])
+        return "ok"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+
+    session = {
+        "employment.work_policy": "Hybrid",
+        "employment.remote_percentage": 60,
+        "lang": "en",
+    }
+    openai_utils.generate_job_ad(session)
+    assert "Work Policy: Hybrid (60% remote)" in prompts[0]
+
+
 def test_generate_job_ad_lists_unique_benefits(monkeypatch):
     captured = {}
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -44,6 +44,26 @@ def test_coerce_and_fill_basic() -> None:
     assert jd.company.name == "Acme"
 
 
+def test_coerce_and_fill_employment_details() -> None:
+    data = {
+        "employment": {
+            "contract_type": "fixed_term",
+            "contract_end": "2025-12-31",
+            "work_schedule": "flexitime",
+            "remote_percentage": 50,
+            "travel_required": True,
+            "travel_details": "20% international",
+            "relocation_support": True,
+            "relocation_details": "Budget provided",
+        }
+    }
+    jd = coerce_and_fill(data)
+    assert jd.employment.contract_end == "2025-12-31"
+    assert jd.employment.remote_percentage == 50
+    assert jd.employment.travel_details == "20% international"
+    assert jd.employment.relocation_details == "Budget provided"
+
+
 def test_default_insertion() -> None:
     jd = coerce_and_fill({})
     assert jd.position.job_title is None


### PR DESCRIPTION
## Summary
- capture work schedule, remote share, contract end, and relocation/travel details in employment step
- surface remote percentage and relocation info in job-ad generator
- test schema coercion and remote percentage formatting

## Testing
- `black models/need_analysis.py schema/need_analysis.schema.json wizard.py openai_utils.py tests/test_generate_job_ad.py tests/test_schema.py`
- `ruff check models/need_analysis.py wizard.py openai_utils.py tests/test_generate_job_ad.py tests/test_schema.py`
- `mypy models/need_analysis.py wizard.py openai_utils.py tests/test_generate_job_ad.py tests/test_schema.py` *(fails: process hung)*
- `PYTHONPATH=. pytest tests/test_generate_job_ad.py tests/test_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68aff69063e0832093ff98c85f241642