### PR TITLE
Fix follow-up ESCO lookups to honour offline mode

### DIFF
--- a/tests/test_question_logic.py
+++ b/tests/test_question_logic.py
@@ -26,7 +26,7 @@ def test_generate_followup_questions() -> None:
 def test_role_specific_extra_question(monkeypatch) -> None:
     """Role classification should add role-specific questions."""
     monkeypatch.setattr(
-        "question_logic.classify_occupation",
+        "question_logic.search_occupation",
         lambda jt, lang="en": {"group": "Software developers"},
     )
     monkeypatch.setattr("question_logic.CRITICAL_FIELDS", {"position.job_title"})


### PR DESCRIPTION
## Summary
- route the follow-up question builder through the offline-aware ESCO integration so VACAYSER_OFFLINE is respected consistently
- flag hard skill follow-ups as critical whenever ESCO reports missing essential skills

## Testing
- ruff check
- black .
- mypy .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9c6ae24f48320abf954f2c462c0bd