### PR TITLE
fix: reset to first step on wizard completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ API, enabling JSON schema validation and function/tool calling.
 
 ## Highlights
 - **Dynamic Wizard**: multi‑step, bilingual (EN/DE), low‑friction inputs with tabbed text/upload/URL choices and auto-start analysis
+- **Restart option**: clicking "Done" returns to the first step to begin another profile
 - **Manual entry option**: skip the upload step and start with an empty profile
 - **Extraction feedback**: review detected base data before continuing
 - **Guided error messages**: clear hints when uploads or URLs fail

--- a/wizard.py
+++ b/wizard.py
@@ -2112,4 +2112,8 @@ def run_wizard():
                     next_step()
                     st.rerun()
             else:
-                st.button(tr("Fertig", "Done"))
+                if st.button(
+                    tr("Fertig", "Done"), type="primary", use_container_width=True
+                ):
+                    st.session_state[StateKeys.STEP] = 0
+                    st.rerun()


### PR DESCRIPTION
## Summary
- restart wizard from the first step when clicking **Done**
- document restart option in README

## Testing
- `ruff check .`
- `black .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b02b012b548320ae1f79d5a5066bd7