### PR TITLE
feat: flag missing extraction fields

### DIFF
--- a/constants/keys.py
+++ b/constants/keys.py
@@ -28,4 +28,5 @@ class StateKeys:
     SKILL_SUGGESTIONS = "skill_suggestions"
     BENEFIT_SUGGESTIONS = "benefit_suggestions"
     EXTRACTION_SUMMARY = "extraction_summary"
+    EXTRACTION_MISSING = "extraction_missing"
     BIAS_FINDINGS = "data.bias_findings"

--- a/state/ensure_state.py
+++ b/state/ensure_state.py
@@ -25,6 +25,8 @@ def ensure_state() -> None:
         st.session_state[StateKeys.STEP] = 0
     if StateKeys.EXTRACTION_SUMMARY not in st.session_state:
         st.session_state[StateKeys.EXTRACTION_SUMMARY] = {}
+    if StateKeys.EXTRACTION_MISSING not in st.session_state:
+        st.session_state[StateKeys.EXTRACTION_MISSING] = []
     if "lang" not in st.session_state:
         st.session_state["lang"] = "de"
     if "model" not in st.session_state:


### PR DESCRIPTION
## Summary
- track missing critical fields after LLM extraction and heuristics
- surface unmapped fields in source step so users can fill them
- add coverage for missing-field feedback

## Testing
- `ruff check .`
- `black tests/test_wizard_source.py`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b081d3c9f88320ac79a02da8523306