### PR TITLE
fix: validate tone presets JSON

### DIFF
--- a/tone_presets.json
+++ b/tone_presets.json
@@ -3,12 +3,12 @@
         "formal": "professional and helpful",
         "casual": "friendly, approachable, and direct",
         "creative": "creative and engaging",
-        "diversity_focused": "inclusive, welcoming, and bias-aware",
+        "diversity_focused": "inclusive, welcoming, and bias-aware"
     },
     "de": {
         "formal": "professionell und hilfreich",
         "casual": "freundlich, nahbar und direkt",
         "creative": "kreativ und inspirierend",
-        "diversity_focused": "inklusiv, einladend und vorurteilsbewusst",
-    },
+        "diversity_focused": "inklusiv, einladend und vorurteilsbewusst"
+    }
 }


### PR DESCRIPTION
## Summary
- fix syntax in tone_presets.json to remove trailing commas

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q` *(fails: KeyboardInterrupt after 84 passed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b66e87008320a18c3b68fbbd9ccc