### PR TITLE
feat: simplify LLM extraction

### DIFF
--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,7 +1,5 @@
 """Tests for the OpenAI LLM client helper."""
 
-import json
-
 import pytest
 
 import llm.client as client
@@ -10,25 +8,14 @@ import llm.client as client
 class _FakeResponse:
     """Minimal stand-in for an OpenAI Responses API result."""
 
-    def __init__(self, text: str = "{}", arguments: str | None = None) -> None:
+    def __init__(self, text: str = "{}") -> None:
         self.output_text = text
-        self.output: list[dict[str, str]] = []
-        if arguments is not None:
-            self.output.append(
-                {
-                    "type": "function_call",
-                    "name": "return_extraction",
-                    "arguments": arguments,
-                }
-            )
         self.usage: dict[str, int] = {}
 
 
 def fake_create(**kwargs):  # noqa: D401
     """Return a fake OpenAI response object."""
 
-    if client.MODE == "function":
-        return _FakeResponse(arguments=json.dumps({"job_title": "x"}))
     return _FakeResponse(text="{}")
 
 


### PR DESCRIPTION
## Summary
- simplify structured extraction via JSON schema mode and plain fallback
- remove legacy function-calling paths and default to configured model
- adjust unit tests for streamlined client

## Testing
- `black llm/client.py tests/test_llm_client.py`
- `ruff check llm/client.py tests/test_llm_client.py`
- `mypy llm`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0159cacfc832083bca819a8426036