### PR TITLE
feat: suggest benefits and follow-up chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ API, enabling JSON schema validation and function/tool calling.
 - **API helper**: `call_chat_api` wraps the OpenAI Responses API with tool and JSON schema support, automatically executing mapped tools and returning a unified `ChatCallResult`
 - **Analysis tools**: built-in `get_salary_benchmark` and `get_skill_definition` functions can be invoked by the model for richer need analysis
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance (now up to 12 by default), shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
+- **Follow-up suggestion chips**: if the assistant proposes possible answers, they appear as one-click chips above the input field.
+- **AI-powered benefit suggestions**: fetch common perks for the role/industry and add them to the profile with a single click.
 - **Auto re‑ask loop**: optional toggle that keeps asking follow-up questions automatically until all critical fields are filled, with clear progress messages and a stop button for user control.
 - **Reasoning effort control**: select low, medium, or high reasoning depth with an environment-variable default.
 - **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts, HR software for human resource professionals, engineering tools for civil engineers, cuisine specialties for chefs).

--- a/constants/keys.py
+++ b/constants/keys.py
@@ -21,4 +21,5 @@ class StateKeys:
     BOOLEAN_STR = "data.boolean_str"
     INTERVIEW_GUIDE_MD = "data.interview_md"
     SKILL_SUGGESTIONS = "skill_suggestions"
+    BENEFIT_SUGGESTIONS = "benefit_suggestions"
     EXTRACTION_SUMMARY = "extraction_summary"

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -743,8 +743,16 @@ def suggest_benefits(
             if perk:
                 benefits.append(perk)
     existing_set = {b.strip().lower() for b in existing_benefits.splitlines()}
-    benefits = [b for b in benefits if b.strip().lower() not in existing_set]
-    return benefits
+    filtered = [b for b in benefits if b.strip().lower() not in existing_set]
+    seen: set[str] = set()
+    unique: list[str] = []
+    for b in filtered:
+        key = b.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(b)
+    return unique
 
 
 def suggest_role_tasks(

--- a/tests/test_benefit_suggestions.py
+++ b/tests/test_benefit_suggestions.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import sys
+import json
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+import openai_utils
+from openai_utils import ChatCallResult, suggest_benefits
+
+
+def fake_call(messages, **kwargs):
+    payload = json.dumps(["A", "B", "A", ""])  # duplicates and blank
+    return ChatCallResult(payload, [], {})
+
+
+def test_suggest_benefits(monkeypatch):
+    monkeypatch.setattr(openai_utils, "call_chat_api", fake_call)
+    out = suggest_benefits("Engineer", existing_benefits="B")
+    assert out == ["A"]
+
+
+def test_suggest_benefits_empty():
+    assert suggest_benefits("") == []


### PR DESCRIPTION
## Summary
- Normalize requirement skills via ESCO when advancing past the requirements step
- Add benefit suggestion helper to compensation step and persist recommendations
- Render LLM follow-up suggestions as clickable chips for faster responses

## Testing
- `python -m black openai_utils.py tests/test_benefit_suggestions.py constants/keys.py wizard.py`
- `ruff check openai_utils.py wizard.py constants/keys.py tests/test_benefit_suggestions.py`
- `mypy openai_utils.py wizard.py constants/keys.py tests/test_benefit_suggestions.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b033e17c788320be9caa694b484b14