### PR TITLE
feat: enable skill triage in source step

### DIFF
--- a/constants/keys.py
+++ b/constants/keys.py
@@ -34,4 +34,7 @@ class StateKeys:
     BENEFIT_SUGGESTIONS = "benefit_suggestions"
     EXTRACTION_SUMMARY = "extraction_summary"
     EXTRACTION_MISSING = "extraction_missing"
+    EXTRACTION_RAW_PROFILE = "extraction_raw_profile"
+    ESCO_SKILLS = "extraction_esco_skills"
     BIAS_FINDINGS = "data.bias_findings"
+    SKILL_BUCKETS = "skill_buckets"

--- a/state/ensure_state.py
+++ b/state/ensure_state.py
@@ -28,6 +28,12 @@ def ensure_state() -> None:
         st.session_state[StateKeys.EXTRACTION_SUMMARY] = {}
     if StateKeys.EXTRACTION_MISSING not in st.session_state:
         st.session_state[StateKeys.EXTRACTION_MISSING] = []
+    if StateKeys.EXTRACTION_RAW_PROFILE not in st.session_state:
+        st.session_state[StateKeys.EXTRACTION_RAW_PROFILE] = {}
+    if StateKeys.ESCO_SKILLS not in st.session_state:
+        st.session_state[StateKeys.ESCO_SKILLS] = []
+    if StateKeys.SKILL_BUCKETS not in st.session_state:
+        st.session_state[StateKeys.SKILL_BUCKETS] = {"must": [], "nice": []}
     if StateKeys.FOLLOWUPS not in st.session_state:
         st.session_state[StateKeys.FOLLOWUPS] = []
     if "lang" not in st.session_state:

--- a/tests/test_wizard_skip_and_reask.py
+++ b/tests/test_wizard_skip_and_reask.py
@@ -14,6 +14,14 @@ def test_skip_source_resets_session(monkeypatch: pytest.MonkeyPatch) -> None:
     st.session_state[StateKeys.PROFILE] = {"position": {"job_title": "X"}}
     st.session_state[StateKeys.EXTRACTION_SUMMARY] = {"foo": "bar"}
     st.session_state[StateKeys.EXTRACTION_MISSING] = ["company.name"]
+    st.session_state[StateKeys.EXTRACTION_RAW_PROFILE] = {
+        "requirements": {"hard_skills_required": ["Python"]}
+    }
+    st.session_state[StateKeys.ESCO_SKILLS] = ["Data Analysis"]
+    st.session_state[StateKeys.SKILL_BUCKETS] = {
+        "must": ["Python"],
+        "nice": ["Excel"],
+    }
     st.session_state[StateKeys.STEP] = 1
     st.session_state["_analyze_attempted"] = True
     monkeypatch.setattr(st, "rerun", lambda: None)
@@ -24,6 +32,9 @@ def test_skip_source_resets_session(monkeypatch: pytest.MonkeyPatch) -> None:
     assert st.session_state[StateKeys.RAW_TEXT] == ""
     assert st.session_state[StateKeys.EXTRACTION_SUMMARY] == {}
     assert st.session_state[StateKeys.EXTRACTION_MISSING] == []
+    assert st.session_state[StateKeys.EXTRACTION_RAW_PROFILE] == {}
+    assert st.session_state[StateKeys.ESCO_SKILLS] == []
+    assert st.session_state[StateKeys.SKILL_BUCKETS] == {"must": [], "nice": []}
     assert st.session_state[StateKeys.PROFILE] == NeedAnalysisProfile().model_dump()
     assert "_analyze_attempted" not in st.session_state
 
@@ -72,3 +83,5 @@ def test_extract_and_summarize_auto_reask(monkeypatch: pytest.MonkeyPatch) -> No
     assert st.session_state[StateKeys.FOLLOWUPS] == [
         {"field": "company.name", "question": "?", "priority": "critical"}
     ]
+    assert StateKeys.EXTRACTION_RAW_PROFILE in st.session_state
+    assert StateKeys.SKILL_BUCKETS in st.session_state


### PR DESCRIPTION
## Summary
- add a drag-and-drop skill triage to the source step so must-have/nice-to-have buckets feed the wizard
- keep raw extraction data and ESCO skill suggestions separate for the compact preview and new skill columns
- initialise and reset new session state keys plus tests that cover the updated state handling

## Testing
- ruff check
- mypy .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cb19dd626883209b741d1ac17a3913