### PR TITLE
feat: extend salary and travel options

### DIFF
--- a/models/need_analysis.py
+++ b/models/need_analysis.py
@@ -93,6 +93,10 @@ class Employment(BaseModel):
     remote_percentage: Optional[int] = None
     contract_end: Optional[str] = None
     travel_required: Optional[bool] = None
+    travel_share: Optional[int] = None
+    travel_region_scope: Optional[str] = None
+    travel_regions: List[str] = Field(default_factory=list)
+    travel_continents: List[str] = Field(default_factory=list)
     travel_details: Optional[str] = None
     overtime_expected: Optional[bool] = None
     relocation_support: Optional[bool] = None

--- a/schema/need_analysis.schema.json
+++ b/schema/need_analysis.schema.json
@@ -364,6 +364,32 @@
                         "null"
                     ]
                 },
+                "travel_share": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "travel_region_scope": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "travel_regions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "travel_continents": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
                 "travel_details": {
                     "type": [
                         "string",
@@ -415,6 +441,10 @@
                 "remote_percentage",
                 "contract_end",
                 "travel_required",
+                "travel_share",
+                "travel_region_scope",
+                "travel_regions",
+                "travel_continents",
                 "travel_details",
                 "overtime_expected",
                 "relocation_support",

--- a/tests/test_salary_dashboard.py
+++ b/tests/test_salary_dashboard.py
@@ -15,9 +15,10 @@ def test_compute_salary_permanent() -> None:
             "Deploy ML services",
         ],
         ["English"],
+        "Technology",
     )
     assert mode == "annual"
-    assert salary == 111364
+    assert salary == 128068
 
 
 def test_compute_salary_contract() -> None:
@@ -30,9 +31,10 @@ def test_compute_salary_contract() -> None:
         "Data Engineer",
         ["Maintain data pipelines", "Support business stakeholders"],
         ["English", "German"],
+        "Consulting",
     )
     assert mode == "hourly"
-    assert rate == 46.23
+    assert rate == 49.93
 
 
 def test_additional_languages_raise_salary() -> None:
@@ -45,6 +47,7 @@ def test_additional_languages_raise_salary() -> None:
         "Software Engineer",
         ["Ship features", "Maintain codebase"],
         ["English"],
+        "Technology",
     )
     multi_language_salary, _ = compute_expected_salary(
         ["Python"],
@@ -55,5 +58,32 @@ def test_additional_languages_raise_salary() -> None:
         "Software Engineer",
         ["Ship features", "Maintain codebase"],
         ["English", "German"],
+        "Technology",
     )
     assert multi_language_salary > base_salary
+
+
+def test_industry_impacts_salary() -> None:
+    tech_salary, _ = compute_expected_salary(
+        ["Python"],
+        [],
+        "Mid",
+        "Berlin",
+        "permanent",
+        "Software Engineer",
+        ["Ship features"],
+        ["English"],
+        "Technology",
+    )
+    nonprofit_salary, _ = compute_expected_salary(
+        ["Python"],
+        [],
+        "Mid",
+        "Berlin",
+        "permanent",
+        "Software Engineer",
+        ["Ship features"],
+        ["English"],
+        "Nonprofit",
+    )
+    assert tech_salary > nonprofit_salary


### PR DESCRIPTION
## Summary
- extend the salary dashboard benchmark to include company industry factors
- expose travel share and dynamic region selection when travel is required, including schema/model updates
- cover the new behaviours with updated salary dashboard tests

## Testing
- ruff check
- mypy .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb01da93fc83209a4b7701b15d5e70