### PR TITLE
Fix follow-up suggestions defaults

### DIFF
--- a/tests/test_ask_followups.py
+++ b/tests/test_ask_followups.py
@@ -13,8 +13,22 @@ def test_ask_followups_parses_message(monkeypatch):
 
     class _FakeMessage:
         def __init__(self) -> None:
-            self.content = json.dumps({"questions": [{"field": "f", "question": "?"}]})
+            self.content = json.dumps(
+                {
+                    "questions": [
+                        {
+                            "field": "f",
+                            "question": "?",
+                            "priority": "normal",
+                        }
+                    ]
+                }
+            )
 
     monkeypatch.setattr(question_logic, "call_chat_api", lambda *a, **k: _FakeMessage())
     out = ask_followups({})
-    assert out == {"questions": [{"field": "f", "question": "?"}]}
+    assert out == {
+        "questions": [
+            {"field": "f", "question": "?", "priority": "normal", "suggestions": []}
+        ]
+    }


### PR DESCRIPTION
## Summary
- require `suggestions` in the follow-up item schema and provide a default empty list
- normalise parsed follow-up payloads so each question includes a suggestions array
- extend question logic tests to cover responses without suggestions

## Testing
- ruff check .
- black .
- mypy .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9d08a60e4832099f87d268bf35d1a