### PR TITLE
fix: preserve contact lines in reader

### DIFF
--- a/ingest/reader.py
+++ b/ingest/reader.py
@@ -187,6 +187,10 @@ def _read_pdf(path: Path) -> str:
 _URL_RE = re.compile(r"^https?://[\w./-]+$")
 _HEADERS = {"User-Agent": "CognitiveNeeds/1.0"}
 
+_EMAIL_RE = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.IGNORECASE)
+_PHONE_RE = re.compile(r"\+?\d[\d\s().\-/]{5,}\d")
+_CONTACT_LABEL_RE = re.compile(r"(kontakt|contact|homepage|telefon|phone|e-?mail)\s*[:–—-]")
+
 
 def _read_url(url: str) -> str:
     if not url or not _URL_RE.match(url):
@@ -230,7 +234,12 @@ def _looks_like_navigation(line: str) -> bool:
         and len(normalized) <= 160
     ):
         return True
+    has_email = bool(_EMAIL_RE.search(stripped))
+    has_phone = bool(_PHONE_RE.search(stripped))
+    has_contact_label = bool(_CONTACT_LABEL_RE.search(normalized))
     if re.search(r"https?://|www\.\w", normalized):
+        if has_contact_label or has_email or has_phone:
+            return False
         return True
 
     tokens = _WORD_RE.findall(normalized)

--- a/tests/test_ingest_reader.py
+++ b/tests/test_ingest_reader.py
@@ -21,3 +21,14 @@ def test_clean_job_text_preserves_bullets():
     cleaned = clean_job_text(raw)
     assert cleaned.startswith("- Verantwortung übernehmen")
     assert "Analysieren" in cleaned
+
+
+def test_clean_job_text_preserves_contact_lines():
+    raw = (
+        "Deine Aufgaben\n"
+        "Kontakt: recruiting@example.com | https://example.com/kontakt\n"
+        "Homepage: https://example.com/jobs\n"
+    )
+    cleaned = clean_job_text(raw)
+    assert "Kontakt: recruiting@example.com | https://example.com/kontakt" in cleaned
+    assert "Homepage: https://example.com/jobs" in cleaned


### PR DESCRIPTION
## Summary
- adjust navigation detection to avoid dropping contact lines that contain URLs, emails, or phone numbers
- add a regression test ensuring clean_job_text keeps contact information lines

## Testing
- ruff check ingest/reader.py tests/test_ingest_reader.py
- PYTHONPATH=. pytest tests/test_ingest_reader.py

------
https://chatgpt.com/codex/tasks/task_e_68cb135d87288320afa5e925c3c58d30