### PR TITLE
feat: default to gpt-5-nano

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
 - **Offline-ready ESCO**: set `VACAYSER_OFFLINE=1` to use cached occupations and skills without API calls
 - **Cached ESCO calls**: Streamlit caching avoids repeated API requests
 - **RAG‑Assist**: use your vector store to fill/contextualize
-- **Cost‑aware**: GPT‑3.5 by default and minimal re‑asks
-- **Model**: optimized for GPT‑3.5 for suggestions and outputs
+- **Cost‑aware**: GPT‑5-nano by default and minimal re‑asks
+- **Model**: optimized for GPT‑5-nano for suggestions and outputs
 - **Inline refinement**: adjust generated documents with custom instructions and instantly update the view
 - **Robust error handling**: user-facing alerts for API or network issues
 - **Cross-field deduplication**: avoids repeating the same information across multiple fields

--- a/components/model_selector.py
+++ b/components/model_selector.py
@@ -16,7 +16,7 @@ def model_selector(key: str = "llm_model") -> str:
     Returns:
         The chosen model identifier.
     """
-    models = ["gpt-3.5-turbo"]
+    models = ["gpt-5-nano", "gpt-4.1-nano"]
     default = st.session_state.get(key, OPENAI_MODEL)
     if default not in models:
         default = models[0]

--- a/config.py
+++ b/config.py
@@ -18,7 +18,7 @@ CHUNK_OVERLAP = 0.1
 
 STREAMLIT_ENV = os.getenv("STREAMLIT_ENV", "development")
 DEFAULT_LANGUAGE = os.getenv("LANGUAGE", "en")
-DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "gpt-3.5-turbo")
+DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "gpt-5-nano")
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "").strip()
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", DEFAULT_MODEL)

--- a/llm/client.py
+++ b/llm/client.py
@@ -95,7 +95,7 @@ NEED_ANALYSIS_SCHEMA.pop("title", None)
 _assert_closed_schema(NEED_ANALYSIS_SCHEMA)
 
 MODE = os.getenv("LLM_MODE", "plain").lower()
-MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+MODEL = os.getenv("OPENAI_MODEL", "gpt-5-nano")
 OPENAI_CLIENT = OpenAI(api_key=os.getenv("OPENAI_API_KEY", ""))
 
 

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -375,7 +375,7 @@ def suggest_additional_skills(
         if existing_skills:
             prompt += f" Bereits aufgelistet: {', '.join(existing_skills)}."
     messages = [{"role": "user", "content": prompt}]
-    max_tokens = 220 if not model or "gpt-3.5" in model else 300
+    max_tokens = 220 if not model or "nano" in model else 300
     res = call_chat_api(messages, model=model, temperature=0.4, max_tokens=max_tokens)
     answer = _chat_content(res)
     tech_skills, soft_skills = [], []
@@ -554,7 +554,7 @@ def suggest_benefits(
         if existing_benefits:
             prompt += f"Already listed: {existing_benefits}"
     messages = [{"role": "user", "content": prompt}]
-    max_tokens = 150 if not model or "gpt-3.5" in model else 200
+    max_tokens = 150 if not model or "nano" in model else 200
     res = call_chat_api(messages, model=model, temperature=0.5, max_tokens=max_tokens)
     answer = _chat_content(res)
     benefits = []
@@ -586,7 +586,7 @@ def suggest_role_tasks(
         return []
     prompt = f"List {num_tasks} concise core responsibilities for a {job_title} role."
     messages = [{"role": "user", "content": prompt}]
-    max_tokens = 180 if not model or "gpt-3.5" in model else 250
+    max_tokens = 180 if not model or "nano" in model else 250
     res = call_chat_api(messages, model=model, temperature=0.5, max_tokens=max_tokens)
     answer = _chat_content(res)
     tasks = []

--- a/state/ensure_state.py
+++ b/state/ensure_state.py
@@ -27,7 +27,7 @@ def ensure_state() -> None:
     if "lang" not in st.session_state:
         st.session_state["lang"] = "de"
     if "model" not in st.session_state:
-        st.session_state["model"] = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+        st.session_state["model"] = os.getenv("OPENAI_MODEL", "gpt-5-nano")
     if "vector_store_id" not in st.session_state:
         st.session_state["vector_store_id"] = os.getenv("VECTOR_STORE_ID", "")
     if "auto_reask" not in st.session_state:


### PR DESCRIPTION
## Summary
- switch default OpenAI model to `gpt-5-nano`
- propagate new model through session state and LLM client
- list `gpt-5-nano` and `gpt-4.1-nano` in model selector; adjust token heuristics

## Testing
- `ruff check . --fix`
- `black .`
- `mypy .`
- `pytest` *(fails: 21 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b0010532a88320b8a80ca7e6c47a5c