### PR TITLE
feat: harden job text ingestion

### DIFF
--- a/cli/extract.py
+++ b/cli/extract.py
@@ -25,6 +25,7 @@ def main() -> None:
     args = parser.parse_args()
 
     from ingest.extractors import extract_text_from_file
+    from ingest.reader import clean_job_text
     from config_loader import load_json
     from openai_utils import extract_with_function
     from config import OPENAI_MODEL
@@ -35,7 +36,7 @@ def main() -> None:
 
     with file_path.open("rb") as fh:
         try:
-            text = extract_text_from_file(fh)
+            text = clean_job_text(extract_text_from_file(fh))
         except ValueError as e:
             raise SystemExit(str(e))
     if not text:

--- a/ingest/__init__.py
+++ b/ingest/__init__.py
@@ -1,10 +1,11 @@
 """Utilities for ingesting job posting text."""
 
 from .extractors import extract_text_from_file, extract_text_from_url
-from .reader import read_job_text
+from .reader import clean_job_text, read_job_text
 
 __all__ = [
     "read_job_text",
     "extract_text_from_file",
     "extract_text_from_url",
+    "clean_job_text",
 ]

--- a/ingest/reader.py
+++ b/ingest/reader.py
@@ -1,4 +1,4 @@
-"""Read job text from multiple sources."""
+"""Read and normalize job posting text from multiple sources."""
 
 from __future__ import annotations
 
@@ -11,10 +11,162 @@ from docx import Document
 import requests
 
 
-def _clean(text: str) -> str:
-    """Collapse whitespace and strip surrounding spaces."""
+_SPACE_RE = re.compile(r"\s+")
+_NAV_SPLIT_RE = re.compile(r"[|>/»«·•→]+")
+_WORD_RE = re.compile(r"[A-Za-zÄÖÜäöüß]+", re.UNICODE)
 
-    return re.sub(r"\s+", " ", text).strip()
+_MENU_TOKENS = {
+    "home",
+    "karriere",
+    "career",
+    "jobs",
+    "stellenangebote",
+    "unternehmen",
+    "company",
+    "about",
+    "team",
+    "people",
+    "culture",
+    "benefits",
+    "solutions",
+    "services",
+    "students",
+    "graduates",
+    "professionals",
+    "kontakt",
+    "contact",
+    "news",
+    "blog",
+    "events",
+    "search",
+    "suche",
+    "karriereportal",
+    "stellenmarkt",
+    "jobsuche",
+    "apply",
+    "bewerben",
+    "bewerbung",
+    "login",
+    "logout",
+    "register",
+    "registrieren",
+}
+
+_LANGUAGE_TOKENS = {
+    "deutsch",
+    "german",
+    "english",
+    "englisch",
+    "français",
+    "französisch",
+    "español",
+    "spanisch",
+    "italiano",
+    "polski",
+    "中文",
+    "日本語",
+}
+
+_SOCIAL_TOKENS = {
+    "linkedin",
+    "facebook",
+    "instagram",
+    "youtube",
+    "twitter",
+    "xing",
+    "whatsapp",
+}
+
+_SHORT_TOKENS = {
+    "faq",
+    "jobs",
+    "job",
+    "karriere",
+    "career",
+    "about",
+    "team",
+    "people",
+    "news",
+    "blog",
+    "events",
+    "apply",
+    "bewerben",
+    "bewerbung",
+    "login",
+    "logout",
+    "register",
+    "kontakt",
+    "contact",
+    "search",
+    "suche",
+    "portal",
+    "jobsuche",
+    "students",
+    "graduates",
+    "professionals",
+    "benefits",
+}
+
+_SINGLE_WORD_REMOVALS = {
+    "menu",
+    "menü",
+    "navigation",
+    "nav",
+    "schließen",
+    "schliessen",
+    "close",
+    "zurück",
+    "back",
+}
+
+_CTA_LINES = {
+    "apply now",
+    "apply now!",
+    "apply online",
+    "jetzt bewerben",
+    "jetzt bewerben!",
+    "jetzt online bewerben",
+    "jetzt informieren",
+    "job merken",
+    "stelle merken",
+    "job teilen",
+    "share job",
+    "share this job",
+    "jetzt teilen",
+}
+
+_FOOTER_KEYWORDS = {
+    "privacy",
+    "privacy policy",
+    "datenschutz",
+    "impressum",
+    "cookie",
+    "agb",
+    "terms",
+    "bedingungen",
+    "all rights reserved",
+    "equal opportunity employer",
+}
+
+_BOILERPLATE_CONTAINS = {
+    "skip to main content",
+    "zum hauptinhalt",
+    "zur hauptnavigation",
+    "toggle navigation",
+    "karriereportal",
+    "bewerber-login",
+    "bewerberlogin",
+    "candidate login",
+    "follow us",
+    "folgen sie uns",
+    "teilen auf",
+    "zurück zur jobsuche",
+    "zur jobübersicht",
+    "zur jobuebersicht",
+    "zur stellenauswahl",
+    "jetzt teilen",
+    "jetzt bewerben",
+}
 
 
 def _read_txt(path: Path) -> str:
@@ -48,6 +200,122 @@ def _read_url(url: str) -> str:
     return soup.get_text(" ")
 
 
+def _normalize_for_check(text: str) -> str:
+    """Return ``text`` lowercased with collapsed whitespace."""
+
+    return _SPACE_RE.sub(" ", text).strip().lower()
+
+
+def _looks_like_navigation(line: str) -> bool:
+    """Return ``True`` if ``line`` resembles navigation or footer boilerplate."""
+
+    stripped = line.strip()
+    if not stripped:
+        return False
+    normalized = _normalize_for_check(stripped)
+    if not normalized:
+        return False
+    if normalized in _CTA_LINES:
+        return True
+    if any(phrase in normalized for phrase in _BOILERPLATE_CONTAINS):
+        return True
+    if normalized.startswith("©") or normalized.startswith("(c)"):
+        return True
+    if ("cookie" in normalized or "all rights reserved" in normalized) and len(
+        normalized
+    ) <= 160:
+        return True
+    if (
+        any(keyword in normalized for keyword in _FOOTER_KEYWORDS)
+        and len(normalized) <= 160
+    ):
+        return True
+    if re.search(r"https?://|www\.\w", normalized):
+        return True
+
+    tokens = _WORD_RE.findall(normalized)
+    if tokens:
+        if len(tokens) >= 3:
+            known = sum(
+                1
+                for tok in tokens
+                if tok in _MENU_TOKENS
+                or tok in _LANGUAGE_TOKENS
+                or tok in _SOCIAL_TOKENS
+                or tok in _SHORT_TOKENS
+            )
+            if known / len(tokens) >= 0.7:
+                return True
+        joined = " ".join(tokens)
+        if joined in _CTA_LINES:
+            return True
+        if len(tokens) == 1 and tokens[0] in _SINGLE_WORD_REMOVALS:
+            return True
+
+    if (
+        stripped.count("|") >= 2
+        or stripped.count(">") >= 2
+        or stripped.count("/") >= 2
+        or stripped.count("•") >= 3
+    ):
+        segments = [
+            seg.strip().lower() for seg in _NAV_SPLIT_RE.split(stripped) if seg.strip()
+        ]
+        if segments:
+            known = sum(
+                1
+                for seg in segments
+                if seg in _MENU_TOKENS
+                or seg in _LANGUAGE_TOKENS
+                or seg in _SOCIAL_TOKENS
+                or seg in _SHORT_TOKENS
+            )
+            if known / len(segments) >= 0.6 or len(segments) >= 5:
+                return True
+    return False
+
+
+def strip_boilerplate(text: str) -> str:
+    """Remove boilerplate navigation/footer lines from ``text``."""
+
+    if not text:
+        return ""
+    cleaned_lines: list[str] = []
+    for raw_line in text.replace("\u00a0", " ").replace("\ufeff", "").splitlines():
+        line = raw_line.rstrip()
+        if not line.strip():
+            cleaned_lines.append("")
+            continue
+        if _looks_like_navigation(line):
+            continue
+        cleaned_lines.append(line.strip())
+
+    result: list[str] = []
+    for line in cleaned_lines:
+        if not line:
+            if result and result[-1] == "":
+                continue
+            if not result:
+                continue
+            result.append("")
+        else:
+            result.append(line)
+    return "\n".join(result).strip()
+
+
+def clean_job_text(text: str) -> str:
+    """Normalize whitespace and remove boilerplate from job posting text."""
+
+    if not text:
+        return ""
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    normalized = strip_boilerplate(normalized)
+    normalized = re.sub(r"[ \t]+\n", "\n", normalized)
+    normalized = re.sub(r"\n{3,}", "\n\n", normalized)
+    normalized = re.sub(r"[ \t]{2,}", " ", normalized)
+    return normalized.strip()
+
+
 def read_job_text(
     files: list[str],
     url: str | None = None,
@@ -76,13 +344,18 @@ def read_job_text(
         elif suffix == ".txt":
             content = _read_txt(path)
         if content:
-            texts.append(content)
+            cleaned = clean_job_text(content)
+            if cleaned:
+                texts.append(cleaned)
 
     if url:
-        texts.append(_read_url(url))
+        cleaned = clean_job_text(_read_url(url))
+        if cleaned:
+            texts.append(cleaned)
     if pasted:
-        texts.append(pasted)
+        cleaned = clean_job_text(pasted)
+        if cleaned:
+            texts.append(cleaned)
 
-    cleaned = [_clean(t) for t in texts if t]
-    unique = list(dict.fromkeys(cleaned))
-    return "\n".join(unique)
+    unique = list(dict.fromkeys(texts))
+    return "\n\n".join(unique)

--- a/tests/test_ingest_reader.py
+++ b/tests/test_ingest_reader.py
@@ -1,4 +1,4 @@
-from ingest.reader import read_job_text
+from ingest.reader import clean_job_text, read_job_text
 
 
 def test_read_job_text_merges_and_cleans(tmp_path):
@@ -6,3 +6,18 @@ def test_read_job_text_merges_and_cleans(tmp_path):
     txt.write_text("Hello   world\n")
     result = read_job_text([str(txt)], pasted="Hello world")
     assert result == "Hello world"
+
+
+def test_clean_job_text_removes_boilerplate():
+    raw = "Home | Jobs | Karriere\n\nDeine Aufgaben\n- Analysieren\nImpressum\n"
+    cleaned = clean_job_text(raw)
+    assert "Home" not in cleaned
+    assert "Impressum" not in cleaned
+    assert "Deine Aufgaben" in cleaned
+
+
+def test_clean_job_text_preserves_bullets():
+    raw = "Menu\n\n- Verantwortung übernehmen\n- Analysieren"
+    cleaned = clean_job_text(raw)
+    assert cleaned.startswith("- Verantwortung übernehmen")
+    assert "Analysieren" in cleaned


### PR DESCRIPTION
## Summary
- add a boilerplate-aware job text cleaning helper and use it when merging file, URL and pasted sources
- run the new cleaning step for uploads, manual analysis and the CLI extractor so the pipeline always receives sanitized text
- export the helper for reuse and cover the heuristics with ingestion unit tests

## Testing
- ruff check .
- black .
- mypy .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9aff5a2388320901c20461be7bb0a