### PR TITLE
perf: cache ESCO skills and warn on offline gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ API, enabling JSON schema validation and function/tool calling.
 - **Reasoning effort control**: select low, medium, or high reasoning depth with an environment-variable default.
 - **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts, HR software for human resource professionals, engineering tools for civil engineers, cuisine specialties for chefs).
 - **ESCO‑Power**: occupation classification + essential skill gaps
-- **Offline-ready ESCO**: set `VACAYSER_OFFLINE=1` to use cached occupations and skills without API calls; data comes from `integrations/esco_offline.json` and covers common roles, unmatched titles simply skip enrichment
+- **Offline-ready ESCO**: set `VACAYSER_OFFLINE=1` to use cached occupations and skills without API calls; data comes from `integrations/esco_offline.json` and covers common roles. Unknown titles log a warning and skip enrichment—update the JSON or unset the env var to fall back to the live ESCO API
 - **Cached ESCO calls**: Streamlit caching avoids repeated API requests
 - **Auto-filled skills**: essential ESCO skills merge into required skills; generic entries like "Communication" are ignored so follow-ups stay relevant
 - **RAG‑Assist**: use your vector store to fill/contextualize

--- a/integrations/esco.py
+++ b/integrations/esco.py
@@ -68,6 +68,8 @@ def enrich_skills(occupation_uri: str, lang: str = "en") -> list[str]:
         return []
     if OFFLINE:
         skills = _OFFLINE_SKILLS.get(occupation_uri, [])
+        if not skills:
+            log.warning("No offline ESCO skills for '%s'", occupation_uri)
     else:
         skills = esco_utils.get_essential_skills(occupation_uri, lang)
     return [s for s in skills if s.lower() not in GENERIC_SKILLS]

--- a/tests/test_esco.py
+++ b/tests/test_esco.py
@@ -49,3 +49,17 @@ def test_normalize_skills(monkeypatch) -> None:
     monkeypatch.setattr(esco, "lookup_esco_skill", fake_lookup)
     out = esco.normalize_skills(["python", "Python ", "docker", ""])
     assert out == ["Python", "Docker"]
+
+
+def test_lookup_esco_skill_caches(monkeypatch) -> None:
+    calls = {"count": 0}
+
+    def fake_get(path, **params):
+        calls["count"] += 1
+        return {"_embedded": {"results": [{"preferredLabel": "Python"}]}}
+
+    esco._SKILL_CACHE.clear()
+    monkeypatch.setattr(esco, "_get", fake_get)
+    esco.lookup_esco_skill("python")
+    esco.lookup_esco_skill("python")
+    assert calls["count"] == 1

--- a/tests/test_esco_integration.py
+++ b/tests/test_esco_integration.py
@@ -33,6 +33,17 @@ def test_offline_unknown_title(monkeypatch):
     assert occ == {}
 
 
+def test_offline_missing_skills_warning(monkeypatch, caplog):
+    """Missing offline skills trigger a warning and return empty list."""
+    monkeypatch.setenv("VACAYSER_OFFLINE", "1")
+    module = importlib.import_module("integrations.esco")
+    importlib.reload(module)
+    with caplog.at_level("WARNING"):
+        skills = module.enrich_skills("unknown-uri")
+    assert skills == []
+    assert any("No offline ESCO skills" in r.message for r in caplog.records)
+
+
 def test_online_delegation(monkeypatch):
     """Wrapper delegates to core.esco_utils when not offline."""
     monkeypatch.delenv("VACAYSER_OFFLINE", raising=False)


### PR DESCRIPTION
## Summary
- cache ESCO skill lookups to avoid duplicate API requests
- warn when offline ESCO data lacks skills for a role and document it
- cover ESCO caching and offline warnings with tests

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0a88a2a488320a5386f4474d2303f