### PR TITLE
fix: humanize missing field warnings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 - fix: prevent wizard navigation deadlock when job title is missing
 - feat: route CLI file extraction through ingest.extractors for OCR and text support
+- fix: show user-friendly labels for missing critical fields

--- a/tests/test_field_labels.py
+++ b/tests/test_field_labels.py
@@ -1,0 +1,13 @@
+import streamlit as st
+
+from wizard import _field_label
+
+
+def test_field_label_known() -> None:
+    st.session_state.lang = "en"
+    assert _field_label("company.name") == "Company name"
+
+
+def test_field_label_fallback() -> None:
+    st.session_state.lang = "en"
+    assert _field_label("compensation.salary_min") == "Compensation Salary Min"

--- a/wizard.py
+++ b/wizard.py
@@ -253,7 +253,15 @@ FIELD_SECTION_MAP = {
 
 
 def _field_label(path: str) -> str:
-    """Return localized label for a schema field path."""
+    """Return localized label for a schema field path.
+
+    Args:
+        path: Dot-separated schema field path.
+
+    Returns:
+        Localized label if known, otherwise a humanized version of ``path``.
+    """
+
     labels = {
         "company.name": tr("Firmenname", "Company name"),
         "position.job_title": tr("Jobtitel", "Job title"),
@@ -266,7 +274,10 @@ def _field_label(path: str) -> str:
             "Pflicht-Soft-Skills", "Required soft skills"
         ),
     }
-    return labels.get(path, path)
+    if path in labels:
+        return labels[path]
+    auto = path.replace(".", " ").replace("_", " ")
+    return tr(auto.title(), auto.title())
 
 
 def get_missing_critical_fields(*, max_section: int | None = None) -> list[str]:
@@ -2114,7 +2125,8 @@ def _step_summary(schema: dict, critical: list[str]):
     data = st.session_state[StateKeys.PROFILE]
     missing = missing_keys(data, critical)
     if missing:
-        st.warning(f"{t('missing', st.session_state.lang)} {', '.join(missing)}")
+        labels = [_field_label(f) for f in missing]
+        st.warning(f"{t('missing', st.session_state.lang)} {', '.join(labels)}")
     else:
         st.success(
             tr(
@@ -2435,7 +2447,8 @@ def run_wizard():
     section = current - 1
     missing = get_missing_critical_fields(max_section=section) if section >= 1 else []
     if missing:
-        st.warning(f"{t('missing', st.session_state.lang)} {', '.join(missing)}")
+        labels = [_field_label(f) for f in missing]
+        st.warning(f"{t('missing', st.session_state.lang)} {', '.join(labels)}")
 
     if current == 0:
         _, col_next, _ = st.columns([1, 1, 1])


### PR DESCRIPTION
## Summary
- show human-friendly labels for missing critical fields
- add tests for field label mapping and fallback
- document change in changelog

## Testing
- `black wizard.py tests/test_field_labels.py`
- `ruff check wizard.py tests/test_field_labels.py`
- `python - <<'PY'
import subprocess
subprocess.run(['mypy','wizard.py','tests/test_field_labels.py'], check=False)
print('mypy finished')
PY`
- `PYTHONPATH=. pytest tests/test_field_labels.py tests/test_missing_critical_fields.py`


------
https://chatgpt.com/codex/tasks/task_e_68b086b55278832081659d6b9c9c9329