### PR TITLE
feat: map alias fields during profile coercion

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -72,6 +72,20 @@ def test_coerce_and_fill_employment_details() -> None:
     assert jd.employment.relocation_details == "Budget provided"
 
 
+def test_coerce_and_fill_alias_mapping() -> None:
+    """Alias keys should map to their canonical schema paths."""
+
+    data = {
+        "requirements": {"hard_skills": ["Python"]},
+        "city": "Berlin",
+        "date_of_employment_start": "2024-01-01",
+    }
+    jd = coerce_and_fill(data)
+    assert jd.requirements.hard_skills_required == ["Python"]
+    assert jd.location.primary_city == "Berlin"
+    assert jd.meta.target_start_date == "2024-01-01"
+
+
 def test_default_insertion() -> None:
     jd = coerce_and_fill({})
     assert jd.position.job_title is None

--- a/wizard.py
+++ b/wizard.py
@@ -18,8 +18,9 @@ from state.ensure_state import ensure_state
 from ingest.extractors import extract_text_from_file, extract_text_from_url
 from ingest.heuristics import apply_basic_fallbacks
 from utils.errors import display_error
-from models.need_analysis import NeedAnalysisProfile
 from config_loader import load_json
+from models.need_analysis import NeedAnalysisProfile
+from core.schema import coerce_and_fill
 
 # LLM/ESCO und Follow-ups
 from openai_utils import (
@@ -208,7 +209,7 @@ def _extract_and_summarize(text: str, schema: dict) -> None:
     """Run extraction on ``text`` and store profile, summary, and missing fields."""
 
     extracted = extract_with_function(text, schema, model=st.session_state.model)
-    profile = NeedAnalysisProfile.model_validate(extracted)
+    profile = coerce_and_fill(extracted)
     profile = apply_basic_fallbacks(profile, text)
     st.session_state[StateKeys.PROFILE] = profile.model_dump()
     title = profile.position.job_title or ""


### PR DESCRIPTION
## Summary
- map legacy alias keys to canonical schema paths during profile coercion
- prefill wizard profile data using `coerce_and_fill`
- cover alias mapping with unit tests

## Testing
- `ruff check --fix core/schema.py wizard.py tests/test_schema.py`
- `black core/schema.py wizard.py tests/test_schema.py`
- `mypy core/schema.py wizard.py tests/test_schema.py`
- `PYTHONPATH=. pytest tests/test_schema.py tests/test_wizard_source.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0baefc414832088760050077fd552