### PR TITLE
feat: enhance requirement parsing

### DIFF
--- a/llm/prompts.py
+++ b/llm/prompts.py
@@ -33,6 +33,11 @@ SYSTEM_JSON_EXTRACTOR: str = (
     "If variable pay or bonuses such as '10% Variable' are mentioned, set compensation.variable_pay=true and capture the percentage in compensation.bonus_percentage. "
     "List every benefit/perk separately in compensation.benefits as a JSON array of strings. "
     "Collect each key task or responsibility (especially bullet points) in responsibilities.items as a JSON array of strings. "
+    "Separate technical vs. social skills: place mandatory hard skills in requirements.hard_skills_required and optional ones in requirements.hard_skills_optional. "
+    "Soft skills like communication or teamwork go into requirements.soft_skills_required or requirements.soft_skills_optional depending on whether they are required or marked as nice-to-have. "
+    "List programming languages, frameworks, and tools in requirements.tools_and_technologies (in addition to hard skill lists). "
+    "Extract spoken language requirements into requirements.languages_required and optional languages into requirements.languages_optional. "
+    "Put mentioned certifications (e.g. 'AWS ML Specialty') into requirements.certifications. "
     "Extract start dates (e.g. '01.10.2024', '2024-10-01', 'ab Herbst 2025') into meta.target_start_date in ISO format."
 )
 

--- a/tests/test_requirements_fallback.py
+++ b/tests/test_requirements_fallback.py
@@ -1,0 +1,31 @@
+"""Tests for requirement heuristics fallback."""
+
+from models.need_analysis import NeedAnalysisProfile
+from ingest.heuristics import apply_basic_fallbacks
+
+
+def test_requirements_split_and_languages() -> None:
+    text = (
+        "Must-haves:\n"
+        "- Python & Data Science Erfahrung\n"
+        "- Du arbeitest analytisch und strukturiert\n"
+        "- AWS ML Specialty certification\n"
+        "- Englisch (Team language)\n"
+        "\n"
+        "Nice-to-haves:\n"
+        "- Docker\n"
+        "- Kommunikationsstärke\n"
+        "- Deutsch nice-to-have\n"
+    )
+    profile = apply_basic_fallbacks(NeedAnalysisProfile(), text)
+
+    r = profile.requirements
+    assert "Python & Data Science Erfahrung" in r.hard_skills_required
+    assert "Docker" in r.hard_skills_optional
+    assert "Du arbeitest analytisch und strukturiert" in r.soft_skills_required
+    assert "Kommunikationsstärke" in r.soft_skills_optional
+    assert "English" in r.languages_required
+    assert "German" in r.languages_optional
+    assert any("aws ml specialty" in c.lower() for c in r.certifications)
+    tools = {t.lower() for t in r.tools_and_technologies}
+    assert "python" in tools and "docker" in tools


### PR DESCRIPTION
## Summary
- refine system extraction prompt to capture optional skills, languages, tools, and certifications
- add heuristics that split must-haves from nice-to-haves and classify soft vs hard skills
- cover requirement fallback logic with unit tests

## Testing
- `black llm/prompts.py ingest/heuristics.py tests/test_requirements_fallback.py`
- `ruff check llm/prompts.py ingest/heuristics.py tests/test_requirements_fallback.py`
- `mypy llm/prompts.py ingest/heuristics.py tests/test_requirements_fallback.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b058d4a0388320a0d36e7c782fb072