### PR TITLE
fix: improve file upload error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ API, enabling JSON schema validation and function/tool calling.
 - **Guided error messages**: clear hints when uploads or URLs fail
 - **Upfront language switch**: choose German or English before entering any data
 - **Advantages page**: explore key benefits and jump straight into the wizard via a dedicated button
-- **One‑hop extraction**: Parse PDFs/DOCX/URLs into 20+ fields
+- **One‑hop extraction**: Parse PDFs/DOCX/TXT/URLs into 20+ fields
 - **Robust base field extraction**: heuristics recover job title, company name and city when the model misses them
 - **Structured output**: function calling/JSON mode ensures valid responses
 - **Instant overview**: review extracted fields in a compact tabbed table before continuing

--- a/cli/extract.py
+++ b/cli/extract.py
@@ -33,7 +33,10 @@ def main() -> None:
         raise SystemExit(f"File not found: {file_path}")
 
     with file_path.open("rb") as fh:
-        text = extract_text_from_file(fh)
+        try:
+            text = extract_text_from_file(fh)
+        except ValueError as e:
+            raise SystemExit(str(e))
     if not text:
         raise SystemExit("No text could be extracted from the file.")
 

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,6 +1,8 @@
 import io
 import sys
 import types
+
+import pytest
 from pypdf import PdfWriter
 
 from ingest.extractors import extract_text_from_file
@@ -36,3 +38,17 @@ def test_extract_pdf_with_ocr(monkeypatch) -> None:
     monkeypatch.setitem(sys.modules, "pdf2image", pdf2image)
     monkeypatch.setitem(sys.modules, "pytesseract", pytesseract)
     assert extract_text_from_file(f) == "OCR TEXT"
+
+
+def test_extract_empty_file() -> None:
+    f = io.BytesIO(b"")
+    f.name = "d.txt"
+    with pytest.raises(ValueError, match="empty file"):
+        extract_text_from_file(f)
+
+
+def test_extract_unsupported_type() -> None:
+    f = io.BytesIO(b"data")
+    f.name = "e.png"
+    with pytest.raises(ValueError, match="unsupported file type"):
+        extract_text_from_file(f)

--- a/wizard.py
+++ b/wizard.py
@@ -78,6 +78,25 @@ def on_file_uploaded() -> None:
         return
     try:
         txt = extract_text_from_file(f)
+    except ValueError as e:
+        msg = str(e).lower()
+        if "unsupported file type" in msg:
+            display_error(
+                tr(
+                    "Dieser Dateityp wird nicht unterstützt. Bitte laden Sie eine PDF-, DOCX- oder Textdatei hoch.",
+                    "Unsupported file type. Please upload a PDF, DOCX, or text file.",
+                ),
+                str(e),
+            )
+        else:
+            display_error(
+                tr(
+                    "Datei enthält keinen Text – Sie können die Informationen auch manuell in den folgenden Schritten eingeben.",
+                    "File contains no text – you can also enter the information manually in the following steps.",
+                ),
+            )
+        st.session_state["source_error"] = True
+        return
     except Exception as e:  # pragma: no cover - defensive
         display_error(
             tr(


### PR DESCRIPTION
## Summary
- detect common text formats and raise clear errors for unsupported uploads
- surface user-friendly warnings for unsupported or empty files in wizard and CLI
- cover edge cases in ingest tests

## Testing
- `ruff check .`
- `black . --check`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b06dc9fcf8832084fcba66ee779a8c