### PR TITLE
fix: handle OpenAI errors explicitly

### DIFF
--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -2,8 +2,10 @@ import pytest
 
 from typing import Any
 
+import httpx
 import openai_utils
 from openai_utils import ChatCallResult, call_chat_api, extract_with_function
+from openai import AuthenticationError, RateLimitError
 
 
 def test_call_chat_api_raises_when_no_api_key(monkeypatch):
@@ -140,3 +142,40 @@ def test_call_chat_api_executes_tool(monkeypatch):
     res = call_chat_api([{"role": "user", "content": "hi"}])
     assert res.content == "done"
     assert res.tool_calls[0]["function"]["name"] == "get_skill_definition"
+
+
+def _dummy_response(status: int) -> httpx.Response:
+    """Return a minimal :class:`httpx.Response` for exception tests."""
+
+    req = httpx.Request("POST", "https://api.openai.com")
+    return httpx.Response(status_code=status, request=req)
+
+
+def test_call_chat_api_authentication_error(monkeypatch):
+    """Authentication errors should surface a clear message."""
+
+    class _Resp:
+        def create(self, **kwargs):
+            raise AuthenticationError("bad key", response=_dummy_response(401), body="")
+
+    class _Client:
+        responses = _Resp()
+
+    monkeypatch.setattr("openai_utils.client", _Client(), raising=False)
+    with pytest.raises(RuntimeError, match="API key invalid"):
+        call_chat_api([{"role": "user", "content": "hi"}])
+
+
+def test_call_chat_api_rate_limit(monkeypatch):
+    """Rate limit errors should surface a clear message."""
+
+    class _Resp:
+        def create(self, **kwargs):
+            raise RateLimitError("quota", response=_dummy_response(429), body="")
+
+    class _Client:
+        responses = _Resp()
+
+    monkeypatch.setattr("openai_utils.client", _Client(), raising=False)
+    with pytest.raises(RuntimeError, match="rate limit"):
+        call_chat_api([{"role": "user", "content": "hi"}])


### PR DESCRIPTION
## Summary
- differentiate OpenAI API failure modes
- test error messaging for auth and rate limit failures

## Testing
- `ruff check --fix openai_utils.py tests/test_openai_utils.py`
- `black openai_utils.py tests/test_openai_utils.py`
- `mypy openai_utils.py tests/test_openai_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0a1b0c6d4832081a60c2c9764c832