### PR TITLE
Improve URL extraction error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ API, enabling JSON schema validation and function/tool calling.
 - **Critical field checks**: wizard blocks navigation until essential fields are filled and highlights missing inputs inline
 - **Extraction feedback**: review detected base data before continuing
 - **Guided error messages**: clear hints when uploads or URLs fail
+- **Improved URL parsing**: reports HTTP status on failures and trims boilerplate
 - **Upfront language switch**: choose German or English before entering any data
 - **Advantages page**: explore key benefits and jump straight into the wizard via a dedicated button
 - **One‑hop extraction**: Parse PDFs/DOCX/TXT/URLs into 20+ fields

--- a/tests/test_extractors_url.py
+++ b/tests/test_extractors_url.py
@@ -1,0 +1,55 @@
+import sys
+import types
+
+import pytest
+
+from ingest.extractors import extract_text_from_url
+
+
+def test_extract_text_from_url_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    html = "<html><body><p>Hello URL</p></body></html>"
+
+    class Resp:
+        status_code = 200
+        text = html
+
+        def raise_for_status(self) -> None:  # pragma: no cover - stub
+            return None
+
+    def fake_get(_url: str, timeout: float, headers: dict | None = None) -> Resp:
+        return Resp()
+
+    fake_traf = types.SimpleNamespace(
+        extract=lambda *_args, **_kwargs: " Hello\n\nWorld "
+    )
+
+    monkeypatch.setattr("ingest.extractors.requests.get", fake_get)
+    monkeypatch.setitem(sys.modules, "trafilatura", fake_traf)
+
+    text = extract_text_from_url("http://example.com")
+    assert text == "Hello\n\nWorld"
+
+
+def test_extract_text_from_url_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import requests
+    from requests import Response
+
+    def fake_get(
+        _url: str, timeout: float, headers: dict | None = None
+    ) -> Response:  # pragma: no cover - stub
+        resp = Response()
+        resp.status_code = 404
+        resp._content = b""
+
+        def raise_for_status() -> None:
+            raise requests.HTTPError(response=resp)
+
+        resp.raise_for_status = raise_for_status  # type: ignore[method-assign]
+        return resp
+
+    monkeypatch.setattr("ingest.extractors.requests.get", fake_get)
+    monkeypatch.setitem(sys.modules, "trafilatura", None)
+
+    with pytest.raises(ValueError) as err:
+        extract_text_from_url("http://example.com")
+    assert "status 404" in str(err.value)


### PR DESCRIPTION
## Summary
- log and surface HTTP status codes when URL fetches fail
- strip boilerplate and fail fast when no text is extracted
- document improved URL parsing in README

## Testing
- `black ingest/extractors.py tests/test_extractors_url.py`
- `ruff check ingest/extractors.py tests/test_extractors_url.py README.md -v`
- `mypy ingest/extractors.py tests/test_extractors_url.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b071f81fc083208a4afe188ba4e860