### PR TITLE
fix: unblock wizard when job title missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,7 @@ The project was refactored from the deprecated Chat Completions endpoint to
 function/tool calling. Legacy model flags were removed, and older model options
 are no longer supported.
 Prompt behaviours may differ slightly due to the new reasoning models.
+
+## Changelog
+
+See [docs/CHANGELOG.md](docs/CHANGELOG.md) for recent changes.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- fix: prevent wizard navigation deadlock when job title is missing

--- a/tests/test_missing_critical_fields.py
+++ b/tests/test_missing_critical_fields.py
@@ -10,19 +10,27 @@ def test_section_filtering() -> None:
     st.session_state.clear()
     st.session_state["followup_questions"] = []
 
-    missing = get_missing_critical_fields(max_section=1)
-    assert "company.name" in missing and "position.job_title" in missing
+    # Section 1 only requires the company name
+    assert get_missing_critical_fields(max_section=1) == ["company.name"]
 
     st.session_state["company.name"] = "Acme"
-    missing = get_missing_critical_fields(max_section=1)
-    assert "company.name" not in missing and "position.job_title" in missing
+    assert get_missing_critical_fields(max_section=1) == []
+
+    # Section 2 requires job title, role summary, and country
+    missing = get_missing_critical_fields(max_section=2)
+    assert {
+        "position.job_title",
+        "position.role_summary",
+        "location.country",
+    } <= set(missing)
 
     st.session_state["position.job_title"] = "Engineer"
     st.session_state["location.country"] = "DE"
-    assert get_missing_critical_fields(max_section=1) == []
-
     missing = get_missing_critical_fields(max_section=2)
     assert "position.role_summary" in missing
+
+    st.session_state["position.role_summary"] = "Build models"
+    assert get_missing_critical_fields(max_section=2) == []
 
 
 def test_followup_critical_detection() -> None:

--- a/wizard.py
+++ b/wizard.py
@@ -215,7 +215,7 @@ def _skip_source() -> None:
 # Mapping from schema field paths to wizard section numbers
 FIELD_SECTION_MAP = {
     "company.name": 1,
-    "position.job_title": 1,
+    "position.job_title": 2,
     "position.role_summary": 2,
     "location.country": 2,
     "requirements.hard_skills_required": 3,


### PR DESCRIPTION
## Summary
- avoid wizard deadlock by requiring job title only in the Position step
- update tests and changelog

## Testing
- `ruff check .`
- `black .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0691c6c7c8320a3615093a2bde5da