### PR TITLE
feat: add OpenAI config warnings

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,21 @@ st.set_page_config(
 ROOT = Path(__file__).parent
 ensure_state()
 
+if st.session_state.get("openai_api_key_missing"):
+    st.warning(
+        tr(
+            "⚠️ OpenAI-API-Schlüssel nicht gesetzt. Bitte in der Umgebung konfigurieren, um KI-Funktionen zu nutzen.",
+            "⚠️ OpenAI API key not set. Please configure it in the environment to use AI features.",
+        )
+    )
+if st.session_state.get("openai_base_url_invalid"):
+    st.warning(
+        tr(
+            "⚠️ OPENAI_BASE_URL scheint ungültig zu sein und wird ignoriert.",
+            "⚠️ OPENAI_BASE_URL appears invalid and will be ignored.",
+        )
+    )
+
 
 def inject_global_css() -> None:
     """Inject the global stylesheet and background image."""

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -55,7 +55,9 @@ def get_client() -> OpenAI:
     if client is None:
         key = OPENAI_API_KEY
         if not key:
-            raise RuntimeError("OPENAI_API_KEY not configured")
+            raise RuntimeError(
+                "OpenAI API key not configured. Set OPENAI_API_KEY in the environment or Streamlit secrets."
+            )
         base = OPENAI_BASE_URL or None
         client = OpenAI(api_key=key, base_url=base)
     return client

--- a/state/ensure_state.py
+++ b/state/ensure_state.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import os
+from urllib.parse import urlparse
 
 import streamlit as st
 
 from constants.keys import StateKeys
-from config import REASONING_EFFORT
+from config import OPENAI_API_KEY, OPENAI_BASE_URL, REASONING_EFFORT
 from models.need_analysis import NeedAnalysisProfile
 
 
@@ -35,6 +36,16 @@ def ensure_state() -> None:
         st.session_state["model"] = os.getenv("OPENAI_MODEL", "gpt-5-nano")
     if "vector_store_id" not in st.session_state:
         st.session_state["vector_store_id"] = os.getenv("VECTOR_STORE_ID", "")
+    if "openai_api_key_missing" not in st.session_state:
+        st.session_state["openai_api_key_missing"] = not OPENAI_API_KEY
+    if "openai_base_url_invalid" not in st.session_state:
+        if OPENAI_BASE_URL:
+            parsed = urlparse(OPENAI_BASE_URL)
+            st.session_state["openai_base_url_invalid"] = not (
+                parsed.scheme and parsed.netloc
+            )
+        else:
+            st.session_state["openai_base_url_invalid"] = False
     if "auto_reask" not in st.session_state:
         st.session_state["auto_reask"] = True
     if "auto_reask_round" not in st.session_state:

--- a/tests/test_openai_config.py
+++ b/tests/test_openai_config.py
@@ -1,0 +1,24 @@
+import importlib
+
+import streamlit as st
+import config
+
+es = importlib.import_module("state.ensure_state")
+
+
+def test_missing_api_key_sets_flag(monkeypatch):
+    st.session_state.clear()
+    monkeypatch.setattr(config, "OPENAI_API_KEY", "", raising=False)
+    monkeypatch.setattr(es, "OPENAI_API_KEY", "", raising=False)
+    es.ensure_state()
+    assert st.session_state["openai_api_key_missing"] is True
+
+
+def test_invalid_base_url_sets_flag(monkeypatch):
+    st.session_state.clear()
+    monkeypatch.setattr(config, "OPENAI_API_KEY", "x", raising=False)
+    monkeypatch.setattr(es, "OPENAI_API_KEY", "x", raising=False)
+    monkeypatch.setattr(config, "OPENAI_BASE_URL", "not a url", raising=False)
+    monkeypatch.setattr(es, "OPENAI_BASE_URL", "not a url", raising=False)
+    es.ensure_state()
+    assert st.session_state["openai_base_url_invalid"] is True


### PR DESCRIPTION
## Summary
- show Streamlit warnings when OpenAI API key is missing or base URL is invalid
- improve OpenAI client error message
- add tests for startup configuration checks

## Testing
- `black app.py openai_utils.py state/ensure_state.py`
- `ruff check app.py openai_utils.py state/ensure_state.py`
- `mypy app.py openai_utils.py state/ensure_state.py tests/test_openai_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0a50948c08320b1c51d5df0d1d2fe