### PR TITLE
feat: extend heuristics post processing

### DIFF
--- a/tests/test_requirements_fallback.py
+++ b/tests/test_requirements_fallback.py
@@ -29,3 +29,20 @@ def test_requirements_split_and_languages() -> None:
     assert any("aws ml specialty" in c.lower() for c in r.certifications)
     tools = {t.lower() for t in r.tools_and_technologies}
     assert "python" in tools and "docker" in tools
+
+
+def test_requirements_formal_heading_variant() -> None:
+    text = (
+        "Was Sie mitbringen:\n"
+        "• Kommunikationsstärke\n"
+        "• Erfahrung im Vertrieb\n"
+        "\n"
+        "Ihre Aufgaben:\n"
+        "• Kunden beraten\n"
+    )
+    profile = apply_basic_fallbacks(NeedAnalysisProfile(), text)
+
+    r = profile.requirements
+    assert "Erfahrung im Vertrieb" in r.hard_skills_required
+    assert "Kommunikationsstärke" in r.soft_skills_required
+    assert profile.responsibilities.items == ["Kunden beraten"]


### PR DESCRIPTION
## Summary
- expand the extraction fallbacks to cover additional city hints, employment/remote heuristics, immediate start phrases, and salary/bonus patterns
- broaden keyword coverage for requirement/responsibility sections and add salary parsing helpers for consistent enrichment
- add regression tests for the new heuristics and formal heading variants

## Testing
- ruff check .
- mypy .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9c1dfb31c8320bdbe33a4a39d7cad