### PR TITLE
feat: migrate to OpenAI Responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **One‑hop extraction**: Parse PDFs/DOCX/URLs into 20+ fields
 - **Structured output**: function calling/JSON mode ensures valid responses
 - **Instant overview**: review extracted fields in a compact tabbed table before continuing
-- **API helper**: `call_chat_api` now returns a unified `ChatCallResult` and supports OpenAI function calls for reliable extraction
+- **API helper**: `call_chat_api` wraps the OpenAI Responses API with tool and JSON schema support, returning a unified `ChatCallResult`
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance (now up to 12 by default), shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
 - **Auto re‑ask loop**: optional toggle that keeps asking follow-up questions automatically until all critical fields are filled, with clear progress messages and a stop button for user control.
 - **Reasoning effort control**: select low, medium, or high reasoning depth with an environment-variable default.

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,30 +1,21 @@
 import json
-from llm.client import extract_and_parse, OPENAI_CLIENT
+from llm.client import OPENAI_CLIENT, extract_and_parse
 
 
-class _Msg:
-    def __init__(self, content: str) -> None:
-        self.content = content
-        self.function_call = None
-
-
-class _Choice:
-    def __init__(self, msg: _Msg) -> None:
-        self.message = msg
-
-
-class _Resp:
-    def __init__(self, msg: _Msg) -> None:
-        self.choices = [_Choice(msg)]
+class _FakeResponse:
+    def __init__(self, text: str) -> None:
+        self.output_text = text
+        self.output: list[dict[str, str]] = []
+        self.usage: dict[str, int] = {}
 
 
 def fake_create(**kwargs):
     payload = {"company": {"name": "Acme"}, "position": {"job_title": "Dev"}}
-    return _Resp(_Msg(json.dumps(payload)))
+    return _FakeResponse(json.dumps(payload))
 
 
 def test_extract_and_parse(monkeypatch) -> None:
-    monkeypatch.setattr(OPENAI_CLIENT.chat.completions, "create", fake_create)
+    monkeypatch.setattr(OPENAI_CLIENT.responses, "create", fake_create)
     out = extract_and_parse("text")
     assert out.company.name == "Acme"
     assert out.position.job_title == "Dev"

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -7,52 +7,35 @@ import pytest
 import llm.client as client
 
 
-class _FakeFunctionCall:
-    """Minimal stand-in for OpenAI function call payload."""
-
-    def __init__(self, arguments: str | None = None) -> None:
-        self.arguments = arguments
-
-
-class _FakeMessage:
-    """Minimal message object returned by the OpenAI client."""
-
-    def __init__(
-        self, content: str = "", function_call: _FakeFunctionCall | None = None
-    ) -> None:
-        self.content = content
-        self.function_call = function_call
-
-
-class _FakeChoice:
-    """Container mimicking a chat completion choice."""
-
-    def __init__(self, message: _FakeMessage) -> None:
-        self.message = message
-
-
 class _FakeResponse:
-    """Simplified response holding a single choice."""
+    """Minimal stand-in for an OpenAI Responses API result."""
 
-    def __init__(self, message: _FakeMessage) -> None:
-        self.choices = [_FakeChoice(message)]
+    def __init__(self, text: str = "{}", arguments: str | None = None) -> None:
+        self.output_text = text
+        self.output: list[dict[str, str]] = []
+        if arguments is not None:
+            self.output.append(
+                {
+                    "type": "function_call",
+                    "name": "return_extraction",
+                    "arguments": arguments,
+                }
+            )
+        self.usage: dict[str, int] = {}
 
 
 def fake_create(**kwargs):  # noqa: D401
     """Return a fake OpenAI response object."""
 
     if client.MODE == "function":
-        msg = _FakeMessage(
-            function_call=_FakeFunctionCall(arguments=json.dumps({"job_title": "x"}))
-        )
-        return _FakeResponse(msg)
-    return _FakeResponse(_FakeMessage(content="{}"))
+        return _FakeResponse(arguments=json.dumps({"job_title": "x"}))
+    return _FakeResponse(text="{}")
 
 
 def test_extract_json_smoke(monkeypatch):
     """Smoke test for the extraction helper."""
 
-    monkeypatch.setattr(client.OPENAI_CLIENT.chat.completions, "create", fake_create)
+    monkeypatch.setattr(client.OPENAI_CLIENT.responses, "create", fake_create)
     out = client.extract_json("text")
     assert isinstance(out, str) and out != ""
 

--- a/tests/test_question_logic.py
+++ b/tests/test_question_logic.py
@@ -102,8 +102,8 @@ def test_rag_suggestions_tool_payload(monkeypatch) -> None:
 
     _rag_suggestions("Engineer", "Tech", ["location"], vector_store_id="vs123")
 
-    assert captured["tools"] == [{"type": "custom", "name": "file_search"}]
+    assert captured["tools"] == [
+        {"type": "file_search", "vector_store_ids": ["vs123"]}
+    ]
     assert captured["tool_choice"] == "auto"
-    assert captured["extra"] == {
-        "tool_resources": {"file_search": {"vector_store_ids": ["vs123"]}}
-    }
+    assert captured.get("extra") in (None, {})


### PR DESCRIPTION
## Summary
- switch to `client.responses.create` for all OpenAI calls
- support JSON schemas and tool calls in `call_chat_api`
- refactor LLM client and follow-up logic for Responses API

## Testing
- `ruff check .`
- `black openai_utils.py llm/client.py question_logic.py tests/test_openai_utils.py tests/test_llm_client.py tests/test_llm.py`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b00d59240c8320899e4ffd4dc262b1