### PR TITLE
fix: remove manual rerun on URL change

### DIFF
--- a/wizard.py
+++ b/wizard.py
@@ -140,7 +140,6 @@ def on_url_changed() -> None:
         return
     st.session_state["__prefill_jd_text__"] = txt
     st.session_state["__run_extraction__"] = True
-    st.rerun()
 
 
 def _autodetect_lang(text: str) -> None:


### PR DESCRIPTION
## Summary
- remove `st.rerun()` call from URL change callback to rely on Streamlit's automatic rerun

## Testing
- `black wizard.py`
- `ruff check wizard.py`
- `mypy wizard.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0642a2f148320a94fe5dbcf4c6789