### PR TITLE
feat: improve wizard critical field flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ API, enabling JSON schema validation and function/tool calling.
 - **Dynamic Wizard**: multi‑step, bilingual (EN/DE), low‑friction inputs with tabbed text/upload/URL choices and auto-start analysis
 - **Restart option**: clicking "Done" returns to the first step to begin another profile
 - **Manual entry option**: skip the upload step and start with an empty profile
+- **Critical field checks**: wizard blocks navigation until essential fields are filled and highlights missing inputs inline
 - **Extraction feedback**: review detected base data before continuing
 - **Guided error messages**: clear hints when uploads or URLs fail
 - **Upfront language switch**: choose German or English before entering any data

--- a/critical_fields.json
+++ b/critical_fields.json
@@ -1,6 +1,10 @@
 {
-  "critical": [
-    "position.role_summary",
-    "location.country"
-  ]
+    "critical": [
+        "company.name",
+        "position.job_title",
+        "position.role_summary",
+        "location.country",
+        "requirements.hard_skills_required",
+        "requirements.soft_skills_required"
+    ]
 }

--- a/tests/test_autodetect_lang.py
+++ b/tests/test_autodetect_lang.py
@@ -1,0 +1,13 @@
+"""Tests for automatic language detection."""
+
+import streamlit as st
+
+from wizard import _autodetect_lang
+
+
+def test_autodetect_lang_switches_to_english() -> None:
+    """English text should switch session language to 'en'."""
+    st.session_state.clear()
+    st.session_state["lang"] = "de"
+    _autodetect_lang("We are looking for a Software Engineer")
+    assert st.session_state["lang"] == "en"

--- a/tests/test_missing_critical_fields.py
+++ b/tests/test_missing_critical_fields.py
@@ -8,13 +8,19 @@ from wizard import FIELD_SECTION_MAP, get_missing_critical_fields
 def test_section_filtering() -> None:
     """Fields beyond the inspected section should be ignored."""
     st.session_state.clear()
-    st.session_state["position.job_title"] = "Engineer"
-    st.session_state["company.name"] = "Acme"
-    st.session_state["location.primary_city"] = "Berlin"
-    st.session_state["location.country"] = "DE"
     st.session_state["followup_questions"] = []
 
+    missing = get_missing_critical_fields(max_section=1)
+    assert "company.name" in missing and "position.job_title" in missing
+
+    st.session_state["company.name"] = "Acme"
+    missing = get_missing_critical_fields(max_section=1)
+    assert "company.name" not in missing and "position.job_title" in missing
+
+    st.session_state["position.job_title"] = "Engineer"
+    st.session_state["location.country"] = "DE"
     assert get_missing_critical_fields(max_section=1) == []
+
     missing = get_missing_critical_fields(max_section=2)
     assert "position.role_summary" in missing
 


### PR DESCRIPTION
## Summary
- enforce navigation only when critical fields filled
- allow skipping source step with clean state
- detect English job ads automatically

## Testing
- `python -m black tests/test_missing_critical_fields.py tests/test_autodetect_lang.py wizard.py`
- `ruff check wizard.py tests/test_missing_critical_fields.py tests/test_autodetect_lang.py`
- `mypy wizard.py tests/test_missing_critical_fields.py tests/test_autodetect_lang.py`
- `PYTHONPATH=$PWD pytest tests/test_missing_critical_fields.py tests/test_autodetect_lang.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0308e4dd88320a917c394326e872c