### PR TITLE
feat: auto-run source extraction

### DIFF
--- a/tests/test_wizard_source.py
+++ b/tests/test_wizard_source.py
@@ -4,7 +4,6 @@ import streamlit as st
 from wizard import _autodetect_lang, _step_source, on_file_uploaded, on_url_changed
 from constants.keys import StateKeys, UIKeys
 from utils.session import bootstrap_session
-from i18n import t
 from models.need_analysis import NeedAnalysisProfile
 
 
@@ -117,12 +116,7 @@ def test_step_source_populates_data(monkeypatch: pytest.MonkeyPatch, mode: str) 
     sample_text = "Job text"
     sample_data = {"position": {"job_title": "Engineer"}}
     _setup_common(monkeypatch)
-    analyze_label = t("analyze", st.session_state.lang)
-
-    def fake_button(label: str, *a, **k) -> bool:
-        return mode == "text" and label == analyze_label
-
-    monkeypatch.setattr(st, "button", fake_button)
+    monkeypatch.setattr(st, "button", lambda *a, **k: False)
     monkeypatch.setattr(
         "wizard.extract_with_function", lambda _t, _s, model=None: sample_data
     )
@@ -165,12 +159,7 @@ def test_step_source_merges_esco_skills(monkeypatch: pytest.MonkeyPatch) -> None
         "requirements": {"hard_skills_required": ["Python"]},
     }
     _setup_common(monkeypatch)
-    analyze_label = t("analyze", st.session_state.lang)
-
-    def fake_button(label: str, *a, **k) -> bool:
-        return label == analyze_label
-
-    monkeypatch.setattr(st, "button", fake_button)
+    monkeypatch.setattr(st, "button", lambda *a, **k: False)
     monkeypatch.setattr(st, "text_area", lambda *a, **k: sample_text)
     monkeypatch.setattr(
         "wizard.extract_with_function", lambda _t, _s, model=None: sample_data
@@ -208,9 +197,7 @@ def test_step_source_flags_missing_fields(monkeypatch: pytest.MonkeyPatch) -> No
     sample_text = "random text without info"
     _setup_common(monkeypatch)
     st.session_state[UIKeys.PROFILE_TEXT_INPUT] = sample_text
-    analyze_label = t("analyze", st.session_state.lang)
-
-    monkeypatch.setattr(st, "button", lambda label, *a, **k: label == analyze_label)
+    monkeypatch.setattr(st, "button", lambda *a, **k: False)
     monkeypatch.setattr(st, "text_area", lambda *a, **k: sample_text)
     monkeypatch.setattr("wizard.extract_with_function", lambda _t, _s, model=None: {})
     monkeypatch.setattr("wizard.search_occupation", lambda _t, _l: None)

--- a/utils/session.py
+++ b/utils/session.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import streamlit as st
 
@@ -33,6 +33,7 @@ def bind_textarea(
     data_key: str,
     placeholder: str = "",
     help: str | None = None,
+    on_change: Callable[[], None] | None = None,
 ) -> None:
     """Render a text area bound to a state key.
 
@@ -45,14 +46,22 @@ def bind_textarea(
 
     def _on_change() -> None:
         st.session_state[data_key] = st.session_state[ui_key]
+        if on_change is not None:
+            on_change()
 
-    st.text_area(
+    value = st.text_area(
         label,
         key=ui_key,
         placeholder=placeholder,
         help=help,
         on_change=_on_change,
     )
+
+    current_value = st.session_state.get(ui_key, value)
+    if st.session_state.get(data_key) != current_value:
+        st.session_state[data_key] = current_value
+        if on_change is not None:
+            on_change()
 
 
 def migrate_legacy_keys() -> None:


### PR DESCRIPTION
## Summary
- trigger the wizard source extraction automatically for text, URL, and file inputs while removing the manual analyze button
- drop the follow-up "Skip" control so unanswered questions remain highlighted and adjust supporting session utilities
- update unit tests to reflect the new automatic flow and stricter follow-up handling

## Testing
- `ruff check`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cadd5f30e083209cab4f90a0496adb