### PR TITLE
fix: defer extraction until prefill is loaded

### DIFF
--- a/wizard.py
+++ b/wizard.py
@@ -506,7 +506,10 @@ def _maybe_run_extraction(schema: dict) -> None:
     if not should_run:
         return
 
-    raw_input = st.session_state.get(StateKeys.RAW_TEXT, "") or ""
+    raw_input = st.session_state.get(StateKeys.RAW_TEXT, "")
+    if not raw_input:
+        raw_input = st.session_state.get("__prefill_profile_text__", "")
+    raw_input = raw_input or ""
     raw_clean = clean_job_text(raw_input)
     if not raw_clean.strip():
         st.session_state["_analyze_attempted"] = True


### PR DESCRIPTION
## Summary
- ensure the extraction step falls back to the queued prefill text before checking for empty input
- add a regression test covering the prefill fallback for `_maybe_run_extraction`

## Testing
- ruff check
- pytest
- mypy wizard.py tests/test_wizard_source.py *(hangs locally, aborted after a long wait)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2682d4048320875eb3ac42ebc513