### PR TITLE
Fix reasoning models temperature parameter handling

### DIFF
--- a/openai_utils/__init__.py
+++ b/openai_utils/__init__.py
@@ -12,7 +12,13 @@ Most existing code imports directly from ``openai_utils``; the symbols below are
 re-exported for backward compatibility.
 """
 
-from .api import ChatCallResult, call_chat_api, get_client, client
+from .api import (
+    ChatCallResult,
+    call_chat_api,
+    get_client,
+    client,
+    model_supports_temperature,
+)
 from .tools import build_extraction_tool
 from .extraction import *  # noqa: F401,F403
 from .extraction import __all__ as _extraction_all
@@ -22,5 +28,6 @@ __all__ = [
     "call_chat_api",
     "client",
     "get_client",
+    "model_supports_temperature",
     "build_extraction_tool",
 ] + _extraction_all


### PR DESCRIPTION
## Summary
- add a helper that detects OpenAI reasoning models and skips sending `temperature`
- use the shared helper in the responses client so reasoning models no longer receive unsupported parameters
- add regression tests covering the temperature handling logic

## Testing
- ruff check
- black .
- mypy .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c97d8598b8832098eab9bfc13d89d6