### PR TITLE
fix: allow wizard progression despite missing fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ API, enabling JSON schema validation and function/tool calling.
 - **Robust error handling**: user-facing alerts for API or network issues
 - **Cross-field deduplication**: avoids repeating the same information across multiple fields
 - **Tabbed summary**: finalize all sections in inline-editable tabs and regenerate outputs instantly
-- **Missing info alerts**: highlights empty critical fields and blocks navigation until they're filled, letting you jump back to fix them
+- **Missing info alerts**: highlights empty critical fields while allowing navigation so you can fix them later
 - **Boolean Builder 2.0**: interactive search string with selectable skills and title synonyms
 - **Export**: clean JSON profile, job‑ad markdown, interview guide
 - **Customizable interview guides**: choose 3–10 questions, automatically covering responsibilities, culture, and specified hard and soft skills

--- a/wizard.py
+++ b/wizard.py
@@ -2075,7 +2075,6 @@ def run_wizard():
                 tr("Weiter ▶︎", "Next ▶︎"),
                 type="primary",
                 use_container_width=True,
-                disabled=bool(missing),
             ):
                 next_step()
                 st.rerun()
@@ -2094,7 +2093,6 @@ def run_wizard():
                 tr("Weiter ▶︎", "Next ▶︎"),
                 type="primary",
                 use_container_width=True,
-                disabled=bool(missing),
             ):
                 next_step()
                 st.rerun()
@@ -2110,14 +2108,8 @@ def run_wizard():
                     tr("Weiter ▶︎", "Next ▶︎"),
                     type="primary",
                     use_container_width=True,
-                    disabled=bool(missing),
                 ):
                     next_step()
                     st.rerun()
             else:
-                st.button(
-                    tr("Fertig", "Done"),
-                    disabled=bool(
-                        missing_keys(st.session_state[StateKeys.PROFILE], critical)
-                    ),
-                )
+                st.button(tr("Fertig", "Done"))


### PR DESCRIPTION
## Summary
- allow navigating between wizard steps even when critical fields are missing
- update README to reflect non-blocking missing-info alerts

## Testing
- `black wizard.py`
- `ruff check wizard.py`
- `mypy wizard.py --follow-imports=skip --hide-error-context`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b027102910832089faef39ed401308