### PR TITLE
feat: add tone and question controls for guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ API, enabling JSON schema validation and function/tool calling.
 - **Export**: clean JSON profile, job‑ad markdown, interview guide
 - **Customizable interview guides**: choose 3–10 questions, automatically covering responsibilities, culture, and specified hard and soft skills
 - **Tone control**: pick formal, casual, creative, or diversity-focused styles for job ads and interview guides
+- **Audience-specific guides**: tailor interview guides for general, technical, or HR interviewers
 - **Comprehensive job ads**: generated ads now mention requirements, salary and work policy when provided
 - **Employer branding**: company mission and culture flow into job ads and interview guides
 - **Culture-aware interviews**: German guides automatically include a question on cultural fit when a company culture is specified

--- a/constants/keys.py
+++ b/constants/keys.py
@@ -7,6 +7,9 @@ class UIKeys:
     LANG_SELECT = "ui.lang_select"
     MODEL_SELECT = "ui.model_select"
     REASONING_SELECT = "ui.reasoning_select"
+    TONE_SELECT = "ui.summary.tone"
+    NUM_QUESTIONS = "ui.summary.num_questions"
+    AUDIENCE_SELECT = "ui.summary.audience"
 
 
 class StateKeys:

--- a/tone_presets.json
+++ b/tone_presets.json
@@ -1,14 +1,14 @@
 {
-  "en": {
-    "formal": "clear, professional, and concise",
-    "casual": "friendly, approachable, and direct",
-    "creative": "engaging, vivid, and persuasive",
-    "diversity_focused": "inclusive, welcoming, and bias-aware"
-  },
-  "de": {
-    "formal": "klar, professionell und prägnant",
-    "casual": "freundlich, nahbar und direkt",
-    "creative": "ansprechend, lebendig und überzeugend",
-    "diversity_focused": "inklusiv, einladend und vorurteilsbewusst"
-  }
+    "en": {
+        "formal": "professional and helpful",
+        "casual": "friendly, approachable, and direct",
+        "creative": "creative and engaging",
+        "diversity_focused": "inclusive, welcoming, and bias-aware",
+    },
+    "de": {
+        "formal": "professionell und hilfreich",
+        "casual": "freundlich, nahbar und direkt",
+        "creative": "kreativ und inspirierend",
+        "diversity_focused": "inklusiv, einladend und vorurteilsbewusst",
+    },
 }


### PR DESCRIPTION
## Summary
- enable tone presets and question count for interview guides
- allow optional audience targeting and pass company culture
- improve interview guide error handling

## Testing
- `ruff check .`
- `black .`
- `mypy wizard.py constants/keys.py` *(fails: interrupted)*
- `pytest` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b038d2b9bc8320bd4bb70a2040b564