### PR TITLE
feat: add nano model selector

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from base64 import b64encode
 import streamlit as st
 
 from components.salary_dashboard import render_salary_dashboard
+from components.model_selector import model_selector
 from config_loader import load_json
 from utils.i18n import tr
 from state.ensure_state import ensure_state
@@ -81,7 +82,7 @@ with st.sidebar:
     st.session_state.auto_reask = st.toggle(
         "Auto Follow-ups", value=st.session_state.auto_reask
     )
-    st.session_state.model = st.text_input("OpenAI Model", value=st.session_state.model)
+    model_selector()
     st.session_state.vector_store_id = st.text_input(
         "Vector Store ID (optional)", value=st.session_state.vector_store_id
     )

--- a/components/model_selector.py
+++ b/components/model_selector.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import streamlit as st
 
 from config import OPENAI_MODEL
+from constants.keys import UIKeys
 
 
-def model_selector(key: str = "llm_model") -> str:
+def model_selector(key: str = "model") -> str:
     """Render a selectbox to allow users to choose the OpenAI model.
 
     Args:
@@ -16,10 +17,12 @@ def model_selector(key: str = "llm_model") -> str:
     Returns:
         The chosen model identifier.
     """
-    models = ["gpt-5-nano", "gpt-4.1-nano"]
+    models = ["gpt-5-nano", "gpt-4.1-nano", "gpt-3.5-turbo"]
     default = st.session_state.get(key, OPENAI_MODEL)
     if default not in models:
         default = models[0]
-    model = st.selectbox("Model", models, index=models.index(default))
+    model = st.selectbox(
+        "Model", models, index=models.index(default), key=UIKeys.MODEL_SELECT
+    )
     st.session_state[key] = model
     return model

--- a/components/salary_dashboard.py
+++ b/components/salary_dashboard.py
@@ -3,6 +3,7 @@
 from typing import Any, Sequence, Tuple
 
 import streamlit as st
+from config import OPENAI_MODEL
 
 
 # ``openai_utils`` is an optional dependency. Import lazily so that the
@@ -12,6 +13,8 @@ def _call_chat_api(messages: list[dict], **kwargs: Any) -> str:
     """Lazy import wrapper around ``openai_utils.call_chat_api``."""
     from openai_utils import call_chat_api
 
+    if "model" not in kwargs:
+        kwargs["model"] = st.session_state.get("model", OPENAI_MODEL)
     res = call_chat_api(messages, **kwargs)
     return (res.content or "") if hasattr(res, "content") else str(res)
 

--- a/constants/keys.py
+++ b/constants/keys.py
@@ -5,6 +5,7 @@ class UIKeys:
     JD_FILE_UPLOADER = "ui.jd_file_uploader"
     JD_URL_INPUT = "ui.jd_url_input"
     LANG_SELECT = "ui.lang_select"
+    MODEL_SELECT = "ui.model_select"
 
 
 class StateKeys:

--- a/question_logic.py
+++ b/question_logic.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
+import streamlit as st
 from openai_utils import call_chat_api
 
 # ESCO helpers (must exist in core/esco_utils.py)
@@ -310,13 +311,17 @@ def _normalize_chat_content(res: Any) -> str:
 
 
 def ask_followups(
-    payload: dict, *, model: str = "gpt-4o-mini", vector_store_id: Optional[str] = None
+    payload: dict,
+    *,
+    model: str | None = None,
+    vector_store_id: Optional[str] = None,
 ) -> dict:
     """Generate follow-up questions via the chat API.
 
     Args:
         payload: Vacancy JSON payload to inspect.
-        model: OpenAI model identifier.
+        model: Optional OpenAI model identifier. Uses the globally selected
+            model when ``None``.
         vector_store_id: Optional vector store ID enabling file search tool usage.
 
     Returns:
@@ -324,6 +329,8 @@ def ask_followups(
         parsing fails or the response is invalid.
     """
 
+    if model is None:
+        model = st.session_state.get("model", OPENAI_MODEL)
     tools: list[Any] = []
     tool_choice: Optional[str] = None
     if vector_store_id:

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -1,5 +1,6 @@
 import openai_utils
 import core.esco_utils as esco_utils
+import streamlit as st
 
 
 def test_suggest_additional_skills_model(monkeypatch):
@@ -27,4 +28,19 @@ def test_suggest_benefits_model(monkeypatch):
     monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
     out = openai_utils.suggest_benefits("Engineer", lang="en", model="gpt-4")
     assert captured["model"] == "gpt-4"
+    assert out == ["BenefitA", "BenefitB"]
+
+
+def test_session_state_model_default(monkeypatch):
+    captured = {}
+    st.session_state.clear()
+    st.session_state["model"] = "gpt-4.1-nano"
+
+    def fake_call_chat_api(messages, model=None, **kwargs):
+        captured["model"] = model
+        return "- BenefitA\n- BenefitB"
+
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call_chat_api)
+    out = openai_utils.suggest_benefits("Engineer")
+    assert captured["model"] == "gpt-4.1-nano"
     assert out == ["BenefitA", "BenefitB"]


### PR DESCRIPTION
## Summary
- add gpt-5-nano and gpt-4.1-nano options in model selector and sidebar UI
- route OpenAI calls through session-selected model across utilities and salary dashboard
- cover model selection in tests

## Testing
- `black components/model_selector.py constants/keys.py app.py openai_utils.py question_logic.py components/salary_dashboard.py tests/test_model_selection.py tests/test_openai_utils.py`
- `ruff check components/model_selector.py constants/keys.py app.py openai_utils.py question_logic.py components/salary_dashboard.py tests/test_model_selection.py tests/test_openai_utils.py`
- `mypy components/model_selector.py constants/keys.py app.py openai_utils.py question_logic.py components/salary_dashboard.py tests/test_model_selection.py tests/test_openai_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b005000fbc8320bef4f9e1264f7525