### PR TITLE
fix: humanize missing field warnings

### DIFF
--- a/tests/test_field_labels.py
+++ b/tests/test_field_labels.py
@@ -1,13 +1,53 @@
 import streamlit as st
+import pytest
+from typing import Literal
 
-from wizard import _field_label
+from wizard import _field_label, _step_summary
+from constants.keys import StateKeys
+from question_logic import CRITICAL_FIELDS
+from models.need_analysis import NeedAnalysisProfile
 
 
 def test_field_label_known() -> None:
     st.session_state.lang = "en"
-    assert _field_label("company.name") == "Company name"
+    assert _field_label("company.name") == "Company Name"
 
 
 def test_field_label_fallback() -> None:
     st.session_state.lang = "en"
     assert _field_label("compensation.salary_min") == "Compensation Salary Min"
+
+
+def test_summary_warning_uses_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Summary step warning should display human-friendly labels."""
+
+    st.session_state.clear()
+    st.session_state.lang = "en"
+    st.session_state[StateKeys.PROFILE] = NeedAnalysisProfile().model_dump()
+
+    captured: dict[str, str] = {}
+    monkeypatch.setattr(st, "warning", lambda msg: captured.setdefault("msg", msg))
+
+    class DummyTab:
+        def __enter__(self) -> None:  # pragma: no cover - trivial
+            return None
+
+        def __exit__(
+            self, exc_type, exc, tb
+        ) -> Literal[False]:  # pragma: no cover - trivial
+            return False
+
+    monkeypatch.setattr(st, "tabs", lambda labels: [DummyTab() for _ in labels])
+    monkeypatch.setattr("wizard._summary_company", lambda: None)
+    monkeypatch.setattr("wizard._summary_position", lambda: None)
+    monkeypatch.setattr("wizard._summary_requirements", lambda: None)
+    monkeypatch.setattr("wizard._summary_employment", lambda: None)
+    monkeypatch.setattr("wizard._summary_compensation", lambda: None)
+    monkeypatch.setattr("wizard._summary_process", lambda: None)
+
+    _step_summary({}, list(CRITICAL_FIELDS))
+
+    msg = captured.get("msg", "")
+    assert "Company Name" in msg
+    assert "Job Title" in msg
+    assert "company.name" not in msg

--- a/wizard.py
+++ b/wizard.py
@@ -249,6 +249,22 @@ def _skip_source() -> None:
     st.rerun()
 
 
+FIELD_LABELS: dict[str, tuple[str, str]] = {
+    "company.name": ("Firmenname", "Company Name"),
+    "position.job_title": ("Jobtitel", "Job Title"),
+    "position.role_summary": ("Rollenbeschreibung", "Role Summary"),
+    "location.country": ("Land", "Country"),
+    "requirements.hard_skills_required": (
+        "Pflicht-Hard-Skills",
+        "Required Hard Skills",
+    ),
+    "requirements.soft_skills_required": (
+        "Pflicht-Soft-Skills",
+        "Required Soft Skills",
+    ),
+}
+
+
 def _field_label(path: str) -> str:
     """Return localized label for a schema field path.
 
@@ -259,20 +275,9 @@ def _field_label(path: str) -> str:
         Localized label if known, otherwise a humanized version of ``path``.
     """
 
-    labels = {
-        "company.name": tr("Firmenname", "Company name"),
-        "position.job_title": tr("Jobtitel", "Job title"),
-        "position.role_summary": tr("Rollenbeschreibung", "Role summary"),
-        "location.country": tr("Land", "Country"),
-        "requirements.hard_skills_required": tr(
-            "Pflicht-Hard-Skills", "Required hard skills"
-        ),
-        "requirements.soft_skills_required": tr(
-            "Pflicht-Soft-Skills", "Required soft skills"
-        ),
-    }
-    if path in labels:
-        return labels[path]
+    if path in FIELD_LABELS:
+        de, en = FIELD_LABELS[path]
+        return tr(de, en)
     auto = path.replace(".", " ").replace("_", " ")
     return tr(auto.title(), auto.title())
 


### PR DESCRIPTION
## Summary
- map critical field keys to human-friendly labels
- ensure summary warnings display those labels
- test that missing field warnings use the label mapping

## Testing
- `black wizard.py tests/test_field_labels.py`
- `ruff check wizard.py tests/test_field_labels.py`
- `mypy wizard.py tests/test_field_labels.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0965839788320a98b078ca5ec34fa