### PR TITLE
feat: extract responsibilities bullet lists

### DIFF
--- a/llm/prompts.py
+++ b/llm/prompts.py
@@ -32,6 +32,7 @@ SYSTEM_JSON_EXTRACTOR: str = (
     "Extract salary ranges like '65.000–85.000 €' into numeric compensation.salary_min and compensation.salary_max and set compensation.currency to an ISO code (e.g. EUR). "
     "If variable pay or bonuses such as '10% Variable' are mentioned, set compensation.variable_pay=true and capture the percentage in compensation.bonus_percentage. "
     "List every benefit/perk separately in compensation.benefits as a JSON array of strings. "
+    "Collect each key task or responsibility (especially bullet points) in responsibilities.items as a JSON array of strings. "
     "Extract start dates (e.g. '01.10.2024', '2024-10-01', 'ab Herbst 2025') into meta.target_start_date in ISO format."
 )
 
@@ -58,7 +59,7 @@ def USER_JSON_EXTRACT_TEMPLATE(
 
     instructions = (
         "Extract the following fields and respond with a JSON object containing these keys. "
-        "If data for a key is missing, use an empty string or empty list. Use position.job_title for the main job title without gender markers and map the employer name to company.name and the primary city to location.primary_city.\n"
+        "If data for a key is missing, use an empty string or empty list. Use position.job_title for the main job title without gender markers and map the employer name to company.name and the primary city to location.primary_city. List each responsibility/task separately in responsibilities.items.\n"
         f"Fields:\n{field_lines}"
     )
 

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -56,3 +56,36 @@ def test_compensation_fallbacks() -> None:
     assert profile.compensation.bonus_percentage == 10.0
     assert profile.compensation.commission_structure
     assert profile.compensation.commission_structure.lower().startswith("bonus")
+
+
+def test_responsibility_fallbacks() -> None:
+    text = (
+        "Dein Spielfeld:\n"
+        "- Features entwickeln\n"
+        "- Team unterstützen\n\n"
+        "Was du mitbringst:\n"
+        "- Python Erfahrung\n"
+    )
+    profile = NeedAnalysisProfile()
+    profile = apply_basic_fallbacks(profile, text)
+    assert profile.responsibilities.items == [
+        "Features entwickeln",
+        "Team unterstützen",
+    ]
+    assert profile.position.role_summary == "Features entwickeln"
+
+
+def test_responsibility_heading_variants() -> None:
+    text = (
+        "Was dich erwartet:\n"
+        "• Kunden beraten\n"
+        "• Angebote erstellen\n"
+        "Dein Profil:\n"
+        "• Kommunikationsstärke\n"
+    )
+    profile = NeedAnalysisProfile()
+    profile = apply_basic_fallbacks(profile, text)
+    assert profile.responsibilities.items == [
+        "Kunden beraten",
+        "Angebote erstellen",
+    ]


### PR DESCRIPTION
## Summary
- expand LLM extraction prompts to record each bullet-task under `responsibilities.items`
- add heuristic parser to recover responsibility bullets and derive role summary when LLM misses them
- test fallback extraction for multiple heading styles

## Testing
- `ruff check ingest/heuristics.py tests/test_heuristics.py llm/prompts.py`
- `black ingest/heuristics.py tests/test_heuristics.py llm/prompts.py`
- `mypy ingest/heuristics.py tests/test_heuristics.py llm/prompts.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b05607e9c08320962f25b45ca3495c