### PR TITLE
feat: add reasoning effort selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - **API helper**: `call_chat_api` now returns a unified `ChatCallResult` and supports OpenAI function calls for reliable extraction
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance (now up to 12 by default), shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
 - **Auto re‑ask loop**: optional toggle that keeps asking follow-up questions automatically until all critical fields are filled, with clear progress messages and a stop button for user control.
+- **Reasoning effort control**: select low, medium, or high reasoning depth with an environment-variable default.
 - **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts, HR software for human resource professionals, engineering tools for civil engineers, cuisine specialties for chefs).
 - **ESCO‑Power**: occupation classification + essential skill gaps
 - **Offline-ready ESCO**: set `VACAYSER_OFFLINE=1` to use cached occupations and skills without API calls

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import streamlit as st
 
 from components.salary_dashboard import render_salary_dashboard
 from components.model_selector import model_selector
+from components.reasoning_selector import reasoning_selector
 from config_loader import load_json
 from utils.i18n import tr
 from state.ensure_state import ensure_state
@@ -83,6 +84,7 @@ with st.sidebar:
         "Auto Follow-ups", value=st.session_state.auto_reask
     )
     model_selector()
+    reasoning_selector()
     st.session_state.vector_store_id = st.text_input(
         "Vector Store ID (optional)", value=st.session_state.vector_store_id
     )

--- a/components/reasoning_selector.py
+++ b/components/reasoning_selector.py
@@ -1,0 +1,31 @@
+"""Reasoning level selection component for Streamlit UI."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from config import REASONING_EFFORT
+from constants.keys import UIKeys
+
+
+def reasoning_selector(key: str = "reasoning_effort") -> str:
+    """Render a selectbox to choose model reasoning effort.
+
+    Args:
+        key: Session key to store the selected reasoning level.
+
+    Returns:
+        The selected reasoning effort level.
+    """
+    levels = ["low", "medium", "high"]
+    default = st.session_state.get(key, REASONING_EFFORT)
+    if default not in levels:
+        default = "medium"
+    effort = st.selectbox(
+        "Reasoning Effort",
+        levels,
+        index=levels.index(default),
+        key=UIKeys.REASONING_SELECT,
+    )
+    st.session_state[key] = effort
+    return effort

--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ CHUNK_OVERLAP = 0.1
 STREAMLIT_ENV = os.getenv("STREAMLIT_ENV", "development")
 DEFAULT_LANGUAGE = os.getenv("LANGUAGE", "en")
 DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "gpt-5-nano")
+REASONING_EFFORT = os.getenv("REASONING_EFFORT", "medium")
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "").strip()
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", DEFAULT_MODEL)
@@ -31,6 +32,11 @@ try:
     VECTOR_STORE_ID = openai_secrets.get("VECTOR_STORE_ID", VECTOR_STORE_ID)
 except Exception:
     openai_secrets = None
+
+try:
+    REASONING_EFFORT = st.secrets.get("REASONING_EFFORT", REASONING_EFFORT)
+except Exception:
+    pass
 
 if OPENAI_API_KEY:
     try:

--- a/constants/keys.py
+++ b/constants/keys.py
@@ -6,6 +6,7 @@ class UIKeys:
     JD_URL_INPUT = "ui.jd_url_input"
     LANG_SELECT = "ui.lang_select"
     MODEL_SELECT = "ui.model_select"
+    REASONING_SELECT = "ui.reasoning_select"
 
 
 class StateKeys:

--- a/llm/client.py
+++ b/llm/client.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 
 from jsonschema import Draft7Validator
 from openai import OpenAI
+import streamlit as st
 
 from .context import build_extract_messages
 from .prompts import FIELDS_ORDER
@@ -17,6 +18,7 @@ from models.need_analysis import NeedAnalysisProfile
 from core.errors import ExtractionError, JsonInvalid
 from utils.json_parse import parse_extraction
 from utils.retry import retry
+from config import REASONING_EFFORT
 
 logger = logging.getLogger("vacalyser.llm")
 
@@ -143,7 +145,13 @@ def extract_json(
     messages = (
         _minimal_messages(text) if minimal else build_extract_messages(text, title, url)
     )
-    common: dict[str, Any] = {"model": MODEL, "messages": messages, "temperature": 0}
+    effort = st.session_state.get("reasoning_effort", REASONING_EFFORT)
+    common: dict[str, Any] = {
+        "model": MODEL,
+        "messages": messages,
+        "temperature": 0,
+        "reasoning": {"effort": effort},
+    }
     # Some SDKs support deterministic seeds
     common["seed"] = 42
 

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -17,7 +17,7 @@ import backoff
 from openai import OpenAI
 import streamlit as st
 
-from config import OPENAI_API_KEY, OPENAI_MODEL
+from config import OPENAI_API_KEY, OPENAI_MODEL, REASONING_EFFORT
 from constants.keys import StateKeys
 
 
@@ -70,17 +70,39 @@ def call_chat_api(
     functions: Optional[list] = None,
     function_call: Optional[Any] = None,
     seed: Optional[int] = None,
+    reasoning_effort: str | None = None,
     extra: Optional[dict] = None,
 ) -> ChatCallResult:
-    """Call the OpenAI chat completion API and return a :class:`ChatCallResult`."""
+    """Call the OpenAI chat completion API and return a :class:`ChatCallResult`.
+
+    Args:
+        messages: Conversation messages.
+        model: Optional model override.
+        temperature: Sampling temperature.
+        max_tokens: Response token limit.
+        json_strict: Enforce JSON output.
+        tools: Tool definitions for tool calling.
+        tool_choice: Requested tool to call.
+        functions: Function definitions.
+        function_call: Forced function call.
+        seed: Optional deterministic seed.
+        reasoning_effort: Reasoning level to pass to the API.
+        extra: Additional payload fields.
+
+    Returns:
+        Parsed result from the OpenAI API.
+    """
 
     if model is None:
         model = st.session_state.get("model", OPENAI_MODEL)
+    if reasoning_effort is None:
+        reasoning_effort = st.session_state.get("reasoning_effort", REASONING_EFFORT)
     payload: Dict[str, Any] = {
         "model": model,
         "messages": messages,
         "temperature": temperature,
     }
+    payload["reasoning"] = {"effort": reasoning_effort}
     if max_tokens is not None:
         payload["max_tokens"] = max_tokens
     if json_strict:

--- a/state/ensure_state.py
+++ b/state/ensure_state.py
@@ -7,6 +7,7 @@ import os
 import streamlit as st
 
 from constants.keys import StateKeys
+from config import REASONING_EFFORT
 from models.need_analysis import NeedAnalysisProfile
 
 
@@ -32,6 +33,8 @@ def ensure_state() -> None:
         st.session_state["vector_store_id"] = os.getenv("VECTOR_STORE_ID", "")
     if "auto_reask" not in st.session_state:
         st.session_state["auto_reask"] = True
+    if "reasoning_effort" not in st.session_state:
+        st.session_state["reasoning_effort"] = REASONING_EFFORT
     if StateKeys.USAGE not in st.session_state:
         st.session_state[StateKeys.USAGE] = {"input_tokens": 0, "output_tokens": 0}
     for key in (


### PR DESCRIPTION
## Summary
- add reasoning effort selectbox with env default
- include reasoning payload when calling OpenAI API
- plumb reasoning effort through LLM client and session state

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b00acc8e508320802e4615c715041e