### PR TITLE
feat: redesign onboarding step

### DIFF
--- a/tests/test_wizard_skip_and_reask.py
+++ b/tests/test_wizard_skip_and_reask.py
@@ -1,7 +1,7 @@
 import streamlit as st
 import pytest
 
-from wizard import _skip_source, _extract_and_summarize, OVERVIEW_STEP_INDEX
+from wizard import _skip_source, _extract_and_summarize, COMPANY_STEP_INDEX
 from constants.keys import StateKeys
 from models.need_analysis import NeedAnalysisProfile
 
@@ -20,7 +20,7 @@ def test_skip_source_resets_session(monkeypatch: pytest.MonkeyPatch) -> None:
 
     _skip_source()
 
-    assert st.session_state[StateKeys.STEP] == OVERVIEW_STEP_INDEX
+    assert st.session_state[StateKeys.STEP] == COMPANY_STEP_INDEX
     assert st.session_state[StateKeys.RAW_TEXT] == ""
     assert st.session_state[StateKeys.EXTRACTION_SUMMARY] == {}
     assert st.session_state[StateKeys.EXTRACTION_MISSING] == []

--- a/tests/test_wizard_source.py
+++ b/tests/test_wizard_source.py
@@ -33,15 +33,27 @@ def _patch_onboarding_streamlit(monkeypatch: pytest.MonkeyPatch) -> None:
             return st.session_state.get(UIKeys.INPUT_METHOD, options[0])
         return options[0]
 
+    def fake_columns(spec, *_, **__):
+        if isinstance(spec, int):
+            count = spec
+        elif isinstance(spec, (list, tuple)):
+            count = len(spec)
+        else:
+            count = 2
+        return tuple(DummyContext() for _ in range(count))
+
+    def fake_tabs(labels):
+        return [DummyContext() for _ in labels]
+
     monkeypatch.setattr(st, "radio", fake_radio)
     monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
-    monkeypatch.setattr(st, "write", lambda *a, **k: None)
-    monkeypatch.setattr(st, "checkbox", lambda *a, **k: False)
-    monkeypatch.setattr(st, "columns", lambda *a, **k: (DummyContext(), DummyContext()))
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "divider", lambda *a, **k: None)
+    monkeypatch.setattr(st, "columns", fake_columns)
     monkeypatch.setattr(st, "info", lambda *a, **k: None)
     monkeypatch.setattr(st, "file_uploader", lambda *a, **k: None)
-    monkeypatch.setattr(st, "image", lambda *a, **k: None)
     monkeypatch.setattr(st, "caption", lambda *a, **k: None)
+    monkeypatch.setattr(st, "tabs", fake_tabs)
     monkeypatch.setattr(st, "button", lambda *a, **k: False)
     monkeypatch.setattr(st, "rerun", lambda: None)
 


### PR DESCRIPTION
## Summary
- reorganized the onboarding step with a top-right language toggle, centered messaging, automatic analysis triggers, and explicit navigation actions
- surfaced detected vacancy data in tabbed previews before leaving onboarding to improve clarity
- removed the old overview step, updated wizard navigation, and refreshed tests/mocks for the new flow

## Testing
- ruff check
- black wizard.py tests/test_wizard_source.py tests/test_wizard_skip_and_reask.py
- mypy wizard.py tests/test_wizard_source.py tests/test_wizard_skip_and_reask.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb0b7817ac83208bf1093368a8c685