### PR TITLE
fix: rely on automatic rerun after upload

### DIFF
--- a/wizard.py
+++ b/wizard.py
@@ -177,7 +177,6 @@ def on_file_uploaded() -> None:
         return
     st.session_state["__prefill_profile_text__"] = txt
     st.session_state["__run_extraction__"] = True
-    st.rerun()
 
 
 def on_url_changed() -> None:


### PR DESCRIPTION
## Summary
- remove the explicit `st.rerun()` call from the file upload callback and rely on Streamlit's automatic rerun while keeping the extraction trigger flags intact

## Testing
- ruff check wizard.py
- black wizard.py
- mypy wizard.py --follow-imports=skip --no-site-packages
- pytest tests/test_wizard_source.py *(fails: ModuleNotFoundError: No module named 'constants')*

------
https://chatgpt.com/codex/tasks/task_e_68cae82ae8048320a27f7d3700141421