### PR TITLE
feat: unify required field indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ API, enabling JSON schema validation and function/tool calling.
 - **Instant overview**: review extracted fields in a compact tabbed table before continuing
 - **API helper**: `call_chat_api` wraps the OpenAI Responses API with tool and JSON schema support, automatically executing mapped tools and returning a unified `ChatCallResult`
 - **Analysis tools**: built-in `get_salary_benchmark` and `get_skill_definition` functions can be invoked by the model for richer need analysis
-- **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance (now up to 12 by default), shown inline in relevant steps. Critical questions are highlighted with a red asterisk.
+- **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance (now up to 12 by default), shown inline in relevant steps. Required fields are consistently marked with a red asterisk.
 - **Persistent follow-up tracking**: answered or skipped questions are remembered and won't reappear when navigating back through the wizard.
 - **Follow-up suggestion chips**: if the assistant proposes possible answers, they appear as one-click chips above the input field.
 - **AI-powered benefit suggestions**: fetch common perks for the role/industry and add them to the profile with a single click.

--- a/tests/test_followup_inline.py
+++ b/tests/test_followup_inline.py
@@ -47,7 +47,7 @@ def test_render_followups_critical_prefix(monkeypatch) -> None:
     monkeypatch.setattr(st, "button", lambda *a, **k: False)
     _render_followup_question(q, data)
     assert seen["markdown"] is not None
-    assert seen["markdown"].lstrip().startswith("<span style='color:red'>*")
+    assert seen["markdown"].lstrip().startswith(":red[*]")
     assert seen["label"] == ""
     assert st.session_state[StateKeys.FOLLOWUPS] == []
     assert data["meta"]["followups_answered"] == ["salary"]

--- a/tests/test_required_indicator.py
+++ b/tests/test_required_indicator.py
@@ -1,0 +1,6 @@
+from wizard import REQUIRED_PREFIX, REQUIRED_SUFFIX
+
+
+def test_required_indicator_format() -> None:
+    assert REQUIRED_SUFFIX.endswith(":red[*]")
+    assert REQUIRED_PREFIX.startswith(":red[*]")

--- a/wizard.py
+++ b/wizard.py
@@ -39,6 +39,9 @@ from core.esco_utils import normalize_skills
 ROOT = Path(__file__).parent
 ensure_state()
 
+REQUIRED_SUFFIX = " :red[*]"
+REQUIRED_PREFIX = ":red[*] "
+
 
 def next_step() -> None:
     """Advance the wizard to the next step."""
@@ -317,9 +320,7 @@ def _render_followup_question(q: dict, data: dict) -> None:
     if key not in st.session_state:
         st.session_state[key] = ""
     if q.get("priority") == "critical":
-        st.markdown(
-            f"<span style='color:red'>*</span> **{prompt}**", unsafe_allow_html=True
-        )
+        st.markdown(f"{REQUIRED_PREFIX}**{prompt}**")
     else:
         st.markdown(f"**{prompt}**")
     if suggestions:
@@ -686,7 +687,7 @@ def _step_company():
 
     label_company = tr("Firma", "Company")
     if "company.name" in missing_here:
-        label_company += " *"
+        label_company += REQUIRED_SUFFIX
     data["company"]["name"] = st.text_input(
         label_company,
         value=data["company"].get("name", ""),
@@ -940,7 +941,7 @@ def _step_position():
     c1, c2 = st.columns(2)
     label_title = tr("Jobtitel", "Job title")
     if "position.job_title" in missing_here:
-        label_title += " *"
+        label_title += REQUIRED_SUFFIX
     data["position"]["job_title"] = c1.text_input(
         label_title,
         value=data["position"].get("job_title", ""),
@@ -977,7 +978,7 @@ def _step_position():
     )
     label_summary = tr("Rollen-Summary", "Role summary")
     if "position.role_summary" in missing_here:
-        label_summary += " *"
+        label_summary += REQUIRED_SUFFIX
     data["position"]["role_summary"] = c6.text_area(
         label_summary,
         value=data["position"].get("role_summary", ""),
@@ -994,7 +995,7 @@ def _step_position():
     )
     label_country = tr("Land", "Country")
     if "location.country" in missing_here:
-        label_country += " *"
+        label_country += REQUIRED_SUFFIX
     data["location"]["country"] = c8.text_input(
         label_country,
         value=data.get("location", {}).get("country", ""),
@@ -1101,7 +1102,7 @@ def _step_requirements():
 
     label_hard_req = tr("Hard Skills (Muss)", "Hard Skills (Must-have)")
     if "requirements.hard_skills_required" in missing_here:
-        label_hard_req += " *"
+        label_hard_req += REQUIRED_SUFFIX
     data["requirements"]["hard_skills_required"] = _chip_multiselect(
         label_hard_req,
         options=data["requirements"].get("hard_skills_required", []),
@@ -1119,7 +1120,7 @@ def _step_requirements():
     )
     label_soft_req = tr("Soft Skills (Muss)", "Soft Skills (Must-have)")
     if "requirements.soft_skills_required" in missing_here:
-        label_soft_req += " *"
+        label_soft_req += REQUIRED_SUFFIX
     data["requirements"]["soft_skills_required"] = _chip_multiselect(
         label_soft_req,
         options=data["requirements"].get("soft_skills_required", []),
@@ -1622,9 +1623,10 @@ def _summary_company() -> None:
     data = st.session_state[StateKeys.PROFILE]
     c1, c2 = st.columns(2)
     name = c1.text_input(
-        tr("Firma *", "Company *"),
+        tr("Firma", "Company") + REQUIRED_SUFFIX,
         value=data["company"].get("name", ""),
         key="ui.summary.company.name",
+        help=tr("Dieses Feld ist erforderlich", "This field is required"),
     )
     industry = c2.text_input(
         tr("Branche", "Industry"),
@@ -1681,9 +1683,10 @@ def _summary_position() -> None:
     data = st.session_state[StateKeys.PROFILE]
     c1, c2 = st.columns(2)
     job_title = c1.text_input(
-        tr("Jobtitel *", "Job title *"),
+        tr("Jobtitel", "Job title") + REQUIRED_SUFFIX,
         value=data["position"].get("job_title", ""),
         key="ui.summary.position.job_title",
+        help=tr("Dieses Feld ist erforderlich", "This field is required"),
     )
     seniority = c2.text_input(
         tr("Seniorität", "Seniority"),
@@ -1706,10 +1709,11 @@ def _summary_position() -> None:
         key="ui.summary.position.reporting_line",
     )
     role_summary = c2.text_area(
-        tr("Rollen-Summary *", "Role summary *"),
+        tr("Rollen-Summary", "Role summary") + REQUIRED_SUFFIX,
         value=data["position"].get("role_summary", ""),
         height=120,
         key="ui.summary.position.role_summary",
+        help=tr("Dieses Feld ist erforderlich", "This field is required"),
     )
     loc_city = c1.text_input(
         tr("Stadt", "City"),


### PR DESCRIPTION
## Summary
- use consistent red asterisk constants for required fields and follow-up questions
- document consistent required field markers in README
- test required indicator formatting and update follow-up question test

## Testing
- `python -m black wizard.py tests/test_followup_inline.py tests/test_required_indicator.py`
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b099a25adc8320b41cf646ca1c43bd