### PR TITLE
fix: improve external service error handling

### DIFF
--- a/wizard.py
+++ b/wizard.py
@@ -91,6 +91,22 @@ def on_file_uploaded() -> None:
                 ),
                 str(e),
             )
+        elif "file too large" in msg:
+            display_error(
+                tr(
+                    "Datei ist zu groß. Maximale Größe: 20 MB.",
+                    "File is too large. Maximum size: 20 MB.",
+                ),
+                str(e),
+            )
+        elif "invalid pdf" in msg:
+            display_error(
+                tr(
+                    "Ungültige oder beschädigte PDF-Datei.",
+                    "Invalid or corrupted PDF file.",
+                ),
+                str(e),
+            )
         else:
             display_error(
                 tr(
@@ -98,6 +114,16 @@ def on_file_uploaded() -> None:
                     "File contains no text – you can also enter the information manually in the following steps.",
                 ),
             )
+        st.session_state["source_error"] = True
+        return
+    except RuntimeError as e:  # pragma: no cover - OCR
+        display_error(
+            tr(
+                "Datei konnte nicht gelesen werden. Prüfen Sie, ob es sich um ein gescanntes PDF handelt und installieren Sie ggf. OCR-Abhängigkeiten.",
+                "Failed to read file. If this is a scanned PDF, install OCR dependencies or check the file quality.",
+            ),
+            str(e),
+        )
         st.session_state["source_error"] = True
         return
     except Exception as e:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary
- detect oversized and invalid PDFs, surface OCR dependency issues
- warn when vector store retrieval fails during follow-up generation
- expand tests for extractor and RAG failure paths

## Testing
- `ruff check ingest/extractors.py question_logic.py tests/test_extractors.py tests/test_question_logic.py wizard.py`
- `mypy ingest/extractors.py question_logic.py tests/test_extractors.py tests/test_question_logic.py wizard.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0aa9c770c8320940b83ecb1a5582a