### PR TITLE
feat: track completed follow-up questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ API, enabling JSON schema validation and function/tool calling.
 - **API helper**: `call_chat_api` wraps the OpenAI Responses API with tool and JSON schema support, automatically executing mapped tools and returning a unified `ChatCallResult`
 - **Analysis tools**: built-in `get_salary_benchmark` and `get_skill_definition` functions can be invoked by the model for richer need analysis
 - **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance (now up to 12 by default), shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
+- **Persistent follow-up tracking**: answered or skipped questions are remembered and won't reappear when navigating back through the wizard.
 - **Follow-up suggestion chips**: if the assistant proposes possible answers, they appear as one-click chips above the input field.
 - **AI-powered benefit suggestions**: fetch common perks for the role/industry and add them to the profile with a single click.
 - **Auto re‑ask loop**: optional toggle that keeps asking follow-up questions automatically until all critical fields are filled, with clear progress messages and a stop button for user control.

--- a/models/need_analysis.py
+++ b/models/need_analysis.py
@@ -162,6 +162,7 @@ class Meta(BaseModel):
 
     target_start_date: Optional[str] = None
     application_deadline: Optional[str] = None
+    followups_answered: List[str] = Field(default_factory=list)
 
 
 class NeedAnalysisProfile(BaseModel):

--- a/tests/test_followup_inline.py
+++ b/tests/test_followup_inline.py
@@ -8,7 +8,7 @@ def test_render_followup_updates_state(monkeypatch) -> None:
     """Entering a response should update the corresponding field."""
     st.session_state.clear()
     st.session_state["lang"] = "en"
-    data: dict = {}
+    data: dict = {"meta": {"followups_answered": []}}
     q = {"field": "compensation.salary_min", "question": "Salary?"}
     st.session_state[StateKeys.FOLLOWUPS] = [q]
     monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
@@ -18,16 +18,18 @@ def test_render_followup_updates_state(monkeypatch) -> None:
         return "100k"
 
     monkeypatch.setattr(st, "text_input", fake_input)
+    monkeypatch.setattr(st, "button", lambda *a, **k: False)
     _render_followup_question(q, data)
     assert data["compensation"]["salary_min"] == "100k"
     assert st.session_state[StateKeys.FOLLOWUPS] == []
+    assert data["meta"]["followups_answered"] == ["compensation.salary_min"]
 
 
 def test_render_followups_critical_prefix(monkeypatch) -> None:
     """Critical questions should be prefixed with a red asterisk."""
     st.session_state.clear()
     st.session_state["lang"] = "en"
-    data: dict = {}
+    data: dict = {"meta": {"followups_answered": []}}
     q = {"field": "salary", "question": "Salary?", "priority": "critical"}
     st.session_state[StateKeys.FOLLOWUPS] = [q]
     seen = {"markdown": None, "label": None}
@@ -42,8 +44,30 @@ def test_render_followups_critical_prefix(monkeypatch) -> None:
 
     monkeypatch.setattr(st, "markdown", fake_markdown)
     monkeypatch.setattr(st, "text_input", fake_input)
+    monkeypatch.setattr(st, "button", lambda *a, **k: False)
     _render_followup_question(q, data)
     assert seen["markdown"] is not None
     assert seen["markdown"].lstrip().startswith("<span style='color:red'>*")
     assert seen["label"] == ""
     assert st.session_state[StateKeys.FOLLOWUPS] == []
+    assert data["meta"]["followups_answered"] == ["salary"]
+
+
+def test_skip_followup(monkeypatch) -> None:
+    """Skipping a question should mark it as completed without storing a value."""
+    st.session_state.clear()
+    st.session_state["lang"] = "en"
+    data: dict = {"meta": {"followups_answered": []}}
+    q = {"field": "employment.travel_required", "question": "Travel?"}
+    st.session_state[StateKeys.FOLLOWUPS] = [q]
+    monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
+    monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
+
+    def fake_button(label, key=None):
+        return key.endswith("_skip")
+
+    monkeypatch.setattr(st, "button", fake_button)
+    _render_followup_question(q, data)
+    assert st.session_state[StateKeys.FOLLOWUPS] == []
+    assert data["meta"]["followups_answered"] == ["employment.travel_required"]
+    assert "employment" not in data


### PR DESCRIPTION
## Summary
- record answered or skipped follow-up fields in profile metadata
- skip button and filtering prevent regenerated follow-ups
- ignore completed follow-ups when checking for missing critical fields

## Testing
- `ruff check . --fix`
- `black --check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b093d1814083208293e437a2e56209