### PR TITLE
refactor: isolate suggestion helpers

### DIFF
--- a/core/suggestions.py
+++ b/core/suggestions.py
@@ -1,0 +1,58 @@
+"""Helpers for generating vacancy suggestions via LLM calls."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from openai_utils import suggest_benefits, suggest_skills_for_role
+
+__all__ = ["get_skill_suggestions", "get_benefit_suggestions"]
+
+
+def get_skill_suggestions(
+    job_title: str, lang: str = "en"
+) -> Tuple[Dict[str, List[str]], str | None]:
+    """Fetch skill suggestions for a role title.
+
+    Args:
+        job_title: Target role title.
+        lang: Output language ("en" or "de").
+
+    Returns:
+        Tuple of (suggestions dict, error message). The suggestions dict contains
+        ``tools_and_technologies``, ``hard_skills`` and ``soft_skills`` lists.
+        On failure, the dict is empty and ``error`` holds the exception message.
+    """
+
+    try:
+        return suggest_skills_for_role(job_title, lang=lang), None
+    except Exception as err:  # pragma: no cover - error path is tested
+        return {}, str(err)
+
+
+def get_benefit_suggestions(
+    job_title: str,
+    industry: str = "",
+    existing_benefits: str = "",
+    lang: str = "en",
+) -> Tuple[List[str], str | None]:
+    """Fetch benefit suggestions for a role.
+
+    Args:
+        job_title: Target role title.
+        industry: Optional industry context.
+        existing_benefits: Benefits already provided by the user.
+        lang: Output language ("en" or "de").
+
+    Returns:
+        Tuple of (benefits list, error message). On failure, the list is empty and
+        ``error`` contains the exception message.
+    """
+
+    try:
+        return (
+            suggest_benefits(job_title, industry, existing_benefits, lang=lang),
+            None,
+        )
+    except Exception as err:  # pragma: no cover - error path is tested
+        return [], str(err)

--- a/tests/test_core_suggestions.py
+++ b/tests/test_core_suggestions.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from core import suggestions
+from core.suggestions import get_benefit_suggestions, get_skill_suggestions
+
+
+def test_get_skill_suggestions(monkeypatch):
+    monkeypatch.setattr(
+        suggestions,
+        "suggest_skills_for_role",
+        lambda title, lang="en": {
+            "tools_and_technologies": ["T"],
+            "hard_skills": [],
+            "soft_skills": [],
+        },
+    )
+    sugg, err = get_skill_suggestions("Engineer")
+    assert sugg["tools_and_technologies"] == ["T"]
+    assert err is None
+
+
+def test_get_skill_suggestions_error(monkeypatch):
+    def raiser(*args, **kwargs):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(suggestions, "suggest_skills_for_role", raiser)
+    sugg, err = get_skill_suggestions("Engineer")
+    assert sugg == {}
+    assert err == "fail"
+
+
+def test_get_benefit_suggestions(monkeypatch):
+    monkeypatch.setattr(suggestions, "suggest_benefits", lambda *a, **k: ["A", "B"])
+    sugg, err = get_benefit_suggestions("Engineer")
+    assert sugg == ["A", "B"]
+    assert err is None
+
+
+def test_get_benefit_suggestions_error(monkeypatch):
+    def raiser(*args, **kwargs):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(suggestions, "suggest_benefits", raiser)
+    sugg, err = get_benefit_suggestions("Engineer")
+    assert sugg == []
+    assert err == "nope"


### PR DESCRIPTION
## Summary
- move skill/benefit suggestion logic into `core.suggestions`
- call new helpers from wizard to keep UI lean
- cover helpers with unit tests

## Testing
- `ruff check core/suggestions.py wizard.py tests/test_core_suggestions.py`
- `mypy core/suggestions.py wizard.py tests/test_core_suggestions.py`
- `pytest tests/test_core_suggestions.py tests/test_skill_suggestions.py tests/test_benefit_suggestions.py tests/test_model_selection.py tests/test_suggest_benefits_language.py`


------
https://chatgpt.com/codex/tasks/task_e_68b08d5c3e588320907727fe16068f66