### PR TITLE
fix: enable pydantic email validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 openai>=1.30
 streamlit>=1.33
-pydantic>=2.5
+pydantic[email]>=2.5
 pymupdf>=1.24
 pillow>=10.0
 python-docx>=0.8.11


### PR DESCRIPTION
## Summary
- ensure email validation is available by depending on `pydantic[email]`

## Testing
- `pip install -r requirements.txt`
- `ruff check .`
- `black --check .`
- `mypy .` *(fails: command hung, manual interrupt)*
- `pytest` *(fails: command hung, manual interrupt)*
- `streamlit run app.py --server.headless true`

------
https://chatgpt.com/codex/tasks/task_e_68b024ad811c832080969040fd4e4d1c