### PR TITLE
fix: add top-level name to tool specs

### DIFF
--- a/core/analysis_tools.py
+++ b/core/analysis_tools.py
@@ -63,31 +63,27 @@ def build_analysis_tools() -> Tuple[list[dict], Mapping[str, Callable[..., Any]]
     tools = [
         {
             "type": "function",
-            "function": {
-                "name": "get_salary_benchmark",
-                "description": "Fetch a rough annual salary range for a role in a country.",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "role": {"type": "string"},
-                        "country": {"type": "string"},
-                    },
-                    "required": ["role"],
+            "name": "get_salary_benchmark",
+            "description": "Fetch a rough annual salary range for a role in a country.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "role": {"type": "string"},
+                    "country": {"type": "string"},
                 },
+                "required": ["role"],
             },
         },
         {
             "type": "function",
-            "function": {
-                "name": "get_skill_definition",
-                "description": "Return a concise definition for a skill.",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "skill": {"type": "string"},
-                    },
-                    "required": ["skill"],
+            "name": "get_skill_definition",
+            "description": "Return a concise definition for a skill.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "skill": {"type": "string"},
                 },
+                "required": ["skill"],
             },
         },
     ]

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -392,11 +392,9 @@ def build_extraction_tool(
     return [
         {
             "type": "function",
-            "function": {
-                "name": name,
-                "description": "Return structured profile data that fits the schema exactly.",
-                "parameters": params,
-            },
+            "name": name,
+            "description": "Return structured profile data that fits the schema exactly.",
+            "parameters": params,
             "strict": not allow_extra,
         }
     ]

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -46,7 +46,7 @@ def test_call_chat_api_tool_call(monkeypatch):
     monkeypatch.setattr("openai_utils.client", _FakeClient(), raising=False)
     out = call_chat_api(
         [],
-        tools=[{"type": "function", "function": {"name": "fn", "parameters": {}}}],
+        tools=[{"type": "function", "name": "fn", "parameters": {}}],
         tool_choice={"type": "function", "name": "fn"},
     )
     assert out.tool_calls[0]["function"]["arguments"] == '{"job_title": "x"}'
@@ -58,8 +58,8 @@ def test_build_extraction_tool_has_name_and_parameters():
     schema = {"type": "object", "properties": {}}
     tool = openai_utils.build_extraction_tool("vacalyser_extract", schema)
     spec = tool[0]
-    assert spec["function"]["name"] == "vacalyser_extract"
-    assert spec["function"]["parameters"]["type"] == "object"
+    assert spec["name"] == "vacalyser_extract"
+    assert spec["parameters"]["type"] == "object"
 
 
 def test_call_chat_api_passes_reasoning(monkeypatch):


### PR DESCRIPTION
## Summary
- fix OpenAI tool definitions by adding top-level `name` fields
- update extraction tool builder to return new spec format
- adjust unit tests for new tool schema

## Testing
- `black core/analysis_tools.py openai_utils.py tests/test_openai_utils.py`
- `ruff check core/analysis_tools.py openai_utils.py tests/test_openai_utils.py`
- `mypy core/analysis_tools.py openai_utils.py tests/test_openai_utils.py`
- `PYTHONPATH=. pytest tests/test_openai_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0cda082bc83209e553aff887ac0aa