### PR TITLE
fix: gate reasoning payload by model

### DIFF
--- a/llm/client.py
+++ b/llm/client.py
@@ -12,7 +12,7 @@ from jsonschema import Draft7Validator
 from openai import OpenAI
 import streamlit as st
 
-from openai_utils import model_supports_temperature
+from openai_utils import model_supports_reasoning, model_supports_temperature
 from .context import build_extract_messages
 from .prompts import FIELDS_ORDER
 from core.errors import ExtractionError
@@ -123,12 +123,13 @@ def extract_json(
         request: dict[str, Any] = {
             "model": model,
             "input": messages,
-            "reasoning": {"effort": effort},
             "response_format": {
                 "type": "json_schema",
                 "json_schema": NEED_ANALYSIS_SCHEMA,
             },
         }
+        if model_supports_reasoning(model):
+            request["reasoning"] = {"effort": effort}
         if model_supports_temperature(model):
             request["temperature"] = 0
         response = OPENAI_CLIENT.responses.create(**request)
@@ -141,8 +142,9 @@ def extract_json(
             request = {
                 "model": model,
                 "input": messages,
-                "reasoning": {"effort": effort},
             }
+            if model_supports_reasoning(model):
+                request["reasoning"] = {"effort": effort}
             if model_supports_temperature(model):
                 request["temperature"] = 0
             response = OPENAI_CLIENT.responses.create(**request)

--- a/openai_utils/__init__.py
+++ b/openai_utils/__init__.py
@@ -17,6 +17,7 @@ from .api import (
     call_chat_api,
     get_client,
     client,
+    model_supports_reasoning,
     model_supports_temperature,
 )
 from .tools import build_extraction_tool
@@ -28,6 +29,7 @@ __all__ = [
     "call_chat_api",
     "client",
     "get_client",
+    "model_supports_reasoning",
     "model_supports_temperature",
     "build_extraction_tool",
 ] + _extraction_all


### PR DESCRIPTION
## Summary
- add a helper that recognises reasoning-capable models and only attaches the reasoning payload when supported
- guard llm extraction requests so that reasoning is sent conditionally and re-export the helper
- update OpenAI utility tests to cover reasoning and non-reasoning models

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c990e4b3688320b9644c13c6ad3bea