### PR TITLE
docs: explain nano model migration and reasoning settings

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,11 @@
+"""Central configuration for Vacalyser's Responses API client.
+
+The application defaults to the lightweight ``gpt-5-nano`` model. Set
+``DEFAULT_MODEL`` or ``OPENAI_MODEL`` to ``gpt-4.1-nano`` to switch models and
+use ``REASONING_EFFORT`` (``low`` | ``medium`` | ``high``) to control how much
+reasoning the model performs by default.
+"""
+
 import os
 import warnings
 


### PR DESCRIPTION
## Summary
- document switch to GPT-5-nano/GPT-4.1-nano reasoning models and Responses API
- add environment variable instructions for model selection and reasoning effort
- describe built-in analysis tools and note migration from Chat Completions

## Testing
- `ruff check .`
- `black config.py`
- `mypy .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0208dc95083208938a936a6b84777