### PR TITLE
refactor: centralize state reset and keys

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ from components.model_selector import model_selector
 from components.reasoning_selector import reasoning_selector
 from config_loader import load_json
 from utils.i18n import tr
-from state.ensure_state import ensure_state
+from state import ensure_state, reset_state
 
 # --- Page config early (keine doppelten Titel/Icon-Resets) ---
 st.set_page_config(
@@ -98,11 +98,7 @@ with st.sidebar:
     )
 
     if st.button("🔁 Reset Wizard", type="secondary"):
-        for k in list(st.session_state.keys()):
-            if k not in ("lang", "model", "vector_store_id", "auto_reask"):
-                del st.session_state[k]
-        st.cache_data.clear()
-        ensure_state()
+        reset_state()
         st.success(tr("Wizard wurde zurückgesetzt.", "Wizard has been reset."))
 
 render_salary_dashboard(st.session_state)

--- a/state/__init__.py
+++ b/state/__init__.py
@@ -1,5 +1,5 @@
 """Session state utilities."""
 
-from .ensure_state import ensure_state
+from .ensure_state import ensure_state, reset_state
 
-__all__ = ["ensure_state"]
+__all__ = ["ensure_state", "reset_state"]

--- a/state/ensure_state.py
+++ b/state/ensure_state.py
@@ -27,6 +27,8 @@ def ensure_state() -> None:
         st.session_state[StateKeys.EXTRACTION_SUMMARY] = {}
     if StateKeys.EXTRACTION_MISSING not in st.session_state:
         st.session_state[StateKeys.EXTRACTION_MISSING] = []
+    if StateKeys.FOLLOWUPS not in st.session_state:
+        st.session_state[StateKeys.FOLLOWUPS] = []
     if "lang" not in st.session_state:
         st.session_state["lang"] = "de"
     if "model" not in st.session_state:
@@ -50,3 +52,18 @@ def ensure_state() -> None:
     ):
         if key not in st.session_state:
             st.session_state[key] = ""
+
+
+def reset_state() -> None:
+    """Reset ``st.session_state`` while preserving basic user settings.
+
+    Keeps language, model, vector store ID and auto-reask flag, then
+    reinitializes defaults via :func:`ensure_state`.
+    """
+
+    preserve = {"lang", "model", "vector_store_id", "auto_reask"}
+    for key in list(st.session_state.keys()):
+        if key not in preserve:
+            del st.session_state[key]
+    st.cache_data.clear()
+    ensure_state()

--- a/tests/test_missing_critical_fields.py
+++ b/tests/test_missing_critical_fields.py
@@ -2,13 +2,14 @@
 
 import streamlit as st
 
+from constants.keys import StateKeys
 from wizard import FIELD_SECTION_MAP, get_missing_critical_fields
 
 
 def test_section_filtering() -> None:
     """Fields beyond the inspected section should be ignored."""
     st.session_state.clear()
-    st.session_state["followup_questions"] = []
+    st.session_state[StateKeys.FOLLOWUPS] = []
 
     # Section 1 only requires the company name
     assert get_missing_critical_fields(max_section=1) == ["company.name"]
@@ -39,7 +40,7 @@ def test_followup_critical_detection() -> None:
     for field in FIELD_SECTION_MAP:
         st.session_state[field] = "filled"
     st.session_state["compensation.salary_min"] = ""
-    st.session_state["followup_questions"] = [
+    st.session_state[StateKeys.FOLLOWUPS] = [
         {"field": "compensation.salary_min", "priority": "critical"},
         {"field": "compensation.variable_pay", "priority": "normal"},
     ]

--- a/wizard.py
+++ b/wizard.py
@@ -301,7 +301,7 @@ def get_missing_critical_fields(*, max_section: int | None = None) -> list[str]:
         if not value:
             missing.append(field)
 
-    for q in st.session_state.get("followup_questions", []):
+    for q in st.session_state.get(StateKeys.FOLLOWUPS, []):
         if q.get("priority") == "critical":
             missing.append(q.get("field", ""))
     return missing
@@ -2313,7 +2313,7 @@ def _step_summary(schema: dict, critical: list[str]):
                     model=st.session_state.model,
                     vector_store_id=st.session_state.vector_store_id or None,
                 )
-                st.session_state["followups"] = res
+                st.session_state[StateKeys.FOLLOWUPS] = res.get("questions", [])
                 st.success(
                     tr("Follow-ups aktualisiert.", "Follow-up questions updated.")
                 )
@@ -2324,10 +2324,9 @@ def _step_summary(schema: dict, critical: list[str]):
                 )
 
     with col2:
-        if st.session_state.get("followups"):
+        if st.session_state.get(StateKeys.FOLLOWUPS):
             st.write(tr("**Vorgeschlagene Fragen:**", "**Suggested questions:**"))
-            fu = st.session_state["followups"]
-            for item in fu.get("questions", []):
+            for item in st.session_state[StateKeys.FOLLOWUPS]:
                 key = item.get(
                     "key"
                 )  # dot key, z.B. "requirements.hard_skills_required"


### PR DESCRIPTION
## Summary
- initialize follow-up question key and provide `reset_state` helper for session reset
- rely on `StateKeys.FOLLOWUPS` for follow-up handling in wizard and tests
- hook up new `reset_state` in app sidebar for consistent state cleanup

## Testing
- `ruff check .`
- `black .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b08ba4231483209575a36952652692