### PR TITLE
feat: extend compensation step with bonus and benefits

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - **Onboarding Intro**: welcome step explains required inputs and allows skipping for returning users
 - **Responsive layout**: mobile-friendly columns and touch-sized buttons
 - **Salary analytics dashboard**: live sidebar estimate with optional factor explanations
+- **Enhanced compensation step**: slider-based salary range, preset currency choices, bonus/commission details and common benefit suggestions
 - **Branding options**: upload a company logo, provide style‑guide hints and toggle between dark and light themes
 - **Glassmorphic theme**: browser-optimized design with a hero background
 - **Expanded skills section**: distinguish must-have and nice-to-have hard/soft skills, plus certifications, language requirements, and tools & technologies

--- a/models/need_analysis.py
+++ b/models/need_analysis.py
@@ -111,6 +111,8 @@ class Compensation(BaseModel):
     currency: Optional[str] = None
     period: Optional[str] = None
     variable_pay: Optional[bool] = None
+    bonus_percentage: Optional[float] = None
+    commission_structure: Optional[str] = None
     equity_offered: Optional[bool] = None
     benefits: List[str] = Field(default_factory=list)
 

--- a/schema/need_analysis.schema.json
+++ b/schema/need_analysis.schema.json
@@ -8,114 +8,265 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "name": {"type": "string"},
-                "industry": {"type": "string"},
-                "hq_location": {"type": "string"},
-                "size": {"type": "string"},
-                "website": {"type": "string"},
-                "mission": {"type": "string"},
-                "culture": {"type": "string"},
-            },
+                "name": {
+                    "type": "string"
+                },
+                "industry": {
+                    "type": "string"
+                },
+                "hq_location": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "string"
+                },
+                "website": {
+                    "type": "string"
+                },
+                "mission": {
+                    "type": "string"
+                },
+                "culture": {
+                    "type": "string"
+                }
+            }
         },
         "position": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "job_title": {"type": "string"},
-                "seniority_level": {"type": "string"},
-                "department": {"type": "string"},
-                "team_structure": {"type": "string"},
-                "reporting_line": {"type": "string"},
-                "role_summary": {"type": "string"},
-                "occupation_label": {"type": "string"},
-                "occupation_uri": {"type": "string"},
-                "occupation_group": {"type": "string"},
-                "supervises": {"type": "integer"},
-                "performance_indicators": {"type": "string"},
-                "decision_authority": {"type": "string"},
-                "key_projects": {"type": "string"},
-            },
+                "job_title": {
+                    "type": "string"
+                },
+                "seniority_level": {
+                    "type": "string"
+                },
+                "department": {
+                    "type": "string"
+                },
+                "team_structure": {
+                    "type": "string"
+                },
+                "reporting_line": {
+                    "type": "string"
+                },
+                "role_summary": {
+                    "type": "string"
+                },
+                "occupation_label": {
+                    "type": "string"
+                },
+                "occupation_uri": {
+                    "type": "string"
+                },
+                "occupation_group": {
+                    "type": "string"
+                },
+                "supervises": {
+                    "type": "integer"
+                },
+                "performance_indicators": {
+                    "type": "string"
+                },
+                "decision_authority": {
+                    "type": "string"
+                },
+                "key_projects": {
+                    "type": "string"
+                }
+            }
         },
         "location": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "primary_city": {"type": "string"},
-                "country": {"type": "string"},
-                "onsite_ratio": {"type": "string"},
-            },
+                "primary_city": {
+                    "type": "string"
+                },
+                "country": {
+                    "type": "string"
+                },
+                "onsite_ratio": {
+                    "type": "string"
+                }
+            }
         },
         "responsibilities": {
             "type": "object",
             "additionalProperties": false,
-            "properties": {"items": {"type": "array", "items": {"type": "string"}}},
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
         },
         "requirements": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "hard_skills_required": {"type": "array", "items": {"type": "string"}},
-                "hard_skills_optional": {"type": "array", "items": {"type": "string"}},
-                "soft_skills_required": {"type": "array", "items": {"type": "string"}},
-                "soft_skills_optional": {"type": "array", "items": {"type": "string"}},
+                "hard_skills_required": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hard_skills_optional": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "soft_skills_required": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "soft_skills_optional": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "tools_and_technologies": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {
+                        "type": "string"
+                    }
                 },
-                "languages_required": {"type": "array", "items": {"type": "string"}},
-                "languages_optional": {"type": "array", "items": {"type": "string"}},
-                "certifications": {"type": "array", "items": {"type": "string"}},
-                "language_level_english": {"type": "string"},
-            },
+                "languages_required": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "languages_optional": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "certifications": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "language_level_english": {
+                    "type": "string"
+                }
+            }
         },
         "employment": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "job_type": {"type": "string"},
-                "work_policy": {"type": "string"},
-                "contract_type": {"type": "string"},
-                "work_schedule": {"type": "string"},
-                "remote_percentage": {"type": "number"},
-                "contract_end": {"type": "string"},
-                "travel_required": {"type": "boolean"},
-                "travel_details": {"type": "string"},
-                "overtime_expected": {"type": "boolean"},
-                "relocation_support": {"type": "boolean"},
-                "relocation_details": {"type": "string"},
-                "visa_sponsorship": {"type": "boolean"},
-                "security_clearance_required": {"type": "boolean"},
-                "shift_work": {"type": "boolean"},
-            },
+                "job_type": {
+                    "type": "string"
+                },
+                "work_policy": {
+                    "type": "string"
+                },
+                "contract_type": {
+                    "type": "string"
+                },
+                "work_schedule": {
+                    "type": "string"
+                },
+                "remote_percentage": {
+                    "type": "number"
+                },
+                "contract_end": {
+                    "type": "string"
+                },
+                "travel_required": {
+                    "type": "boolean"
+                },
+                "travel_details": {
+                    "type": "string"
+                },
+                "overtime_expected": {
+                    "type": "boolean"
+                },
+                "relocation_support": {
+                    "type": "boolean"
+                },
+                "relocation_details": {
+                    "type": "string"
+                },
+                "visa_sponsorship": {
+                    "type": "boolean"
+                },
+                "security_clearance_required": {
+                    "type": "boolean"
+                },
+                "shift_work": {
+                    "type": "boolean"
+                }
+            }
         },
         "compensation": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "salary_min": {"type": "number"},
-                "salary_max": {"type": "number"},
-                "currency": {"type": "string"},
-                "period": {"type": "string"},
-                "variable_pay": {"type": "boolean"},
-                "equity_offered": {"type": "boolean"},
-                "benefits": {"type": "array", "items": {"type": "string"}},
-            },
+                "salary_min": {
+                    "type": "number"
+                },
+                "salary_max": {
+                    "type": "number"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "period": {
+                    "type": "string"
+                },
+                "variable_pay": {
+                    "type": "boolean"
+                },
+                "bonus_percentage": {
+                    "type": "number"
+                },
+                "commission_structure": {
+                    "type": "string"
+                },
+                "equity_offered": {
+                    "type": "boolean"
+                },
+                "benefits": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
         },
         "process": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "interview_stages": {"type": "integer"},
-                "process_notes": {"type": "string"},
-            },
+                "interview_stages": {
+                    "type": "integer"
+                },
+                "process_notes": {
+                    "type": "string"
+                }
+            }
         },
         "meta": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "target_start_date": {"type": "string"},
-                "application_deadline": {"type": "string"},
-            },
-        },
-    },
+                "target_start_date": {
+                    "type": "string"
+                },
+                "application_deadline": {
+                    "type": "string"
+                }
+            }
+        }
+    }
 }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -24,7 +24,11 @@ def test_coerce_and_fill_basic() -> None:
         "requirements": {"hard_skills_required": ["Python"]},
         "responsibilities": {"items": ["Code apps"]},
         "employment": {"job_type": "full time", "contract_type": "permanent"},
-        "compensation": {"benefits": ["Gym", "Gym"]},
+        "compensation": {
+            "benefits": ["Gym", "Gym"],
+            "bonus_percentage": 10.0,
+            "commission_structure": "10% of sales",
+        },
         "meta": {"target_start_date": "2024-01-01"},
     }
     jd = coerce_and_fill(data)
@@ -41,6 +45,8 @@ def test_coerce_and_fill_basic() -> None:
     assert jd.position.supervises == 3
     assert jd.meta.target_start_date == "2024-01-01"
     assert jd.compensation.benefits == ["Gym", "Gym"]
+    assert jd.compensation.bonus_percentage == 10.0
+    assert jd.compensation.commission_structure == "10% of sales"
     assert jd.company.name == "Acme"
 
 


### PR DESCRIPTION
## Summary
- add bonus and commission fields to compensation model and schema
- enhance compensation step with salary slider, currency dropdown, and benefit suggestions
- document new compensation features and test schema updates

## Testing
- `ruff check models/need_analysis.py wizard.py tests/test_schema.py`
- `mypy models/need_analysis.py wizard.py tests/test_schema.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68affb1afc488320875ebeb1bc73e080