### PR TITLE
feat: improve follow-up visibility

### DIFF
--- a/state/ensure_state.py
+++ b/state/ensure_state.py
@@ -37,6 +37,10 @@ def ensure_state() -> None:
         st.session_state["vector_store_id"] = os.getenv("VECTOR_STORE_ID", "")
     if "auto_reask" not in st.session_state:
         st.session_state["auto_reask"] = True
+    if "auto_reask_round" not in st.session_state:
+        st.session_state["auto_reask_round"] = 0
+    if "auto_reask_total" not in st.session_state:
+        st.session_state["auto_reask_total"] = 0
     if "reasoning_effort" not in st.session_state:
         st.session_state["reasoning_effort"] = REASONING_EFFORT
     if "dark_mode" not in st.session_state:

--- a/styles/vacalyser.css
+++ b/styles/vacalyser.css
@@ -128,3 +128,12 @@ footer, #MainMenu { visibility: hidden; }
 *::-webkit-scrollbar { height: 12px; width: 12px; }
 *::-webkit-scrollbar-track { background: rgba(0,0,0,.2); }
 *::-webkit-scrollbar-thumb { background: rgba(255,255,255,.25); border-radius: 20px; border: 2px solid rgba(0,0,0,.25); }
+
+/* Flash highlight for critical follow-up questions */
+.fu-highlight {
+  animation: fu-flash 2s ease-in-out 2;
+}
+@keyframes fu-flash {
+  0%,100% { background: transparent; }
+  50% { background: rgba(255, 255, 0, 0.2); }
+}

--- a/styles/vacalyser_light.css
+++ b/styles/vacalyser_light.css
@@ -112,3 +112,12 @@ footer, #MainMenu { visibility: hidden; }
 *::-webkit-scrollbar { height: 12px; width: 12px; }
 *::-webkit-scrollbar-track { background: rgba(0,0,0,.2); }
 *::-webkit-scrollbar-thumb { background: rgba(0,0,0,.25); border-radius: 20px; border: 2px solid rgba(255,255,255,.25); }
+
+/* Flash highlight for critical follow-up questions */
+.fu-highlight {
+  animation: fu-flash 2s ease-in-out 2;
+}
+@keyframes fu-flash {
+  0%,100% { background: transparent; }
+  50% { background: rgba(255, 255, 0, 0.2); }
+}


### PR DESCRIPTION
## Summary
- highlight critical follow-up questions and scroll them into view
- show progress message during auto re-ask loops
- track auto re-ask rounds in session state

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b09e661214832094325b8895b78d62