### PR TITLE
fix: parse benefit suggestions from object schema

### DIFF
--- a/tests/test_core_suggestions.py
+++ b/tests/test_core_suggestions.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 
@@ -5,6 +6,7 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from core import suggestions
 from core.suggestions import get_benefit_suggestions, get_skill_suggestions
+from openai_utils import api as openai_api, extraction
 
 
 def test_get_skill_suggestions(monkeypatch):
@@ -47,3 +49,41 @@ def test_get_benefit_suggestions_error(monkeypatch):
     sugg, err = get_benefit_suggestions("Engineer")
     assert sugg == []
     assert err == "nope"
+
+
+def test_suggest_benefits_parses_object_schema(monkeypatch):
+    payload = {"items": ["Hybrid work", "Health insurance", "Hybrid work"]}
+
+    monkeypatch.setattr(
+        extraction.api,
+        "call_chat_api",
+        lambda *args, **kwargs: openai_api.ChatCallResult(
+            json.dumps(payload),
+            [],
+            {},
+        ),
+    )
+
+    result = extraction.suggest_benefits(
+        "Engineer",
+        existing_benefits="Health insurance",
+        model="dummy",
+    )
+
+    assert result == ["Hybrid work"]
+
+
+def test_suggest_benefits_accepts_legacy_list(monkeypatch):
+    monkeypatch.setattr(
+        extraction.api,
+        "call_chat_api",
+        lambda *args, **kwargs: openai_api.ChatCallResult(
+            json.dumps(["Remote work", "Bonus"]),
+            [],
+            {},
+        ),
+    )
+
+    result = extraction.suggest_benefits("Engineer", model="dummy")
+
+    assert result == ["Remote work", "Bonus"]


### PR DESCRIPTION
## Summary
- wrap the benefit suggestion schema in an object property and extend the parser to extract items while tolerating legacy arrays
- cover the new schema contract and legacy fallback behaviour with unit tests for suggest_benefits

## Testing
- ruff check
- black openai_utils/extraction.py tests/test_core_suggestions.py
- mypy openai_utils/extraction.py
- mypy tests/test_core_suggestions.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9d213cfd08320a61f49ba8eaaaee5