### PR TITLE
refactor: unify profile terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vacalyser — AI Recruitment Need Analysis (Streamlit)
 
-**Vacalyser** turns messy job ads into a **complete, structured vacancy profile**, then asks only the *minimal* follow‑ups. It enriches with **ESCO** (skills/occupations) and your **OpenAI Vector Store** to propose **missing skills, benefits, tools, and tasks**. Finally, it generates a polished **job ad**, **interview guide**, and **boolean search string**.
+**Vacalyser** turns messy job ads into a **complete, structured profile**, then asks only the *minimal* follow‑ups. It enriches with **ESCO** (skills/occupations) and your **OpenAI Vector Store** to propose **missing skills, benefits, tools, and tasks**. Finally, it generates a polished **job ad**, **interview guide**, and **boolean search string**.
 
 Vacalyser now defaults to OpenAI’s reasoning-friendly `gpt-5-nano` model and can
 optionally run on `gpt-4.1-nano`. These lightweight models improve reasoning,
@@ -140,7 +140,7 @@ Core JSON schemas like `schema/need_analysis.schema.json`, `critical_fields.json
 `config_loader.load_json`, which falls back to safe defaults and logs a warning
 if a file is missing or malformed.
 
-The vacancy profile schema does not enforce any required properties; every field
+The profile schema does not enforce any required properties; every field
 is optional and may be omitted.
 
 ## Built-in Analysis Tools
@@ -159,8 +159,8 @@ process.
 ## Session State & Migration
 
 Session keys are centralized in `constants/keys.py`. Business data uses flat
-keys from `StateKeys` such as `profile_data` or `jd_raw_text`, while widget
-"shadow" keys come from `UIKeys` like `ui.jd_text_input`. Legacy entries like
+keys from `StateKeys` such as `profile_data` or `profile_raw_text`, while widget
+"shadow" keys come from `UIKeys` like `ui.profile_text_input`. Legacy entries like
 `data.jd_text` or plain `jd_text` are migrated to the new schema on startup so
 existing drafts remain intact.
 

--- a/cli/extract.py
+++ b/cli/extract.py
@@ -10,18 +10,16 @@ import json
 def main() -> None:
     """Parse arguments and print validated JSON to stdout.
 
-    The command reads a local job description file (PDF, DOCX or text), extracts
+    The command reads a local job posting file (PDF, DOCX or text), extracts
     text using the same logic as the Streamlit app – including optional OCR for
     scanned PDFs – and runs the LLM pipeline without requiring Streamlit.
     Example::
 
-        python -m cli.extract --file jd.pdf --title "..." --url "..."
+        python -m cli.extract --file profile.pdf --title "..." --url "..."
     """
 
     parser = argparse.ArgumentParser(description="Vacalyser JSON extractor")
-    parser.add_argument(
-        "--file", required=True, help="Path to the job description file"
-    )
+    parser.add_argument("--file", required=True, help="Path to the job posting file")
     parser.add_argument("--title", help="Optional job title for context")
     parser.add_argument("--url", help="Optional source URL for context")
     args = parser.parse_args()
@@ -44,8 +42,8 @@ def main() -> None:
         raise SystemExit("No text could be extracted from the file.")
 
     schema = load_json("schema/need_analysis.schema.json", fallback={})
-    jd = extract_with_function(text, schema, model=OPENAI_MODEL)
-    print(json.dumps(jd, indent=2))
+    profile = extract_with_function(text, schema, model=OPENAI_MODEL)
+    print(json.dumps(profile, indent=2))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/components/salary_dashboard.py
+++ b/components/salary_dashboard.py
@@ -81,7 +81,7 @@ def render_salary_dashboard(session_state: Any) -> None:
     """Render salary analytics widget in the sidebar.
 
     Args:
-        session_state: Streamlit session state used to fetch vacancy data.
+        session_state: Streamlit session state used to fetch profile data.
     """
 
     must_skills = _session_list(

--- a/constants/keys.py
+++ b/constants/keys.py
@@ -1,9 +1,9 @@
 class UIKeys:
     """Keys for UI widgets in ``st.session_state``."""
 
-    JD_TEXT_INPUT = "ui.jd_text_input"
-    JD_FILE_UPLOADER = "ui.jd_file_uploader"
-    JD_URL_INPUT = "ui.jd_url_input"
+    PROFILE_TEXT_INPUT = "ui.profile_text_input"
+    PROFILE_FILE_UPLOADER = "ui.profile_file_uploader"
+    PROFILE_URL_INPUT = "ui.profile_url_input"
     LANG_SELECT = "ui.lang_select"
     MODEL_SELECT = "ui.model_select"
     REASONING_SELECT = "ui.reasoning_select"
@@ -18,7 +18,7 @@ class StateKeys:
     """Keys for data stored in ``st.session_state``."""
 
     PROFILE = "profile_data"
-    RAW_TEXT = "jd_raw_text"
+    RAW_TEXT = "profile_raw_text"
     STEP = "current_step"
     FOLLOWUPS = "followup_questions"
     USAGE = "api_usage"

--- a/core/field_suggestions.py
+++ b/core/field_suggestions.py
@@ -1,4 +1,4 @@
-"""Predefined suggestion lists for common vacancy fields."""
+"""Predefined suggestion lists for common profile fields."""
 
 from typing import Dict, List
 
@@ -58,7 +58,7 @@ __all__ = ["FIELD_SUGGESTIONS", "get_field_suggestions"]
 
 
 def get_field_suggestions(field: str, lang: str = "en") -> List[str]:
-    """Return normalized suggestions for a vacancy field.
+    """Return normalized suggestions for a profile field.
 
     Args:
         field: Field name such as ``"programming_languages"``.

--- a/core/schema.py
+++ b/core/schema.py
@@ -99,5 +99,6 @@ def coerce_and_fill(data: Mapping[str, Any] | None) -> NeedAnalysisProfile:
     return NeedAnalysisProfile.model_validate(data)
 
 
-# Backwards compatibility alias
-VacalyserJD = NeedAnalysisProfile
+# Backwards compatibility aliases
+VacalyserProfile = NeedAnalysisProfile
+VacalyserJD = NeedAnalysisProfile  # pragma: no cover - legacy alias

--- a/core/ss_bridge.py
+++ b/core/ss_bridge.py
@@ -4,11 +4,11 @@ from models.need_analysis import NeedAnalysisProfile
 from .schema import ALL_FIELDS, ALIASES, LIST_FIELDS, coerce_and_fill
 
 
-def to_session_state(jd: NeedAnalysisProfile, ss: dict) -> None:
+def to_session_state(profile: NeedAnalysisProfile, ss: dict) -> None:
     """Populate session state dict with values from a NeedAnalysisProfile object."""
 
     def _get(path: str) -> Any:
-        cursor: Any = jd
+        cursor: Any = profile
         for part in path.split("."):
             cursor = getattr(cursor, part)
         return cursor

--- a/core/suggestions.py
+++ b/core/suggestions.py
@@ -1,4 +1,4 @@
-"""Helpers for generating vacancy suggestions via LLM calls."""
+"""Helpers for generating profile suggestions via LLM calls."""
 
 from __future__ import annotations
 

--- a/docs/json_pipeline.md
+++ b/docs/json_pipeline.md
@@ -1,5 +1,5 @@
 ## Schema (v2.1)
-Vacalyzer's schema is now hierarchical, grouping related fields for a vacancy. Each top-level key represents a category (such as `company`, `position`, `compensation`, etc.), containing sub-fields. We focus on core fields (priority 1–3) to gather essential information first. Below are the groups and example fields:
+Vacalyzer's schema is now hierarchical, grouping related fields for a profile. Each top-level key represents a category (such as `company`, `position`, `compensation`, etc.), containing sub-fields. We focus on core fields (priority 1–3) to gather essential information first. Below are the groups and example fields:
 - **company:** `name`, `industry`, `hq_location`, `size`, `website`  
 - **position:** `job_title`, `seniority_level`, `department`, `management_scope`, `reporting_line`, `role_summary`, `team_structure`, etc.  
 - **employment:** `job_type`, `work_policy` (Onsite/Hybrid/Remote), `travel_required`, `work_schedule`, etc.  

--- a/i18n.py
+++ b/i18n.py
@@ -10,7 +10,7 @@ STR = {
         "missing": "Es fehlen noch kritische Felder:",
     },
     "en": {
-        "intro_title": "Identify ALL recruiting-relevant information about your vacancy!",
+        "intro_title": "Identify ALL recruiting-relevant information about your profile!",
         "source": "Source",
         "analyze": "🔎 Analyze automatically (LLM)",
         "missing": "Critical fields still missing:",

--- a/ingest/__init__.py
+++ b/ingest/__init__.py
@@ -1,4 +1,4 @@
-"""Utilities for ingesting job description text."""
+"""Utilities for ingesting job posting text."""
 
 from .extractors import extract_text_from_file, extract_text_from_url
 from .reader import read_job_text

--- a/llm/client.py
+++ b/llm/client.py
@@ -105,7 +105,7 @@ def extract_json(
     """Extract schema fields via JSON mode with optional plain fallback.
 
     Args:
-        text: Input job description.
+        text: Input job posting.
         title: Optional job title for context.
         url: Optional source URL.
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,4 +1,4 @@
-"""Pydantic models for vacancy need analysis."""
+"""Pydantic models for profile need analysis."""
 
 from .need_analysis import NeedAnalysisProfile
 

--- a/models/need_analysis.py
+++ b/models/need_analysis.py
@@ -156,7 +156,7 @@ class Process(BaseModel):
 
 
 class Meta(BaseModel):
-    """Miscellaneous metadata about the vacancy."""
+    """Miscellaneous metadata about the profile."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -394,7 +394,7 @@ def build_extraction_tool(
             "type": "function",
             "function": {
                 "name": name,
-                "description": "Return structured vacancy data that fits the schema exactly.",
+                "description": "Return structured profile data that fits the schema exactly.",
                 "parameters": params,
             },
             "strict": not allow_extra,
@@ -405,14 +405,14 @@ def build_extraction_tool(
 def extract_with_function(
     job_text: str, schema: dict, *, model: str | None = None
 ) -> Mapping[str, Any]:
-    """Extract vacancy data from ``job_text`` using strict function calling.
+    """Extract profile data from ``job_text`` using strict function calling.
 
     The function first requests a structured ``function_call``; if none is
     returned, it retries the extraction with ``json`` output. Any malformed
     JSON is best-effort repaired before validation.
 
     Args:
-        job_text: Source job description text.
+        job_text: Source job posting text.
         schema: JSON schema describing the expected structure.
         model: Optional OpenAI model to use for extraction. Falls back to the
             globally selected model in ``st.session_state``.
@@ -482,8 +482,8 @@ def extract_with_function(
     from models.need_analysis import NeedAnalysisProfile
     from core.schema import coerce_and_fill
 
-    jd: NeedAnalysisProfile = coerce_and_fill(raw)
-    return jd.model_dump()
+    profile: NeedAnalysisProfile = coerce_and_fill(raw)
+    return profile.model_dump()
 
 
 def suggest_additional_skills(

--- a/pages/advantages.py
+++ b/pages/advantages.py
@@ -50,7 +50,7 @@ benefits: BenefitsDict = {
             "Gamifizierte Completion‑Tracker zur Motivation",
         ],
         "Recruiter": [
-            "Automatisches Parsing von JD‑Entwürfen, CVs & Links",
+            "Automatisches Parsing von Stellenanzeigen‑Entwürfen, CVs & Links",
             "Datenbank‑Vernetzung (ATS, CRM, LinkedIn Recruiter, GitHub)",
             "KPIs in Echtzeit (Sourcing‑Conversion‑Rate, Pipeline‑Velocity)",
             'KI‑basierte Suchstrings generieren ("Boolean‑Builder 2.0")',
@@ -87,7 +87,7 @@ benefits: BenefitsDict = {
             "Kosten‑Transparenz pro Cost‑Center & Hire‑Kategorie",
             "Einhaltung globaler Policies (DE&I, Remote‑First, Comp‑Ratio)",
             "Predictive‑Hiring‑Modelle für saisonale Peaks",
-            "Reduziertes Time‑to‑Productivity durch passgenaue JD",
+            "Reduziertes Time‑to‑Productivity durch passgenaue Stellenprofile",
             "Weniger Fehlbesetzungen dank Skill‑Validierung vor Ausschreibung",
             "Employer‑Brand‑Stärkung durch konsistente, ansprechende Jobpages",
             "Revisionssichere Dokumentation aller Hiring‑Entscheidungen",
@@ -173,7 +173,7 @@ benefits: BenefitsDict = {
             "Gamified completion tracker for motivation",
         ],
         "Recruiter": [
-            "Automatic parsing of JD drafts, CVs & links",
+            "Automatic parsing of job posting drafts, CVs & links",
             "Database connectivity (ATS, CRM, LinkedIn Recruiter, GitHub)",
             "Real‑time KPIs (sourcing conversion rate, pipeline velocity)",
             'AI‑generated search strings ("Boolean Builder 2.0")',
@@ -210,7 +210,7 @@ benefits: BenefitsDict = {
             "Cost transparency per cost centre & hire category",
             "Compliance with global policies (DE&I, remote first, comp ratio)",
             "Predictive hiring models for seasonal peaks",
-            "Reduced time‑to‑productivity through precise JD",
+            "Reduced time‑to‑productivity through precise job profiles",
             "Fewer mis‑hires thanks to skill validation before posting",
             "Employer brand strengthening via consistent, appealing job pages",
             "Audit‑proof documentation of all hiring decisions",
@@ -298,7 +298,7 @@ intro_de = (
 
 title_en = "🚀 Advantages of **Vacancy Need Analysis**"
 intro_en = (
-    "Our Vacancy Need Analysis helps you nail the first step of any hiring process – describing the vacancy. "
+    "Our Need Analysis helps you nail the first step of any hiring process – describing the role. "
     "Upload your material and let dynamic OpenAI questions uncover missing details. "
     "The result is a complete profile that prevents information loss, saves time and gives candidates a clear picture."
 )

--- a/question_logic.py
+++ b/question_logic.py
@@ -258,7 +258,7 @@ def _rag_suggestions(
         return {}
     model = model or st.session_state.get("model", OPENAI_MODEL)
     sys = (
-        "You provide short, concrete suggestions to help complete a vacancy profile. "
+        "You provide short, concrete suggestions to help complete a profile. "
         "Use retrieved context; if none, return empty arrays. Respond as a JSON object "
         "mapping each requested field to an array of up to N concise suggestions (no explanations)."
     )

--- a/questions/__init__.py
+++ b/questions/__init__.py
@@ -1,4 +1,4 @@
-"""Question utilities for vacancy completeness."""
+"""Question utilities for profile completeness."""
 
 from .generate import generate_followup_questions
 

--- a/questions/generate.py
+++ b/questions/generate.py
@@ -12,7 +12,7 @@ from question_logic import (
 
 
 def generate_followup_questions(
-    jd: NeedAnalysisProfile,
+    profile: NeedAnalysisProfile,
     num_questions: Optional[int] = None,
     lang: str = "en",
     use_rag: bool = True,
@@ -26,7 +26,7 @@ def generate_followup_questions(
     set of parameters is forwarded to the underlying function.
 
     Args:
-        jd: Parsed job description data.
+        profile: Parsed profile data.
         num_questions: Optional maximum number of questions to return.
         lang: Language for generated questions.
         use_rag: Whether to use RAG-based suggestions.
@@ -36,7 +36,7 @@ def generate_followup_questions(
     """
 
     items = _generate_followup_questions(
-        jd.model_dump(),
+        profile.model_dump(),
         num_questions=num_questions,
         lang=lang,
         use_rag=use_rag,

--- a/tests/test_e2e_extraction.py
+++ b/tests/test_e2e_extraction.py
@@ -12,8 +12,8 @@ def test_e2e_to_session_state(monkeypatch) -> None:
     monkeypatch.setattr(
         openai_utils, "extract_with_function", fake_extract_with_function
     )
-    jd_dict = openai_utils.extract_with_function("input", {})
-    jd = NeedAnalysisProfile.model_validate(jd_dict)
+    profile_dict = openai_utils.extract_with_function("input", {})
+    profile = NeedAnalysisProfile.model_validate(profile_dict)
     ss: dict = {}
-    to_session_state(jd, ss)
+    to_session_state(profile, ss)
     assert ss["position.job_title"] == "Dev"

--- a/tests/test_generate_followups.py
+++ b/tests/test_generate_followups.py
@@ -28,9 +28,9 @@ def test_generate_followups_wrapper(monkeypatch):
         "questions.generate._generate_followup_questions", fake_generate
     )
 
-    jd = NeedAnalysisProfile()
+    profile = NeedAnalysisProfile()
     questions = generate_followup_questions(
-        jd, num_questions=2, lang="de", use_rag=False
+        profile, num_questions=2, lang="de", use_rag=False
     )
 
     assert questions == ["Company name?", "Location?"]
@@ -47,5 +47,5 @@ def test_generate_followups_wrapper_empty(monkeypatch):
         "questions.generate._generate_followup_questions", fake_generate
     )
 
-    jd = NeedAnalysisProfile()
-    assert generate_followup_questions(jd) == []
+    profile = NeedAnalysisProfile()
+    assert generate_followup_questions(profile) == []

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -26,8 +26,10 @@ def test_guess_city_from_header() -> None:
 
 
 def test_parse_extraction_city_alias() -> None:
-    jd = parse_extraction('{"position": {"job_title": "Dev"}, "city": "Düsseldorf"}')
-    assert jd.location.primary_city == "Düsseldorf"
+    profile = parse_extraction(
+        '{"position": {"job_title": "Dev"}, "city": "Düsseldorf"}'
+    )
+    assert profile.location.primary_city == "Düsseldorf"
 
 
 def test_employment_and_start_date_fallbacks() -> None:

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -97,14 +97,14 @@ def test_extract_with_function(monkeypatch):
     )
     from core import schema as cs
 
-    class _FakeJD:
+    class _FakeProfile:
         def __init__(self, data: dict[str, str]) -> None:
             self._data = data
 
         def model_dump(self) -> dict[str, str]:
             return self._data
 
-    monkeypatch.setattr(cs, "coerce_and_fill", lambda data: _FakeJD(data))
+    monkeypatch.setattr(cs, "coerce_and_fill", lambda data: _FakeProfile(data))
 
     result = extract_with_function("text", {})
     assert result["job_title"] == "Dev"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,8 +9,8 @@ from utils.json_parse import parse_extraction  # noqa: E402
 
 
 def test_parse_pure_json() -> None:
-    jd = parse_extraction('{"position": {"job_title": "Dev"}}')
-    assert jd.position.job_title == "Dev"
+    profile = parse_extraction('{"position": {"job_title": "Dev"}}')
+    assert profile.position.job_title == "Dev"
 
 
 @pytest.mark.parametrize(
@@ -21,8 +21,8 @@ def test_parse_pure_json() -> None:
     ],
 )
 def test_parse_with_sanitization(raw: str) -> None:
-    jd = parse_extraction(raw)
-    assert jd.position.job_title == "Dev"
+    profile = parse_extraction(raw)
+    assert profile.position.job_title == "Dev"
 
 
 def test_parse_mismatched_quotes() -> None:
@@ -32,8 +32,8 @@ def test_parse_mismatched_quotes() -> None:
 
 def test_parse_benefits_string() -> None:
     raw = '{"compensation": {"benefits": "30 Urlaubstage, Sabbatical-Option, 1.000€ Lernbudget"}}'
-    jd = parse_extraction(raw)
-    assert jd.compensation.benefits == [
+    profile = parse_extraction(raw)
+    assert profile.compensation.benefits == [
         "30 Urlaubstage",
         "Sabbatical-Option",
         "1.000€ Lernbudget",
@@ -41,13 +41,13 @@ def test_parse_benefits_string() -> None:
 
 
 def test_parse_brand_name_alias() -> None:
-    jd = parse_extraction('{"Brand Name": "Acme"}')
-    assert jd.company.brand_name == "Acme"
+    profile = parse_extraction('{"Brand Name": "Acme"}')
+    assert profile.company.brand_name == "Acme"
 
 
 def test_parse_application_deadline_alias() -> None:
-    jd = parse_extraction('{"Application Deadline": "2024-12-31"}')
-    assert jd.meta.application_deadline == "2024-12-31"
+    profile = parse_extraction('{"Application Deadline": "2024-12-31"}')
+    assert profile.meta.application_deadline == "2024-12-31"
 
 
 def test_parse_type_coercion() -> None:
@@ -56,8 +56,8 @@ def test_parse_type_coercion() -> None:
         ' "compensation": {"equity_offered": "false"},'
         ' "requirements": {"hard_skills_required": "Python, SQL"}}'
     )
-    jd = parse_extraction(raw)
-    assert jd.employment.remote_percentage == 50
-    assert jd.employment.travel_required is True
-    assert jd.compensation.equity_offered is False
-    assert jd.requirements.hard_skills_required == ["Python", "SQL"]
+    profile = parse_extraction(raw)
+    assert profile.employment.remote_percentage == 50
+    assert profile.employment.travel_required is True
+    assert profile.compensation.equity_offered is False
+    assert profile.requirements.hard_skills_required == ["Python", "SQL"]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -31,25 +31,25 @@ def test_coerce_and_fill_basic() -> None:
         },
         "meta": {"target_start_date": "2024-01-01"},
     }
-    jd = coerce_and_fill(data)
-    assert isinstance(jd, NeedAnalysisProfile)
-    assert jd.position.job_title == "Engineer"
-    assert jd.requirements is not None
-    assert jd.responsibilities is not None
-    assert jd.employment is not None
-    assert jd.compensation is not None
-    assert jd.requirements.hard_skills_required == ["Python"]
-    assert jd.responsibilities.items == ["Code apps"]
-    assert jd.employment.job_type == "full time"
-    assert jd.employment.contract_type == "permanent"
-    assert jd.position.supervises == 3
-    assert jd.position.team_size == 10
-    assert jd.meta.target_start_date == "2024-01-01"
-    assert jd.compensation.benefits == ["Gym", "Gym"]
-    assert jd.compensation.bonus_percentage == 10.0
-    assert jd.compensation.commission_structure == "10% of sales"
-    assert jd.compensation.salary_provided is False
-    assert jd.company.name == "Acme"
+    profile = coerce_and_fill(data)
+    assert isinstance(profile, NeedAnalysisProfile)
+    assert profile.position.job_title == "Engineer"
+    assert profile.requirements is not None
+    assert profile.responsibilities is not None
+    assert profile.employment is not None
+    assert profile.compensation is not None
+    assert profile.requirements.hard_skills_required == ["Python"]
+    assert profile.responsibilities.items == ["Code apps"]
+    assert profile.employment.job_type == "full time"
+    assert profile.employment.contract_type == "permanent"
+    assert profile.position.supervises == 3
+    assert profile.position.team_size == 10
+    assert profile.meta.target_start_date == "2024-01-01"
+    assert profile.compensation.benefits == ["Gym", "Gym"]
+    assert profile.compensation.bonus_percentage == 10.0
+    assert profile.compensation.commission_structure == "10% of sales"
+    assert profile.compensation.salary_provided is False
+    assert profile.company.name == "Acme"
 
 
 def test_coerce_and_fill_employment_details() -> None:
@@ -65,11 +65,11 @@ def test_coerce_and_fill_employment_details() -> None:
             "relocation_details": "Budget provided",
         }
     }
-    jd = coerce_and_fill(data)
-    assert jd.employment.contract_end == "2025-12-31"
-    assert jd.employment.remote_percentage == 50
-    assert jd.employment.travel_details == "20% international"
-    assert jd.employment.relocation_details == "Budget provided"
+    profile = coerce_and_fill(data)
+    assert profile.employment.contract_end == "2025-12-31"
+    assert profile.employment.remote_percentage == 50
+    assert profile.employment.travel_details == "20% international"
+    assert profile.employment.relocation_details == "Budget provided"
 
 
 def test_coerce_and_fill_alias_mapping() -> None:
@@ -80,20 +80,20 @@ def test_coerce_and_fill_alias_mapping() -> None:
         "city": "Berlin",
         "date_of_employment_start": "2024-01-01",
     }
-    jd = coerce_and_fill(data)
-    assert jd.requirements.hard_skills_required == ["Python"]
-    assert jd.location.primary_city == "Berlin"
-    assert jd.meta.target_start_date == "2024-01-01"
+    profile = coerce_and_fill(data)
+    assert profile.requirements.hard_skills_required == ["Python"]
+    assert profile.location.primary_city == "Berlin"
+    assert profile.meta.target_start_date == "2024-01-01"
 
 
 def test_default_insertion() -> None:
-    jd = coerce_and_fill({})
-    assert jd.position.job_title is None
-    assert jd.company.name is None
-    assert jd.requirements.hard_skills_required == []
+    profile = coerce_and_fill({})
+    assert profile.position.job_title is None
+    assert profile.company.name is None
+    assert profile.requirements.hard_skills_required == []
 
 
 def test_job_type_invalid() -> None:
-    jd = coerce_and_fill({"employment": {"job_type": "unknown"}})
-    assert jd.employment is not None
-    assert jd.employment.job_type == "unknown"
+    profile = coerce_and_fill({"employment": {"job_type": "unknown"}})
+    assert profile.employment is not None
+    assert profile.employment.job_type == "unknown"

--- a/tests/test_session_migration.py
+++ b/tests/test_session_migration.py
@@ -4,8 +4,8 @@ from constants.keys import StateKeys, UIKeys
 from utils.session import bootstrap_session, migrate_legacy_keys
 
 
-def test_migrate_legacy_jd_text() -> None:
-    """Legacy ``jd_text`` key is moved to ``jd_raw_text``."""
+def test_migrate_legacy_profile_text() -> None:
+    """Legacy ``jd_text`` key is moved to ``profile_raw_text``."""
     st.session_state.clear()
     st.session_state["jd_text"] = "legacy"
     bootstrap_session()
@@ -14,17 +14,33 @@ def test_migrate_legacy_jd_text() -> None:
     assert "jd_text" not in st.session_state
 
 
+def test_migrate_jd_raw_text_alias() -> None:
+    """Existing ``jd_raw_text`` key is migrated to ``profile_raw_text``."""
+    st.session_state.clear()
+    st.session_state["jd_raw_text"] = "legacy"
+    bootstrap_session()
+    migrate_legacy_keys()
+    assert st.session_state.get(StateKeys.RAW_TEXT) == "legacy"
+    assert "jd_raw_text" not in st.session_state
+
+
 def test_migrate_legacy_ui_keys() -> None:
     """Legacy UI keys are promoted to namespaced ``ui.*`` variants."""
     st.session_state.clear()
     st.session_state["jd_text_input"] = "txt"
     st.session_state["jd_file_uploader"] = object()
     st.session_state["jd_url_input"] = "https://example.com"
+    st.session_state["ui.jd_text_input"] = "txt2"
+    st.session_state["ui.jd_file_uploader"] = object()
+    st.session_state["ui.jd_url_input"] = "https://example.org"
     bootstrap_session()
     migrate_legacy_keys()
-    assert st.session_state.get(UIKeys.JD_TEXT_INPUT) == "txt"
-    assert st.session_state.get(UIKeys.JD_FILE_UPLOADER) is not None
-    assert st.session_state.get(UIKeys.JD_URL_INPUT) == "https://example.com"
+    assert st.session_state.get(UIKeys.PROFILE_TEXT_INPUT) == "txt2"
+    assert st.session_state.get(UIKeys.PROFILE_FILE_UPLOADER) is not None
+    assert st.session_state.get(UIKeys.PROFILE_URL_INPUT) == "https://example.org"
     assert "jd_text_input" not in st.session_state
     assert "jd_file_uploader" not in st.session_state
     assert "jd_url_input" not in st.session_state
+    assert "ui.jd_text_input" not in st.session_state
+    assert "ui.jd_file_uploader" not in st.session_state
+    assert "ui.jd_url_input" not in st.session_state

--- a/tests/test_ss_bridge.py
+++ b/tests/test_ss_bridge.py
@@ -3,7 +3,7 @@ from core.ss_bridge import from_session_state, to_session_state
 
 
 def test_round_trip_session_state():
-    jd = coerce_and_fill(
+    profile = coerce_and_fill(
         {
             "position": {"job_title": "Dev"},
             "responsibilities": {"items": ["Code", "Review"]},
@@ -16,7 +16,7 @@ def test_round_trip_session_state():
         }
     )
     ss = {}
-    to_session_state(jd, ss)
-    jd2 = from_session_state(ss)
-    assert jd2 == jd
+    to_session_state(profile, ss)
+    profile2 = from_session_state(ss)
+    assert profile2 == profile
     assert ss["responsibilities.items"] == "Code\nReview"

--- a/tests/test_wizard_source.py
+++ b/tests/test_wizard_source.py
@@ -35,57 +35,61 @@ def _setup_common(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_on_file_uploaded_populates_text(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Uploading a file populates JD text and text input state."""
+    """Uploading a file populates profile text and text input state."""
 
     st.session_state.clear()
     st.session_state.lang = "en"
     sample_text = "from file"
     _setup_common(monkeypatch)
     monkeypatch.setattr("wizard.extract_text_from_file", lambda _f: sample_text)
-    st.session_state[UIKeys.JD_FILE_UPLOADER] = object()
+    st.session_state[UIKeys.PROFILE_FILE_UPLOADER] = object()
 
     on_file_uploaded()
 
-    assert st.session_state.get("__prefill_jd_text__") == sample_text
+    assert st.session_state.get("__prefill_profile_text__") == sample_text
     assert st.session_state.get("__run_extraction__") is True
 
     monkeypatch.setattr("wizard.extract_with_function", lambda _t, _s, model=None: {})
     monkeypatch.setattr("wizard.search_occupation", lambda _t, _l: None)
     monkeypatch.setattr(
-        st, "text_area", lambda *a, **k: st.session_state.get(UIKeys.JD_TEXT_INPUT, "")
+        st,
+        "text_area",
+        lambda *a, **k: st.session_state.get(UIKeys.PROFILE_TEXT_INPUT, ""),
     )
 
     _step_source({})
 
     assert st.session_state.get(StateKeys.RAW_TEXT) == sample_text
-    assert st.session_state.get(UIKeys.JD_TEXT_INPUT) == sample_text
+    assert st.session_state.get(UIKeys.PROFILE_TEXT_INPUT) == sample_text
 
 
 def test_on_url_changed_populates_text(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Entering a URL populates JD text and text input state."""
+    """Entering a URL populates profile text and text input state."""
 
     st.session_state.clear()
     st.session_state.lang = "en"
     sample_text = "from url"
     _setup_common(monkeypatch)
     monkeypatch.setattr("wizard.extract_text_from_url", lambda _u: sample_text)
-    st.session_state[UIKeys.JD_URL_INPUT] = "https://example.com"
+    st.session_state[UIKeys.PROFILE_URL_INPUT] = "https://example.com"
 
     on_url_changed()
 
-    assert st.session_state.get("__prefill_jd_text__") == sample_text
+    assert st.session_state.get("__prefill_profile_text__") == sample_text
     assert st.session_state.get("__run_extraction__") is True
 
     monkeypatch.setattr("wizard.extract_with_function", lambda _t, _s, model=None: {})
     monkeypatch.setattr("wizard.search_occupation", lambda _t, _l: None)
     monkeypatch.setattr(
-        st, "text_area", lambda *a, **k: st.session_state.get(UIKeys.JD_TEXT_INPUT, "")
+        st,
+        "text_area",
+        lambda *a, **k: st.session_state.get(UIKeys.PROFILE_TEXT_INPUT, ""),
     )
 
     _step_source({})
 
     assert st.session_state.get(StateKeys.RAW_TEXT) == sample_text
-    assert st.session_state.get(UIKeys.JD_TEXT_INPUT) == sample_text
+    assert st.session_state.get(UIKeys.PROFILE_TEXT_INPUT) == sample_text
 
 
 def test_on_url_changed_handles_none(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -95,12 +99,12 @@ def test_on_url_changed_handles_none(monkeypatch: pytest.MonkeyPatch) -> None:
     st.session_state.lang = "en"
     _setup_common(monkeypatch)
     monkeypatch.setattr("wizard.extract_text_from_url", lambda _u: None)
-    st.session_state[UIKeys.JD_URL_INPUT] = "https://example.com"
+    st.session_state[UIKeys.PROFILE_URL_INPUT] = "https://example.com"
 
     on_url_changed()
 
     assert st.session_state.get(StateKeys.RAW_TEXT) == ""
-    assert "__prefill_jd_text__" not in st.session_state
+    assert "__prefill_profile_text__" not in st.session_state
 
 
 @pytest.mark.parametrize("mode", ["text", "file", "url"])
@@ -126,17 +130,19 @@ def test_step_source_populates_data(monkeypatch: pytest.MonkeyPatch, mode: str) 
 
     if mode == "file":
         monkeypatch.setattr("wizard.extract_text_from_file", lambda _f: sample_text)
-        st.session_state[UIKeys.JD_FILE_UPLOADER] = object()
+        st.session_state[UIKeys.PROFILE_FILE_UPLOADER] = object()
         on_file_uploaded()
     elif mode == "url":
         monkeypatch.setattr("wizard.extract_text_from_url", lambda _u: sample_text)
-        st.session_state[UIKeys.JD_URL_INPUT] = "https://example.com"
+        st.session_state[UIKeys.PROFILE_URL_INPUT] = "https://example.com"
         on_url_changed()
     else:
-        st.session_state[UIKeys.JD_TEXT_INPUT] = sample_text
+        st.session_state[UIKeys.PROFILE_TEXT_INPUT] = sample_text
 
     monkeypatch.setattr(
-        st, "text_area", lambda *a, **k: st.session_state.get(UIKeys.JD_TEXT_INPUT, "")
+        st,
+        "text_area",
+        lambda *a, **k: st.session_state.get(UIKeys.PROFILE_TEXT_INPUT, ""),
     )
 
     _step_source({})
@@ -153,7 +159,7 @@ def test_step_source_merges_esco_skills(monkeypatch: pytest.MonkeyPatch) -> None
     st.session_state.model = "gpt"
     st.session_state[StateKeys.STEP] = 0
     sample_text = "Job text"
-    st.session_state[UIKeys.JD_TEXT_INPUT] = sample_text
+    st.session_state[UIKeys.PROFILE_TEXT_INPUT] = sample_text
     sample_data = {
         "position": {"job_title": "Engineer"},
         "requirements": {"hard_skills_required": ["Python"]},
@@ -201,7 +207,7 @@ def test_step_source_flags_missing_fields(monkeypatch: pytest.MonkeyPatch) -> No
     st.session_state.model = "gpt"
     sample_text = "random text without info"
     _setup_common(monkeypatch)
-    st.session_state[UIKeys.JD_TEXT_INPUT] = sample_text
+    st.session_state[UIKeys.PROFILE_TEXT_INPUT] = sample_text
     analyze_label = t("analyze", st.session_state.lang)
 
     monkeypatch.setattr(st, "button", lambda label, *a, **k: label == analyze_label)
@@ -228,7 +234,7 @@ def test_step_source_skip_creates_empty_profile(
     monkeypatch.setattr(
         st,
         "text_area",
-        lambda *a, **k: st.session_state.get(UIKeys.JD_TEXT_INPUT, ""),
+        lambda *a, **k: st.session_state.get(UIKeys.PROFILE_TEXT_INPUT, ""),
     )
 
     skip_label = "Continue without template"
@@ -248,7 +254,7 @@ def test_step_source_skip_creates_empty_profile(
 def test_on_change_handles_extraction_errors(
     monkeypatch: pytest.MonkeyPatch, mode: str
 ) -> None:
-    """Extraction errors should show a message and keep JD text unchanged."""
+    """Extraction errors should show a message and keep profile text unchanged."""
 
     st.session_state.clear()
     st.session_state.lang = "en"
@@ -262,7 +268,7 @@ def test_on_change_handles_extraction_errors(
             raise ValueError("bad file")
 
         monkeypatch.setattr("wizard.extract_text_from_file", raise_err)
-        st.session_state[UIKeys.JD_FILE_UPLOADER] = object()
+        st.session_state[UIKeys.PROFILE_FILE_UPLOADER] = object()
         on_file_uploaded()
     else:
 
@@ -270,7 +276,7 @@ def test_on_change_handles_extraction_errors(
             raise ValueError("bad url")
 
         monkeypatch.setattr("wizard.extract_text_from_url", raise_err)
-        st.session_state[UIKeys.JD_URL_INPUT] = "https://example.com"
+        st.session_state[UIKeys.PROFILE_URL_INPUT] = "https://example.com"
         on_url_changed()
 
     assert st.session_state.get(StateKeys.RAW_TEXT, "") == ""
@@ -283,6 +289,6 @@ def test_autodetect_lang_sets_en() -> None:
     st.session_state.clear()
     st.session_state.lang = "de"
 
-    _autodetect_lang("This is an English job description.")
+    _autodetect_lang("This is an English job posting.")
 
     assert st.session_state.lang == "en"

--- a/utils/session.py
+++ b/utils/session.py
@@ -59,10 +59,11 @@ def migrate_legacy_keys() -> None:
     """Migrate legacy session keys for backward compatibility.
 
     Older versions stored widget and data values under plain keys like
-    ``jd_text`` or nested structures such as ``data.jd_text``. Newer releases
-    use flat, descriptive keys defined in :class:`StateKeys`. This function
-    promotes old keys to their new counterparts and removes the deprecated
-    entries to prevent collisions.
+    ``jd_text`` or nested structures such as ``data.jd_text``. Later revisions
+    renamed ``jd_raw_text`` to ``profile_raw_text``. Newer releases use flat,
+    descriptive keys defined in :class:`StateKeys`. This function promotes old
+    keys to their new counterparts and removes the deprecated entries to prevent
+    collisions.
     """
 
     ss = st.session_state
@@ -72,8 +73,11 @@ def migrate_legacy_keys() -> None:
         ss[StateKeys.RAW_TEXT] = ss["jd_text"]
     if "data.jd_text" in ss and not ss.get(StateKeys.RAW_TEXT):
         ss[StateKeys.RAW_TEXT] = ss["data.jd_text"]
+    if "jd_raw_text" in ss and not ss.get(StateKeys.RAW_TEXT):
+        ss[StateKeys.RAW_TEXT] = ss["jd_raw_text"]
     ss.pop("jd_text", None)
     ss.pop("data.jd_text", None)
+    ss.pop("jd_raw_text", None)
 
     if "data.profile" in ss and not ss.get(StateKeys.PROFILE):
         ss[StateKeys.PROFILE] = ss["data.profile"]
@@ -95,11 +99,16 @@ def migrate_legacy_keys() -> None:
 
     # --- UI key migrations ---
     legacy_ui_map: Dict[str, str] = {
-        "jd_text_input": UIKeys.JD_TEXT_INPUT,
-        "jd_file_uploader": UIKeys.JD_FILE_UPLOADER,
-        "jd_url_input": UIKeys.JD_URL_INPUT,
+        "ui.jd_text_input": UIKeys.PROFILE_TEXT_INPUT,
+        "ui.jd_file_uploader": UIKeys.PROFILE_FILE_UPLOADER,
+        "ui.jd_url_input": UIKeys.PROFILE_URL_INPUT,
+        "jd_text_input": UIKeys.PROFILE_TEXT_INPUT,
+        "jd_file_uploader": UIKeys.PROFILE_FILE_UPLOADER,
+        "jd_url_input": UIKeys.PROFILE_URL_INPUT,
     }
     for old, new in legacy_ui_map.items():
-        if old in ss and not ss.get(new):
+        if old in ss and old.startswith("ui."):
+            ss[new] = ss[old]
+        elif old in ss and not ss.get(new):
             ss[new] = ss[old]
         ss.pop(old, None)

--- a/wizard.py
+++ b/wizard.py
@@ -75,9 +75,9 @@ def prev_step() -> None:
 
 
 def on_file_uploaded() -> None:
-    """Handle file uploads and populate job description text."""
+    """Handle file uploads and populate job posting text."""
 
-    f = st.session_state.get(UIKeys.JD_FILE_UPLOADER)
+    f = st.session_state.get(UIKeys.PROFILE_FILE_UPLOADER)
     if not f:
         return
     try:
@@ -146,15 +146,15 @@ def on_file_uploaded() -> None:
         )
         st.session_state["source_error"] = True
         return
-    st.session_state["__prefill_jd_text__"] = txt
+    st.session_state["__prefill_profile_text__"] = txt
     st.session_state["__run_extraction__"] = True
     st.rerun()
 
 
 def on_url_changed() -> None:
-    """Fetch text from URL and populate job description text."""
+    """Fetch text from URL and populate job posting text."""
 
-    url = st.session_state.get(UIKeys.JD_URL_INPUT, "").strip()
+    url = st.session_state.get(UIKeys.PROFILE_URL_INPUT, "").strip()
     if not url:
         return
     if not re.match(r"^https?://[\w./-]+$", url):
@@ -187,7 +187,7 @@ def on_url_changed() -> None:
         )
         st.session_state["source_error"] = True
         return
-    st.session_state["__prefill_jd_text__"] = txt
+    st.session_state["__prefill_profile_text__"] = txt
     st.session_state["__run_extraction__"] = True
 
 
@@ -520,11 +520,11 @@ def _step_intro():
         tr(
             (
                 "Dieser Wizard hilft Ihnen, alle relevanten Stellenanforderungen zu sammeln und aufzubereiten. "
-                "Am Ende erhalten Sie ein strukturiertes Profil Ihrer Vakanz."
+                "Am Ende erhalten Sie ein strukturiertes Stellenprofil."
             ),
             (
                 "This wizard helps you collect and organize all relevant job requirements. "
-                "In the end, you'll receive a structured profile of your vacancy."
+                "In the end, you'll receive a structured job profile."
             ),
         )
     )
@@ -601,7 +601,7 @@ def _step_source(schema: dict) -> None:
     st.caption(
         tr(
             "Stellenbeschreibung laden oder diesen Schritt überspringen, um Daten manuell einzugeben.",
-            "Load a job description or skip to enter data manually.",
+            "Load a job posting or skip to enter data manually.",
         )
     )
     if st.session_state.pop("source_error", False):
@@ -611,9 +611,9 @@ def _step_source(schema: dict) -> None:
                 "You can still fill in the info manually in the next steps.",
             )
         )
-    prefill = st.session_state.pop("__prefill_jd_text__", None)
+    prefill = st.session_state.pop("__prefill_profile_text__", None)
     if prefill is not None:
-        st.session_state[UIKeys.JD_TEXT_INPUT] = prefill
+        st.session_state[UIKeys.PROFILE_TEXT_INPUT] = prefill
         st.session_state[StateKeys.RAW_TEXT] = prefill
     if st.session_state.pop("__run_extraction__", False) and st.session_state.get(
         StateKeys.RAW_TEXT
@@ -639,11 +639,11 @@ def _step_source(schema: dict) -> None:
     with tab_text:
         bind_textarea(
             tr("Jobtext", "Job text"),
-            UIKeys.JD_TEXT_INPUT,
+            UIKeys.PROFILE_TEXT_INPUT,
             StateKeys.RAW_TEXT,
             placeholder=tr(
-                "Bitte JD-Text einfügen oder Datei/URL wählen...",
-                "Paste JD text here or upload a file / enter URL...",
+                "Bitte Stellenanzeigentext einfügen oder Datei/URL wählen...",
+                "Paste job posting text here or upload a file / enter URL...",
             ),
             help=tr(
                 "Fügen Sie den reinen Text Ihrer Stellenanzeige ein.",
@@ -653,9 +653,12 @@ def _step_source(schema: dict) -> None:
 
     with tab_file:
         st.file_uploader(
-            tr("JD hochladen (PDF/DOCX/TXT)", "Upload JD (PDF/DOCX/TXT)"),
+            tr(
+                "Stellenanzeige hochladen (PDF/DOCX/TXT)",
+                "Upload job posting (PDF/DOCX/TXT)",
+            ),
             type=["pdf", "docx", "txt"],
-            key=UIKeys.JD_FILE_UPLOADER,
+            key=UIKeys.PROFILE_FILE_UPLOADER,
             on_change=on_file_uploaded,
             help=tr(
                 "Unterstützte Formate: PDF, DOCX oder TXT.",
@@ -665,8 +668,8 @@ def _step_source(schema: dict) -> None:
 
     with tab_url:
         st.text_input(
-            tr("oder eine Job-URL eingeben", "or enter a Job URL"),
-            key=UIKeys.JD_URL_INPUT,
+            tr("oder eine Stellenanzeige-URL eingeben", "or enter a job posting URL"),
+            key=UIKeys.PROFILE_URL_INPUT,
             on_change=on_url_changed,
             placeholder="https://example.com/job",
             help=tr(
@@ -678,7 +681,7 @@ def _step_source(schema: dict) -> None:
     analyze_clicked = st.button(t("analyze", st.session_state.lang), type="primary")
     skip_clicked = st.button(tr("Ohne Vorlage fortfahren", "Continue without template"))
     if analyze_clicked:
-        raw = (st.session_state.get(UIKeys.JD_TEXT_INPUT, "") or "").strip()
+        raw = (st.session_state.get(UIKeys.PROFILE_TEXT_INPUT, "") or "").strip()
         st.session_state["_analyze_attempted"] = True
         if not raw:
             st.warning(
@@ -2493,7 +2496,7 @@ def _step_summary(schema: dict, critical: list[str]):
 
 # --- Haupt-Wizard-Runner ---
 def run_wizard():
-    """Run the multi-step vacancy creation wizard.
+    """Run the multi-step profile creation wizard.
 
     Returns:
         None


### PR DESCRIPTION
## Summary
- rename JD-related state keys and UI labels to profile equivalents
- migrate legacy `jd_*` session keys to new `profile_*` names
- refresh docs and tests for consistent profile terminology

## Testing
- `python -m black .`
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0bef3c0b08320aec0882e2c8a057d