### PR TITLE
fix: allow optional stakeholder emails

### DIFF
--- a/models/need_analysis.py
+++ b/models/need_analysis.py
@@ -125,8 +125,17 @@ class Stakeholder(BaseModel):
 
     name: str
     role: str
-    email: EmailStr
+    email: EmailStr | None = None
     primary: bool = False
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def _blank_email_to_none(cls, value: str | None) -> str | None:
+        """Coerce blank email strings to ``None`` for optional storage."""
+
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
 
 
 class Phase(BaseModel):

--- a/tests/test_process_step.py
+++ b/tests/test_process_step.py
@@ -14,6 +14,8 @@ def test_process_model_supports_stakeholders_and_phases():
                 name="Alice", role="Recruiter", email="alice@example.com", primary=True
             ),
             Stakeholder(name="Bob", role="Manager", email="bob@example.com"),
+            Stakeholder(name="Carol", role="HR"),
+            Stakeholder(name="Dana", role="Coordinator", email=""),
         ],
         phases=[
             Phase(
@@ -41,4 +43,12 @@ def test_process_model_supports_stakeholders_and_phases():
     profile = NeedAnalysisProfile(process=process)
     assert profile.process.interview_stages == 2
     assert profile.process.stakeholders[0].primary is True
+    assert profile.process.stakeholders[2].email is None
+    assert profile.process.stakeholders[3].email is None
     assert profile.process.phases[1].participants == ["Bob"]
+
+
+def test_stakeholder_blank_email_coerced_to_none():
+    stakeholder = Stakeholder(name="Eve", role="HR", email="   ")
+    assert stakeholder.email is None
+    assert stakeholder.model_dump()["email"] is None

--- a/wizard.py
+++ b/wizard.py
@@ -1050,7 +1050,7 @@ def _render_stakeholders(process: dict, key_prefix: str) -> None:
         )
         person["email"] = c3.text_input(
             "E-Mail",
-            value=person.get("email", ""),
+            value=person.get("email") or "",
             key=f"{key_prefix}.{idx}.email",
         )
 


### PR DESCRIPTION
## Summary
- allow stakeholder emails to be optional and coerce blank values to `None`
- ensure the stakeholder wizard input handles missing emails without errors
- extend process step tests to cover stakeholders without email addresses

## Testing
- ruff check .
- black .
- mypy .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9dd8189e08320a94a2d7e71e5a409