### PR TITLE
feat: integrate tool calls for analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 - **One‑hop extraction**: Parse PDFs/DOCX/URLs into 20+ fields
 - **Structured output**: function calling/JSON mode ensures valid responses
 - **Instant overview**: review extracted fields in a compact tabbed table before continuing
-- **API helper**: `call_chat_api` wraps the OpenAI Responses API with tool and JSON schema support, returning a unified `ChatCallResult`
+- **API helper**: `call_chat_api` wraps the OpenAI Responses API with tool and JSON schema support, automatically executing mapped tools and returning a unified `ChatCallResult`
+- **Analysis tools**: built-in `get_salary_benchmark` and `get_skill_definition` functions can be invoked by the model for richer need analysis
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance (now up to 12 by default), shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
 - **Auto re‑ask loop**: optional toggle that keeps asking follow-up questions automatically until all critical fields are filled, with clear progress messages and a stop button for user control.
 - **Reasoning effort control**: select low, medium, or high reasoning depth with an environment-variable default.

--- a/core/analysis_tools.py
+++ b/core/analysis_tools.py
@@ -1,0 +1,105 @@
+"""Domain-specific tools for recruitment need analysis.
+
+This module provides helper functions that the language model can invoke via
+the OpenAI ``tools`` interface. The functions are intentionally lightweight and
+rely on static data so they can run in offline environments and unit tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Mapping, Tuple
+
+
+def get_salary_benchmark(role: str, country: str = "US") -> Dict[str, str]:
+    """Return a naive annual salary benchmark for ``role`` in ``country``.
+
+    The values are illustrative only. A production implementation should query
+    a dedicated compensation API or database.
+
+    Args:
+        role: Job title to look up.
+        country: ISO country code.
+
+    Returns:
+        Dictionary with key ``salary_range`` describing the estimated salary.
+    """
+
+    data: Dict[str, Dict[str, str]] = {
+        "software developer": {"US": "$90k-$130k", "DE": "€60k-€85k"},
+        "data scientist": {"US": "$95k-$140k", "DE": "€65k-€90k"},
+    }
+    role_key = role.lower().strip()
+    country_key = country.upper().strip()
+    salary = data.get(role_key, {}).get(country_key, "unknown")
+    return {"salary_range": salary}
+
+
+def get_skill_definition(skill: str) -> Dict[str, str]:
+    """Return a short definition for a given ``skill``.
+
+    Args:
+        skill: Name of the skill.
+
+    Returns:
+        Dictionary with key ``definition`` holding a description.
+    """
+
+    definitions: Dict[str, str] = {
+        "python": "A high-level programming language known for readability.",
+        "project management": "Planning and overseeing projects to meet goals.",
+    }
+    definition = definitions.get(skill.lower().strip(), "definition unavailable")
+    return {"definition": definition}
+
+
+def build_analysis_tools() -> Tuple[list[dict], Mapping[str, Callable[..., Any]]]:
+    """Return tool specifications and corresponding callables.
+
+    Returns:
+        Tuple containing a list of tool spec dictionaries and a mapping from
+        tool name to callable.
+    """
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_salary_benchmark",
+                "description": "Fetch a rough annual salary range for a role in a country.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "role": {"type": "string"},
+                        "country": {"type": "string"},
+                    },
+                    "required": ["role"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "get_skill_definition",
+                "description": "Return a concise definition for a skill.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "skill": {"type": "string"},
+                    },
+                    "required": ["skill"],
+                },
+            },
+        },
+    ]
+    funcs: Mapping[str, Callable[..., Any]] = {
+        "get_salary_benchmark": get_salary_benchmark,
+        "get_skill_definition": get_skill_definition,
+    }
+    return tools, funcs
+
+
+__all__ = [
+    "get_salary_benchmark",
+    "get_skill_definition",
+    "build_analysis_tools",
+]

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -1,5 +1,7 @@
 import pytest
 
+from typing import Any
+
 import openai_utils
 from openai_utils import ChatCallResult, call_chat_api, extract_with_function
 
@@ -13,16 +15,19 @@ def test_call_chat_api_raises_when_no_api_key(monkeypatch):
         call_chat_api([{"role": "user", "content": "hi"}])
 
 
-def test_call_chat_api_function_call(monkeypatch):
-    """Function call arguments should be accessible on the returned message."""
+def test_call_chat_api_tool_call(monkeypatch):
+    """Tool call information should be returned to the caller."""
 
     class _FakeResponse:
         def __init__(self) -> None:
-            self.output: list[dict[str, str]] = [
+            self.output: list[dict[str, Any]] = [
                 {
-                    "type": "function_call",
-                    "name": "fn",
-                    "arguments": '{"job_title": "x"}',
+                    "type": "tool_call",
+                    "id": "1",
+                    "function": {
+                        "name": "fn",
+                        "arguments": '{"job_title": "x"}',
+                    },
                 }
             ]
             self.output_text = ""
@@ -39,10 +44,10 @@ def test_call_chat_api_function_call(monkeypatch):
     monkeypatch.setattr("openai_utils.client", _FakeClient(), raising=False)
     out = call_chat_api(
         [],
-        tools=[{"type": "function", "name": "fn", "parameters": {}}],
+        tools=[{"type": "function", "function": {"name": "fn", "parameters": {}}}],
         tool_choice={"type": "function", "name": "fn"},
     )
-    assert out.function_call and out.function_call["arguments"] == '{"job_title": "x"}'
+    assert out.tool_calls[0]["function"]["arguments"] == '{"job_title": "x"}'
 
 
 def test_extract_with_function(monkeypatch):
@@ -52,7 +57,7 @@ def test_extract_with_function(monkeypatch):
         openai_utils,
         "call_chat_api",
         lambda *a, **k: ChatCallResult(
-            None, [], {"arguments": '{"job_title": "Dev"}'}, {}
+            None, [{"function": {"arguments": '{"job_title": "Dev"}'}}], {}
         ),
     )
     from core import schema as cs
@@ -68,3 +73,54 @@ def test_extract_with_function(monkeypatch):
 
     result = extract_with_function("text", {})
     assert result["job_title"] == "Dev"
+
+
+def test_call_chat_api_executes_tool(monkeypatch):
+    """call_chat_api should execute mapped tools and return final content."""
+
+    from core import analysis_tools
+
+    class _FirstResponse:
+        def __init__(self) -> None:
+            self.output = [
+                {
+                    "type": "tool_call",
+                    "id": "1",
+                    "function": {
+                        "name": "get_salary_benchmark",
+                        "arguments": '{"role": "software developer", "country": "US"}',
+                    },
+                }
+            ]
+            self.output_text = ""
+            self.usage: dict[str, int] = {}
+
+    class _SecondResponse:
+        def __init__(self) -> None:
+            self.output: list[dict[str, Any]] = []
+            self.output_text = "done"
+            self.usage: dict[str, int] = {}
+
+    class _FakeResponses:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def create(self, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                return _FirstResponse()
+            assert kwargs["input"][1]["role"] == "tool"
+            return _SecondResponse()
+
+    class _FakeClient:
+        responses = _FakeResponses()
+
+    monkeypatch.setattr("openai_utils.client", _FakeClient(), raising=False)
+    tools, funcs = analysis_tools.build_analysis_tools()
+    res = call_chat_api(
+        [{"role": "user", "content": "hi"}],
+        tools=tools,
+        tool_functions=funcs,
+    )
+    assert res.content == "done"
+    assert res.tool_calls[0]["function"]["name"] == "get_salary_benchmark"

--- a/tests/test_skill_suggestions.py
+++ b/tests/test_skill_suggestions.py
@@ -16,7 +16,7 @@ def fake_call(messages, **kwargs):
             "soft_skills": ["S1", "S2"],
         }
     )
-    return ChatCallResult(payload, [], None, {})
+    return ChatCallResult(payload, [], {})
 
 
 def test_suggest_skills_for_role(monkeypatch):


### PR DESCRIPTION
## Summary
- refactor ChatCallResult and call_chat_api for new tool execution flow
- add salary benchmark and skill definition analysis tools
- document tool usage and cover with tests

## Testing
- `ruff check openai_utils.py core/analysis_tools.py tests/test_openai_utils.py tests/test_skill_suggestions.py`
- `mypy openai_utils.py core/analysis_tools.py tests/test_openai_utils.py tests/test_skill_suggestions.py`
- `PYTHONPATH=. pytest tests/test_openai_utils.py tests/test_skill_suggestions.py`


------
https://chatgpt.com/codex/tasks/task_e_68b019313d0c8320b93540fec4b4a807