### PR TITLE
feat: improve wizard intro and extraction summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ API, enabling JSON schema validation and function/tool calling.
 - **Restart option**: clicking "Done" returns to the first step to begin another profile
 - **Manual entry option**: skip the upload step and start with an empty profile
 - **Critical field checks**: wizard blocks navigation until essential fields are filled and highlights missing inputs inline
-- **Extraction feedback**: review detected base data before continuing
+- **Extraction feedback**: review detected base data in a sidebar table with missing fields highlighted before continuing
 - **Guided error messages**: clear hints when uploads or URLs fail
 - **Improved URL parsing**: reports HTTP status on failures and trims boilerplate
 - **Upfront language switch**: choose German or English before entering any data


### PR DESCRIPTION
## Summary
- clarify intro step with options to upload a file, paste text or enter a URL
- keep extracted-field summary visible in sidebar and flag missing entries
- document persistent extraction feedback in README

## Testing
- `python -m black wizard.py`
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b09c0636d483209c6df8c8becb8bc2