### PR TITLE
Improve ESCO classification and offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ API, enabling JSON schema validation and function/tool calling.
 - **Reasoning effort control**: select low, medium, or high reasoning depth with an environment-variable default.
 - **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts, HR software for human resource professionals, engineering tools for civil engineers, cuisine specialties for chefs).
 - **ESCO‑Power**: occupation classification + essential skill gaps
-- **Offline-ready ESCO**: set `VACAYSER_OFFLINE=1` to use cached occupations and skills without API calls
+- **Offline-ready ESCO**: set `VACAYSER_OFFLINE=1` to use cached occupations and skills without API calls; data comes from `integrations/esco_offline.json` and covers common roles, unmatched titles simply skip enrichment
 - **Cached ESCO calls**: Streamlit caching avoids repeated API requests
+- **Auto-filled skills**: essential ESCO skills merge into required skills; generic entries like "Communication" are ignored so follow-ups stay relevant
 - **RAG‑Assist**: use your vector store to fill/contextualize
 - **Reasoning models**: GPT‑5-nano by default (switchable to GPT‑4.1-nano) via
   the Responses API for better reasoning, JSON mode and tool calling at lower

--- a/integrations/esco_offline.json
+++ b/integrations/esco_offline.json
@@ -1,0 +1,57 @@
+{
+  "occupations": {
+    "software engineer": {
+      "preferredLabel": "Software developers",
+      "uri": "http://data.europa.eu/esco/occupation/12345",
+      "group": "Information and communications technology professionals"
+    },
+    "project manager": {
+      "preferredLabel": "Project managers",
+      "uri": "http://data.europa.eu/esco/occupation/pm",
+      "group": "Business services managers"
+    },
+    "nurse": {
+      "preferredLabel": "Nursing professionals",
+      "uri": "http://data.europa.eu/esco/occupation/nurse",
+      "group": "Health professionals"
+    },
+    "sales representative": {
+      "preferredLabel": "Sales representatives",
+      "uri": "http://data.europa.eu/esco/occupation/sales_rep",
+      "group": "Sales workers"
+    },
+    "data scientist": {
+      "preferredLabel": "Data scientists",
+      "uri": "http://data.europa.eu/esco/occupation/data_scientist",
+      "group": "Information and communications technology professionals"
+    }
+  },
+  "skills": {
+    "http://data.europa.eu/esco/occupation/12345": [
+      "Python",
+      "Agile methodologies",
+      "Version control"
+    ],
+    "http://data.europa.eu/esco/occupation/pm": [
+      "Project management",
+      "Risk management",
+      "Stakeholder communication"
+    ],
+    "http://data.europa.eu/esco/occupation/nurse": [
+      "Patient care",
+      "Medical record keeping",
+      "Infection control"
+    ],
+    "http://data.europa.eu/esco/occupation/sales_rep": [
+      "Communication",
+      "Customer relationship management",
+      "Negotiation",
+      "Sales forecasting"
+    ],
+    "http://data.europa.eu/esco/occupation/data_scientist": [
+      "Machine learning",
+      "Data analysis",
+      "Python"
+    ]
+  }
+}

--- a/llm/client.py
+++ b/llm/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import logging
 from pathlib import Path
 from typing import Any, Optional
@@ -90,7 +91,9 @@ SCHEMA_PATH = (
     Path(__file__).resolve().parent.parent / "schema" / "need_analysis.schema.json"
 )
 with open(SCHEMA_PATH, "r", encoding="utf-8") as _f:
-    NEED_ANALYSIS_SCHEMA = json.load(_f)
+    raw = _f.read()
+    cleaned = re.sub(r",\s*([}\]])", r"\1", raw)
+    NEED_ANALYSIS_SCHEMA = json.loads(cleaned)
 NEED_ANALYSIS_SCHEMA.pop("$schema", None)
 NEED_ANALYSIS_SCHEMA.pop("title", None)
 _assert_closed_schema(NEED_ANALYSIS_SCHEMA)

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -88,10 +88,17 @@ def call_chat_api(
         Parsed result from the OpenAI API.
     """
 
+    from core import analysis_tools
+
     if model is None:
         model = st.session_state.get("model", OPENAI_MODEL)
     if reasoning_effort is None:
         reasoning_effort = st.session_state.get("reasoning_effort", REASONING_EFFORT)
+
+    base_tools, base_funcs = analysis_tools.build_analysis_tools()
+    tools = (tools or []) + base_tools
+    tool_functions = {**base_funcs, **(tool_functions or {})}
+
     payload: Dict[str, Any] = {
         "model": model,
         "input": messages,
@@ -102,7 +109,7 @@ def call_chat_api(
         payload["max_output_tokens"] = max_tokens
     if json_schema is not None:
         payload["text"] = {"format": {"type": "json_schema", **json_schema}}
-    if tools is not None:
+    if tools:
         payload["tools"] = tools
         if tool_choice is not None:
             payload["tool_choice"] = tool_choice

--- a/tests/test_esco_integration.py
+++ b/tests/test_esco_integration.py
@@ -4,7 +4,7 @@ import importlib
 
 
 def test_offline_fallback(monkeypatch):
-    """search_occupation and enrich_skills use fixtures when VACAYSER_OFFLINE is set."""
+    """search_occupation and enrich_skills use offline JSON when enabled."""
     monkeypatch.setenv("VACAYSER_OFFLINE", "1")
     module = importlib.import_module("integrations.esco")
     importlib.reload(module)
@@ -12,6 +12,25 @@ def test_offline_fallback(monkeypatch):
     assert occ["uri"] == "http://data.europa.eu/esco/occupation/12345"
     skills = module.enrich_skills(occ["uri"])
     assert "Python" in skills
+
+
+def test_offline_generic_skills_filtered(monkeypatch):
+    """Generic skills like 'Communication' are filtered out."""
+    monkeypatch.setenv("VACAYSER_OFFLINE", "1")
+    module = importlib.import_module("integrations.esco")
+    importlib.reload(module)
+    occ = module.search_occupation("Sales Representative")
+    skills = module.enrich_skills(occ["uri"])
+    assert "Communication" not in skills
+
+
+def test_offline_unknown_title(monkeypatch):
+    """Unknown titles return empty dict and no crash."""
+    monkeypatch.setenv("VACAYSER_OFFLINE", "1")
+    module = importlib.import_module("integrations.esco")
+    importlib.reload(module)
+    occ = module.search_occupation("Unknown Role")
+    assert occ == {}
 
 
 def test_online_delegation(monkeypatch):

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -101,8 +101,6 @@ def test_extract_with_function(monkeypatch):
 def test_call_chat_api_executes_tool(monkeypatch):
     """call_chat_api should execute mapped tools and return final content."""
 
-    from core import analysis_tools
-
     class _FirstResponse:
         def __init__(self) -> None:
             self.output = [
@@ -110,8 +108,8 @@ def test_call_chat_api_executes_tool(monkeypatch):
                     "type": "tool_call",
                     "id": "1",
                     "function": {
-                        "name": "get_salary_benchmark",
-                        "arguments": '{"role": "software developer", "country": "US"}',
+                        "name": "get_skill_definition",
+                        "arguments": '{"skill": "Python"}',
                     },
                 }
             ]
@@ -139,11 +137,6 @@ def test_call_chat_api_executes_tool(monkeypatch):
         responses = _FakeResponses()
 
     monkeypatch.setattr("openai_utils.client", _FakeClient(), raising=False)
-    tools, funcs = analysis_tools.build_analysis_tools()
-    res = call_chat_api(
-        [{"role": "user", "content": "hi"}],
-        tools=tools,
-        tool_functions=funcs,
-    )
+    res = call_chat_api([{"role": "user", "content": "hi"}])
     assert res.content == "done"
-    assert res.tool_calls[0]["function"]["name"] == "get_salary_benchmark"
+    assert res.tool_calls[0]["function"]["name"] == "get_skill_definition"


### PR DESCRIPTION
## Summary
- refine occupation matching with similarity scoring and graceful group lookup failure handling
- expand offline ESCO dataset and filter generic skills; document auto-filled ESCO skills
- expose analysis tools (salary and skill definitions) to the model by default

## Testing
- `ruff check integrations/esco.py core/esco_utils.py openai_utils.py tests/test_esco_integration.py tests/test_openai_utils.py llm/client.py`
- `mypy integrations/esco.py core/esco_utils.py openai_utils.py tests/test_esco_integration.py tests/test_openai_utils.py llm/client.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b03eed46a88320affc17337ef1b32d