### PR TITLE
chore: rebrand to cognitive needs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# Vacalyser — Autonomous Agents
+# Cognitive Needs — Autonomous Agents
 
-This document lists all current and planned autonomous agents in Vacalyser, along with their roles and interfaces. Each agent is small, focused, and composable. *Note: earlier docs used the labels “GPT‑4o” and “GPT‑4o‑mini”; in code these map to OpenAI’s cost-optimized `gpt-5-nano` and `gpt-4.1-nano` models respectively.*
+This document lists all current and planned autonomous agents in Cognitive Needs, along with their roles and interfaces. Each agent is small, focused, and composable. *Note: earlier docs used the labels “GPT‑4o” and “GPT‑4o‑mini”; in code these map to OpenAI’s cost-optimized `gpt-5-nano` and `gpt-4.1-nano` models respectively.*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Vacalyser — AI Recruitment Need Analysis (Streamlit)
+# Cognitive Needs — AI Recruitment Need Analysis (Streamlit)
 
-**Vacalyser** turns messy job ads into a **complete, structured profile**, then asks only the *minimal* follow‑ups. It enriches with **ESCO** (skills/occupations) and your **OpenAI Vector Store** to propose **missing skills, benefits, tools, and tasks**. Finally, it generates a polished **job ad**, **interview guide**, and **boolean search string**.
+**Cognitive Needs** turns messy job ads into a **complete, structured profile**, then asks only the *minimal* follow‑ups. It enriches with **ESCO** (skills/occupations) and your **OpenAI Vector Store** to propose **missing skills, benefits, tools, and tasks**. Finally, it generates a polished **job ad**, **interview guide**, and **boolean search string**.
 
-Vacalyser supports OpenAI’s cost-optimized `gpt-4o-mini` and flagship
+Cognitive Needs supports OpenAI’s cost-optimized `gpt-4o-mini` and flagship
 `gpt-4o` models on compatible endpoints and falls back to the widely available
 `gpt-3.5-turbo` by default. These newer models improve reasoning, support
 JSON-mode structured output and tool calls, and deliver lower cost and
@@ -127,7 +127,7 @@ models such as `gpt-4o-mini` require a compatible OpenAI or Azure endpoint.
 
 ### Model selection & reasoning effort
 
-Vacalyser auto-detects the endpoint: it uses `gpt-4o-mini` on compatible custom
+Cognitive Needs auto-detects the endpoint: it uses `gpt-4o-mini` on compatible custom
 deployments and `gpt-3.5-turbo` on the public API. Set `OPENAI_MODEL` or
 `DEFAULT_MODEL` to `gpt-4o`, `gpt-4`, or any other supported model, and adjust
 `REASONING_EFFORT` (`low`, `medium`, or `high`) for more or less
@@ -148,7 +148,7 @@ the default OpenAI API URL.
 
 ### Configuration
 
-Vacalyser reads API credentials from environment variables or [Streamlit
+Cognitive Needs reads API credentials from environment variables or [Streamlit
 secrets](https://docs.streamlit.io/streamlit-community-cloud/get-started/deploy-an-app/secrets-management). At minimum,
 define `OPENAI_API_KEY` before launching the app:
 
@@ -179,7 +179,7 @@ Other environment flags:
 
 ### Optional: OCR for scanned PDFs
 
-Vacalyser can perform OCR on PDF pages without embedded text. Install the
+Cognitive Needs can perform OCR on PDF pages without embedded text. Install the
 dependencies and corresponding system packages:
 
 ```bash
@@ -197,7 +197,7 @@ set the environment variable `VECTOR_STORE_ID` to its ID:
 export VECTOR_STORE_ID=vs_XXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
-If `VECTOR_STORE_ID` is unset or empty, Vacalyser runs without RAG.
+If `VECTOR_STORE_ID` is unset or empty, Cognitive Needs runs without RAG.
 
 ## Troubleshooting
 
@@ -224,7 +224,7 @@ missing.
 
 ## Built-in Analysis Tools
 
-Vacalyser registers light-weight tools that the model can call via the
+Cognitive Needs registers light-weight tools that the model can call via the
 Responses API:
 
 - `get_salary_benchmark(role, country="US")` – returns an illustrative annual

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-# app.py — Vacalyser (clean entrypoint, single source of truth)
+# app.py — Cognitive Needs (clean entrypoint, single source of truth)
 from __future__ import annotations
 
 from pathlib import Path
@@ -15,7 +15,7 @@ from state import ensure_state, reset_state
 
 # --- Page config early (keine doppelten Titel/Icon-Resets) ---
 st.set_page_config(
-    page_title="Vacalyser — AI Recruitment Need Analysis",
+    page_title="Cognitive Needs - AI powered Recruitment Analysis, Detection and Improvement Tool",
     page_icon="🧭",
     layout="wide",
 )
@@ -44,9 +44,9 @@ def inject_global_css() -> None:
     """Inject the global stylesheet and background image."""
 
     theme = (
-        "vacalyser.css"
+        "cognitive_needs.css"
         if st.session_state.get("dark_mode", True)
-        else "vacalyser_light.css"
+        else "cognitive_needs_light.css"
     )
     css = (ROOT / "styles" / theme).read_text(encoding="utf-8")
     bg_bytes = (ROOT / "images" / "AdobeStock_506577005.jpeg").read_bytes()

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,1 +1,1 @@
-"""Command line interfaces for Vacalyser."""
+"""Command line interfaces for Cognitive Needs."""

--- a/cli/extract.py
+++ b/cli/extract.py
@@ -18,7 +18,7 @@ def main() -> None:
         python -m cli.extract --file profile.pdf --title "..." --url "..."
     """
 
-    parser = argparse.ArgumentParser(description="Vacalyser JSON extractor")
+    parser = argparse.ArgumentParser(description="Cognitive Needs JSON extractor")
     parser.add_argument("--file", required=True, help="Path to the job posting file")
     parser.add_argument("--title", help="Optional job title for context")
     parser.add_argument("--url", help="Optional source URL for context")

--- a/components/tailwind_injector.py
+++ b/components/tailwind_injector.py
@@ -92,7 +92,7 @@ def inject_tailwind(theme: str = "dark") -> None:
         parentDoc.head.appendChild(s);
       }}
       parentDoc.documentElement.classList.toggle('dark', '{theme}' === 'dark');
-      const styleId = 'vacalyser-theme-vars';
+      const styleId = 'cognitive-needs-theme-vars';
       let st = parentDoc.getElementById(styleId);
       if (!st) {{
         st = parentDoc.createElement('style');

--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
-"""Central configuration for Vacalyser's Responses API client.
+"""Central configuration for the Cognitive Needs Responses API client.
 
 The application uses cost-optimized ``gpt-4o-mini``/``gpt-4o`` models on
 endpoints that support them and falls back to the widely available

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,4 +1,4 @@
-"""Core package for Vacalyser models and utilities."""
+"""Core package for Cognitive Needs models and utilities."""
 
 from .field_suggestions import FIELD_SUGGESTIONS, get_field_suggestions
 

--- a/core/esco_utils.py
+++ b/core/esco_utils.py
@@ -18,8 +18,8 @@ import requests
 import streamlit as st
 
 _ESO = "https://ec.europa.eu/esco/api"
-_HEADERS = {"User-Agent": "Vacalyser/1.0"}
-log = logging.getLogger("vacalyser.esco")
+_HEADERS = {"User-Agent": "CognitiveNeeds/1.0"}
+log = logging.getLogger("cognitive_needs.esco")
 
 _SKILL_CACHE: Dict[Tuple[str, str], Dict[str, str]] = {}
 

--- a/core/schema.py
+++ b/core/schema.py
@@ -100,5 +100,5 @@ def coerce_and_fill(data: Mapping[str, Any] | None) -> NeedAnalysisProfile:
 
 
 # Backwards compatibility aliases
-VacalyserProfile = NeedAnalysisProfile
-VacalyserJD = NeedAnalysisProfile  # pragma: no cover - legacy alias
+CognitiveNeedsProfile = NeedAnalysisProfile
+CognitiveNeedsJD = NeedAnalysisProfile  # pragma: no cover - legacy alias

--- a/i18n.py
+++ b/i18n.py
@@ -1,4 +1,4 @@
-"""Core translation utilities for Vacalyser."""
+"""Core translation utilities for Cognitive Needs."""
 
 from __future__ import annotations
 

--- a/ingest/extractors.py
+++ b/ingest/extractors.py
@@ -28,7 +28,7 @@ def _fetch_url(url: str, timeout: float = 15.0) -> str:
         raise ValueError("Invalid URL")
     try:
         resp: Response = requests.get(
-            url, timeout=timeout, headers={"User-Agent": "Vacalyser/1.0"}
+            url, timeout=timeout, headers={"User-Agent": "CognitiveNeeds/1.0"}
         )
         resp.raise_for_status()
     except requests.RequestException as exc:  # pragma: no cover - network

--- a/ingest/reader.py
+++ b/ingest/reader.py
@@ -33,7 +33,7 @@ def _read_pdf(path: Path) -> str:
 
 
 _URL_RE = re.compile(r"^https?://[\w./-]+$")
-_HEADERS = {"User-Agent": "Vacalyser/1.0"}
+_HEADERS = {"User-Agent": "CognitiveNeeds/1.0"}
 
 
 def _read_url(url: str) -> str:

--- a/integrations/esco.py
+++ b/integrations/esco.py
@@ -10,7 +10,7 @@ from typing import Dict, List
 
 from core import esco_utils
 
-log = logging.getLogger("vacalyser.esco")
+log = logging.getLogger("cognitive_needs.esco")
 
 # Environment flag intentionally named ``VACAYSER_OFFLINE`` (without an ``l``)
 # to match historical "Vacayser" naming used in earlier deployments.

--- a/llm/client.py
+++ b/llm/client.py
@@ -18,7 +18,7 @@ from .prompts import FIELDS_ORDER
 from core.errors import ExtractionError
 from config import OPENAI_API_KEY, OPENAI_BASE_URL, OPENAI_MODEL, REASONING_EFFORT
 
-logger = logging.getLogger("vacalyser.llm")
+logger = logging.getLogger("cognitive_needs.llm")
 
 
 def _assert_closed_schema(schema: dict[str, Any]) -> None:

--- a/openai_utils/api.py
+++ b/openai_utils/api.py
@@ -30,7 +30,7 @@ import streamlit as st
 from config import OPENAI_API_KEY, OPENAI_MODEL, OPENAI_BASE_URL, REASONING_EFFORT
 from constants.keys import StateKeys
 
-logger = logging.getLogger("vacalyser.openai")
+logger = logging.getLogger("cognitive_needs.openai")
 
 # Global client instance (monkeypatchable in tests)
 client: OpenAI | None = None

--- a/openai_utils/extraction.py
+++ b/openai_utils/extraction.py
@@ -117,7 +117,7 @@ def extract_with_function(
     """
     if model is None:
         model = st.session_state.get("model", OPENAI_MODEL)
-    fn_name = "vacalyser_extract"
+    fn_name = "cognitive_needs_extract"
     messages: Sequence[dict] = [
         {
             "role": "system",

--- a/pages/advantages.py
+++ b/pages/advantages.py
@@ -1,5 +1,5 @@
 # pages/advantages.py
-"""Streamlit-Seite: Vorteile / Advantages von Vacalyser
+"""Streamlit-Seite: Vorteile / Advantages von Cognitive Needs
 
 Bietet einen Sprachumschalter (Deutsch ↔ English) und drei Tabs für die
 Zielgruppen Line Manager, Recruiter und Unternehmen.
@@ -305,14 +305,14 @@ intro_en = (
 
 finish_de = (
     "Auf Basis dieser Daten kannst du DSGVO-geprüfte Stellenanzeigen, Boolean-Suchstrings, "
-    "Verträge oder Interviewleitfäden erstellen. Vacalyser lässt sich lokal betreiben, um "
+    "Verträge oder Interviewleitfäden erstellen. Cognitive Needs lässt sich lokal betreiben, um "
     "sensible Daten zu schützen, und der Gehaltsrechner unterstützt bei der Definition von "
     "Must- und Nice-to-have-Skills."
 )
 
 finish_en = (
     "Use the collected data to create GDPR-safe job ads, boolean search strings, contracts "
-    "or interview guides. Run Vacalyser locally to keep information secure while the salary "
+    "or interview guides. Run Cognitive Needs locally to keep information secure while the salary "
     "calculator helps define must-have and nice-to-have skills."
 )
 

--- a/pages/tech_overview.py
+++ b/pages/tech_overview.py
@@ -2,7 +2,7 @@
 """Streamlit-Seite: Technology Deep Dive & Wizard Flow
 
 Für IT‑Spezialisten und Entscheider bietet diese Seite einen kompakten, aber
-technisch fundierten Überblick über den *Vacalyser*-Stack sowie eine visuelle
+technisch fundierten Überblick über den *Cognitive Needs*-Stack sowie eine visuelle
 Darstellung des mehrstufigen Wizard‑Flows (Discovery‑Process).
 Ein Sprach‑ und Zielgruppenumschalter sorgt dafür, dass Texte sowohl für ein
 Fach‑Publikum (Tech‑interessiert/Tech‑savvy) als auch für nicht‑technische
@@ -85,7 +85,7 @@ tech_info = {
         "Allgemein verständlich": [
             (
                 "Künstliche Intelligenz",
-                "Vacalyser nutzt modernste KI, um Stellenanforderungen präzise zu verstehen und passende Kompetenzen vorzuschlagen.",
+                "Cognitive Needs nutzt modernste KI, um Stellenanforderungen präzise zu verstehen und passende Kompetenzen vorzuschlagen.",
             ),
             (
                 "Schlaue Suche",
@@ -147,7 +147,7 @@ tech_info = {
         "General public": [
             (
                 "Artificial Intelligence",
-                "Vacalyser uses cutting‑edge AI to understand job requirements and suggest matching skills.",
+                "Cognitive Needs uses cutting‑edge AI to understand job requirements and suggest matching skills.",
             ),
             (
                 "Smart Search",
@@ -209,10 +209,10 @@ else:
 st.title(title)
 
 intro = (
-    "Nachfolgend findest du die Schlüsseltechnologien, die Vacalyser antreiben, "
+    "Nachfolgend findest du die Schlüsseltechnologien, die Cognitive Needs antreiben, "
     "sowie eine Grafik, die den Discovery‑Prozess Schritt für Schritt veranschaulicht."
     if lang == "de"
-    else "Below you can explore the core technologies powering Vacalyser together with a graph "
+    else "Below you can explore the core technologies powering Cognitive Needs together with a graph "
     "illustrating each step of the discovery process."
 )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
-name = vacalyser
+name = cognitive-needs
 version = 0.3.0
 description = AI-powered vacancy analysis with ESCO and vector-store RAG
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/KleinerBaum/cognitivestaffing
-author = Vacalyser Authors
+author = Cognitive Needs Authors
 license = MIT
 classifiers =
     Intended Audience :: Human Resources
@@ -48,7 +48,7 @@ dev =
 
 [options.entry_points]
 console_scripts =
-    vacalyser-extract = cli.extract:main
+    cognitive-needs-extract = cli.extract:main
 
 [flake8]
 max-line-length = 120

--- a/styles/cognitive_needs.css
+++ b/styles/cognitive_needs.css
@@ -1,4 +1,4 @@
-/* === Vacalyser Futuristic Theme ===========================================
+/* === Cognitive Needs Futuristic Theme ===========================================
    This stylesheet assumes dark base colors from .streamlit/config.toml.
    It adds a glassmorphic layout, consistent buttons, and a global background.
    The background image is provided at runtime via :root { --bg-image: url(...); }

--- a/styles/cognitive_needs_light.css
+++ b/styles/cognitive_needs_light.css
@@ -1,5 +1,5 @@
-/* === Vacalyser Light Theme ==================================================
-   Alternate light theme using the same structure as vacalyser.css but with
+/* === Cognitive Needs Light Theme ==================================================
+   Alternate light theme using the same structure as cognitive_needs.css but with
    light-friendly colors. ==================================================== */
 
 @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&family=Inter:wght@300;400;600;700&display=swap');

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -14,10 +14,10 @@ def test_guess_job_title_strip_gender() -> None:
 
 
 def test_guess_company_brand() -> None:
-    text = "Wir sind Vacalyser, ein Tech-Brand der Example GmbH"
+    text = "Wir sind Cognitive Needs, ein Tech-Brand der Example GmbH"
     name, brand = guess_company(text)
     assert name == "Example GmbH"
-    assert brand == "Vacalyser"
+    assert brand == "Cognitive Needs"
 
 
 def test_guess_city_from_header() -> None:

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -78,9 +78,9 @@ def test_build_extraction_tool_has_name_and_parameters():
     """build_extraction_tool should include function name and parameters."""
 
     schema = {"type": "object", "properties": {}}
-    tool = openai_utils.build_extraction_tool("vacalyser_extract", schema)
+    tool = openai_utils.build_extraction_tool("cognitive_needs_extract", schema)
     spec = tool[0]
-    assert spec["name"] == "vacalyser_extract"
+    assert spec["name"] == "cognitive_needs_extract"
     assert spec["parameters"]["type"] == "object"
 
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,4 @@
-"""Utility helpers for the Vacalyser app."""
+"""Utility helpers for the Cognitive Needs app."""
 
 from __future__ import annotations
 

--- a/utils/url_utils.py
+++ b/utils/url_utils.py
@@ -8,7 +8,7 @@ import requests
 from bs4 import BeautifulSoup
 
 _URL_RE = re.compile(r"^https?://[\w./-]+$")
-_HEADERS = {"User-Agent": "Vacalyser/1.0"}
+_HEADERS = {"User-Agent": "CognitiveNeeds/1.0"}
 
 
 def extract_text_from_url(url: str) -> str:

--- a/wizard.py
+++ b/wizard.py
@@ -1,4 +1,4 @@
-# wizard.py — Vacalyser Wizard (clean flow, schema-aligned)
+# wizard.py — Cognitive Needs Wizard (clean flow, schema-aligned)
 from __future__ import annotations
 
 import io
@@ -39,6 +39,10 @@ from core.esco_utils import normalize_skills
 
 ROOT = Path(__file__).parent
 ensure_state()
+
+WIZARD_TITLE = (
+    "Cognitive Needs - AI powered Recruitment Analysis, Detection and Improvement Tool"
+)
 
 REQUIRED_SUFFIX = " :red[*]"
 REQUIRED_PREFIX = ":red[*] "
@@ -533,9 +537,8 @@ def _step_intro():
         on_change=_on_lang_change,
     )
 
-    st.header(
-        tr("Willkommen zum Recruiting-Wizard", "Welcome to the Recruiting Wizard")
-    )
+    st.header(WIZARD_TITLE)
+    st.subheader(WIZARD_TITLE)
     st.write(
         tr(
             (
@@ -548,7 +551,7 @@ def _step_intro():
             ),
         )
     )
-    st.subheader(t("intro_title", st.session_state.lang))
+    st.markdown("#### " + t("intro_title", st.session_state.lang))
     st.write(
         tr(
             (
@@ -2268,7 +2271,7 @@ def _step_summary(schema: dict, critical: list[str]):
     st.download_button(
         "⬇️ Download JSON",
         data=buff,
-        file_name="vacalyser_profile.json",
+        file_name="cognitive_needs_profile.json",
         mime="application/json",
     )
 


### PR DESCRIPTION
## Summary
- rebrand documentation, configuration, and themes to the Cognitive Needs naming
- update the Streamlit wizard title, export name, and CLI metadata to use the new Cognitive Needs label
- refresh headers, loggers, and tests to remove the Vacalyser identifier throughout the codebase

## Testing
- black .
- ruff check .
- mypy .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c99a423c24832093be22624006b8ce