### PR TITLE
feat: support json responses for followups and suggestions

### DIFF
--- a/question_logic.py
+++ b/question_logic.py
@@ -34,7 +34,6 @@ from core.esco_utils import (
 )
 from config import OPENAI_API_KEY, OPENAI_MODEL, VECTOR_STORE_ID
 
-DEFAULT_LOW_COST_MODEL = OPENAI_MODEL
 # Optional OpenAI vector store ID for RAG suggestions; set via env/secrets.
 # If unset or blank, RAG lookups are skipped.
 RAG_VECTOR_STORE_ID = VECTOR_STORE_ID
@@ -235,7 +234,7 @@ def _rag_suggestions(
     vector_store_id = vector_store_id or RAG_VECTOR_STORE_ID
     if not vector_store_id:
         return {}
-    model = model or DEFAULT_LOW_COST_MODEL
+    model = model or st.session_state.get("model", OPENAI_MODEL)
     sys = (
         "You provide short, concrete suggestions to help complete a vacancy profile. "
         "Use retrieved context; if none, return empty arrays. Respond as a JSON object "


### PR DESCRIPTION
## Summary
- fetch RAG suggestions and follow-ups using the session's configured model
- request JSON-formatted outputs for skill, benefit and task suggestions
- parse suggestion responses as JSON with line-split fallback

## Testing
- `black openai_utils.py question_logic.py`
- `ruff check openai_utils.py question_logic.py`
- `mypy openai_utils.py question_logic.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0176521488320b1ffc98d0ae6d2d1