### PR TITLE
Remove redundant Step 1 instructions from wizard

### DIFF
--- a/wizard.py
+++ b/wizard.py
@@ -2022,14 +2022,7 @@ def run_wizard():
     # Stepbar
     steps = [
         (
-            tr(
-                "Erstellen Sie eine umfassende Informationssammlung zu Ihrer Vakanz "
-                "und nutzen Sie diese Informationen zur Optimierung aller folgenden "
-                "Schritte Ihres Recruitment-Prozesses",
-                "Create a comprehensive information collection for your vacancy and "
-                "use this information to optimize all subsequent steps of your "
-                "recruitment process",
-            ),
+            "",
             _step_intro,
         ),
         (tr("Quelle", "Source"), lambda: _step_source(schema)),
@@ -2047,18 +2040,15 @@ def run_wizard():
 
     # Step Navigation (oben)
     render_stepper(st.session_state[StateKeys.STEP], len(steps))
-    st.caption(
-        tr(
-            "Klicke auf 'Weiter' oder navigiere direkt zu einem Schritt.",
-            "Click 'Next' or navigate directly to a step.",
-        )
-    )
 
     # Render current step
     current = st.session_state[StateKeys.STEP]
     label, renderer = steps[current]
     step_word = tr("Schritt", "Step")
-    st.markdown(f"#### {step_word} {current + 1} — {label}")
+    if label:
+        st.markdown(f"#### {step_word} {current + 1} — {label}")
+    else:
+        st.markdown(f"#### {step_word} {current + 1}")
     renderer()
 
     # Bottom nav


### PR DESCRIPTION
## Summary
- remove verbose description from wizard step 1 and hide navigation caption
- handle empty step labels when rendering headings

## Testing
- `black wizard.py`
- `ruff check wizard.py`
- `mypy wizard.py` *(failed: produced excessive log output and could not complete)*
- `pytest -q` *(failed: ImportError: email-validator is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b02ac5225083208dae8c61208f965d