### PR TITLE
fix: wrap extraction tool in function object

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,3 +5,4 @@
 - feat: route CLI file extraction through ingest.extractors for OCR and text support
 - fix: show user-friendly labels for missing critical fields
 - fix: stack columns and buttons on small screens for mobile usability
+- fix: send valid OpenAI tool definitions to avoid missing name errors

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -392,9 +392,11 @@ def build_extraction_tool(
     return [
         {
             "type": "function",
-            "name": name,
-            "description": "Return structured vacancy data that fits the schema exactly.",
-            "parameters": params,
+            "function": {
+                "name": name,
+                "description": "Return structured vacancy data that fits the schema exactly.",
+                "parameters": params,
+            },
             "strict": not allow_extra,
         }
     ]

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -52,6 +52,16 @@ def test_call_chat_api_tool_call(monkeypatch):
     assert out.tool_calls[0]["function"]["arguments"] == '{"job_title": "x"}'
 
 
+def test_build_extraction_tool_has_name_and_parameters():
+    """build_extraction_tool should include function name and parameters."""
+
+    schema = {"type": "object", "properties": {}}
+    tool = openai_utils.build_extraction_tool("vacalyser_extract", schema)
+    spec = tool[0]
+    assert spec["function"]["name"] == "vacalyser_extract"
+    assert spec["function"]["parameters"]["type"] == "object"
+
+
 def test_call_chat_api_passes_reasoning(monkeypatch):
     """Reasoning effort should be forwarded to the API payload."""
 


### PR DESCRIPTION
## Summary
- wrap extraction tool spec in `function` object so name and parameters reach OpenAI
- cover extraction tool helper with test
- record fix in changelog

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0b78f3d488320845dce0618a6b052