### PR TITLE
feat: expand process step with stakeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
   - **Schema-aligned benefits**: benefit inputs bind directly to schema keys, merging health and retirement perks so all appear automatically
 - **Company insights**: specify headquarters location, company size, brand and contact details for clearer context
 - **Detailed role setup**: capture desired start date, direct reports, contract type and optional KPIs or key projects via an expandable section
+- **Process mapping**: plan stakeholders, per-stage details and application instructions directly in the wizard
 - **Domain-specific suggestions**: built-in lists of programming languages, frameworks, databases, cloud providers and DevOps tools help guide inputs
 - **LLM skill proposals**: AI suggests relevant hard skills, soft skills and IT technologies based on the job title
 

--- a/models/need_analysis.py
+++ b/models/need_analysis.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
-from typing import Any
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
 
 
 class Company(BaseModel):
@@ -117,13 +116,41 @@ class Compensation(BaseModel):
     benefits: List[str] = Field(default_factory=list)
 
 
+class Stakeholder(BaseModel):
+    """Person involved in the hiring process."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    role: str
+    email: EmailStr
+    primary: bool = False
+
+
+class Phase(BaseModel):
+    """Single phase of the hiring process."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    interview_format: Optional[str] = None
+    participants: List[str] = Field(default_factory=list)
+    docs_required: Optional[str] = None
+    assessment_tests: Optional[bool] = None
+    timeframe: Optional[str] = None
+
+
 class Process(BaseModel):
     """Information about the hiring process."""
 
     model_config = ConfigDict(extra="forbid")
-
     interview_stages: Optional[int] = None
+    stakeholders: List[Stakeholder] = Field(default_factory=list)
+    phases: List[Phase] = Field(default_factory=list)
+    recruitment_timeline: Optional[str] = None
     process_notes: Optional[str] = None
+    application_instructions: Optional[str] = None
+    onboarding_process: Optional[str] = None
 
 
 class Meta(BaseModel):

--- a/schema/need_analysis.schema.json
+++ b/schema/need_analysis.schema.json
@@ -251,7 +251,47 @@
                 "interview_stages": {
                     "type": "integer"
                 },
+                "stakeholders": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {"type": "string"},
+                            "role": {"type": "string"},
+                            "email": {"type": "string"},
+                            "primary": {"type": "boolean"}
+                        }
+                    }
+                },
+                "phases": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {"type": "string"},
+                            "interview_format": {"type": "string"},
+                            "participants": {
+                                "type": "array",
+                                "items": {"type": "string"}
+                            },
+                            "docs_required": {"type": "string"},
+                            "assessment_tests": {"type": "boolean"},
+                            "timeframe": {"type": "string"}
+                        }
+                    }
+                },
+                "recruitment_timeline": {
+                    "type": "string"
+                },
                 "process_notes": {
+                    "type": "string"
+                },
+                "application_instructions": {
+                    "type": "string"
+                },
+                "onboarding_process": {
                     "type": "string"
                 }
             }

--- a/tests/test_process_step.py
+++ b/tests/test_process_step.py
@@ -1,0 +1,44 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from models.need_analysis import NeedAnalysisProfile, Process, Stakeholder, Phase
+
+
+def test_process_model_supports_stakeholders_and_phases():
+    process = Process(
+        interview_stages=2,
+        stakeholders=[
+            Stakeholder(
+                name="Alice", role="Recruiter", email="alice@example.com", primary=True
+            ),
+            Stakeholder(name="Bob", role="Manager", email="bob@example.com"),
+        ],
+        phases=[
+            Phase(
+                name="Phone Screen",
+                interview_format="phone",
+                participants=["Alice"],
+                docs_required="",
+                assessment_tests=False,
+                timeframe="Week 1",
+            ),
+            Phase(
+                name="On-site",
+                interview_format="on_site",
+                participants=["Bob"],
+                docs_required="Portfolio",
+                assessment_tests=True,
+                timeframe="Week 2",
+            ),
+        ],
+        recruitment_timeline="6 weeks",
+        process_notes="Notes",
+        application_instructions="Send one PDF",
+        onboarding_process="Buddy program",
+    )
+    profile = NeedAnalysisProfile(process=process)
+    assert profile.process.interview_stages == 2
+    assert profile.process.stakeholders[0].primary is True
+    assert profile.process.phases[1].participants == ["Bob"]


### PR DESCRIPTION
## Summary
- allow adding stakeholders and stage details in hiring process
- capture timeline, application instructions and optional onboarding notes
- document process mapping in README

## Testing
- `ruff check models/need_analysis.py wizard.py tests/test_process_step.py`
- `mypy models/need_analysis.py tests/test_process_step.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68affde5db98832086e5ba15b25f577b