### PR TITLE
Route LLM workloads to GPT-5 models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Cognitive Needs — Autonomous Agents
 
-This document lists all current and planned autonomous agents in Cognitive Needs, along with their roles and interfaces. Each agent is small, focused, and composable. *Note: earlier docs used the labels “GPT‑4o” and “GPT‑4o‑mini”; in code these map to OpenAI’s cost-optimized `gpt-5-nano` and `gpt-4.1-nano` models respectively.*
+This document lists all current and planned autonomous agents in Cognitive Needs, along with their roles and interfaces. Each agent is small, focused, and composable. *Note: earlier docs used the labels “GPT‑4o” and “GPT‑4o‑mini”; the new router maps these to OpenAI’s `gpt-5-mini` and `gpt-5-nano` models respectively.*
 
 ---
 
@@ -38,7 +38,7 @@ Turn a partially filled vacancy JSON into a minimal, targeted list of follow-up 
   - `suggestions`: list[str] (optional, to render as answer chips)
 
 **Model / APIs**
-- OpenAI Responses API with `gpt-5-nano` / `gpt-4.1-nano` (JSON schema + tool calling)
+- OpenAI Responses API with `gpt-5-nano` (JSON schema + tool calling)
 - ESCO API (occupation + essential skills lookup)
 - Optional File Search tool using `vector_store_id` for context suggestions
 
@@ -86,7 +86,7 @@ Fill or propose values for missing fields using your **OpenAI vector store** (se
 - (Optionally) short rationales or source snippets for each suggestion
 
 **Model / APIs**
-- OpenAI Responses API with `gpt-5-nano` / `gpt-4.1-nano`
+- OpenAI Responses API with `gpt-5-nano`
 - File Search tool driven by `vector_store_id` (no separate API call)
 
 **When**  
@@ -111,7 +111,7 @@ Extract company name, location, mission/values, and culture from a given company
 - `company_culture`
 
 **Model / APIs**
-- OpenAI Responses API with `gpt-5-nano` / `gpt-4.1-nano` for structured text extraction
+- OpenAI Responses API with `gpt-5-mini` for structured text extraction
 - Uses `ingest.extractors` to fetch website content
 
 **When**
@@ -129,7 +129,8 @@ Extract company name, location, mission/values, and culture from a given company
 - **Job‑Ad Writer** – Draft a polished, SEO-aware job ad in Markdown format
 
 **Models**
-- OpenAI Responses API with `gpt-5-nano` / `gpt-4.1-nano`
+- OpenAI Responses API with `gpt-5-mini` for job-ad, interview and boolean generation
+- OpenAI Responses API with `gpt-5-nano` for skill, benefit and task suggestions
 
 ---
 
@@ -147,7 +148,7 @@ Automatically invoke the FQG until all critical fields are answered, reducing ma
 - Updated follow-up questions (same schema as FQG)
 
 **Model / APIs**
-- Delegates to FQG, thus OpenAI Responses API with `gpt-5-nano` / `gpt-4.1-nano` and optional File Search tool
+- Delegates to FQG, thus OpenAI Responses API with `gpt-5-nano` and optional File Search tool
 
 **When**
 - After extraction when the user enables **Auto Follow-ups**; implemented in `_extract_and_summarize`
@@ -161,4 +162,4 @@ Automatically invoke the FQG until all critical fields are answered, reducing ma
 - **Tech‑Stack Miner** – Identify prevalent tech stack elements for the role/industry via RAG + ESCO patterns
 - **Compliance Checker** – Check outputs for bias, EEO/GDPR compliance, add boilerplate as needed
 - **DEI Language Auditor** – Provide inclusive language suggestions (flag potentially discriminatory phrasing)
-- **Content Cost Router** – Auto-select between `gpt-5-nano`, `gpt-4.1-nano`, or `gpt-3.5-turbo` based on content complexity to manage cost
+- **Content Cost Router** – Auto-select between `gpt-5-mini` and `gpt-5-nano` based on content complexity to manage cost

--- a/components/salary_dashboard.py
+++ b/components/salary_dashboard.py
@@ -3,7 +3,7 @@
 from typing import Any, Final, Sequence, Tuple
 
 import streamlit as st
-from config import OPENAI_MODEL
+from config import ModelTask, get_model_for
 
 
 # ``openai_utils`` is an optional dependency. Import lazily so that the
@@ -14,7 +14,7 @@ def _call_chat_api(messages: list[dict], **kwargs: Any) -> str:
     from openai_utils import call_chat_api
 
     if "model" not in kwargs:
-        kwargs["model"] = st.session_state.get("model", OPENAI_MODEL)
+        kwargs["model"] = get_model_for(ModelTask.DEFAULT)
     res = call_chat_api(messages, **kwargs)
     return (res.content or "") if hasattr(res, "content") else str(res)
 

--- a/config.py
+++ b/config.py
@@ -1,17 +1,21 @@
 """Central configuration for the Cognitive Needs Responses API client.
 
-The application uses cost-optimized ``gpt-4o-mini``/``gpt-4o`` models on
-endpoints that support them and falls back to the widely available
-``gpt-3.5-turbo`` for the public OpenAI API. Set ``DEFAULT_MODEL`` or
-``OPENAI_MODEL`` to override the choice and use ``REASONING_EFFORT`` (``low`` |
-``medium`` | ``high``) to control how much reasoning the model performs by
-default.
+The application now routes requests between OpenAI's GPT-5 family to balance
+quality and cost. ``gpt-5-mini`` serves as the default large language model for
+generative workloads, while ``gpt-5-nano`` powers lightweight suggestion flows.
+Structured retrieval keeps using ``text-embedding-3-small``.
+
+Set ``DEFAULT_MODEL`` or ``OPENAI_MODEL`` to override the primary model and use
+``REASONING_EFFORT`` (``low`` | ``medium`` | ``high``) to control how much
+reasoning the model performs by default.
 """
 
 import os
 import warnings
 
 import streamlit as st
+from enum import StrEnum
+from typing import Dict
 
 try:
     from dotenv import load_dotenv
@@ -31,28 +35,12 @@ DEFAULT_LANGUAGE = os.getenv("LANGUAGE", "en")
 
 
 def _detect_default_model() -> str:
-    """Determine a sensible default model based on the endpoint.
-
-    ``DEFAULT_MODEL`` takes precedence if provided. Otherwise, the function
-    selects ``gpt-4o-mini`` for known custom endpoints (Azure, OpenRouter or
-    other non-public gateways) and ``gpt-3.5-turbo`` for the standard OpenAI
-    API.
-    """
+    """Determine the default model for generic chat workloads."""
 
     env_default = os.getenv("DEFAULT_MODEL")
     if env_default:
         return env_default
-
-    base_url = os.getenv("OPENAI_BASE_URL", "")
-    normalized_url = base_url.strip().lower()
-    if not normalized_url:
-        return "gpt-3.5-turbo"
-
-    if any(host in normalized_url for host in ("openrouter.ai", "azure")):
-        return "gpt-4o-mini"
-    if "api.openai.com" in normalized_url:
-        return "gpt-3.5-turbo"
-    return "gpt-4o-mini"
+    return "gpt-5-mini"
 
 
 DEFAULT_MODEL = _detect_default_model()
@@ -76,6 +64,91 @@ try:
     REASONING_EFFORT = st.secrets.get("REASONING_EFFORT", REASONING_EFFORT)
 except Exception:
     pass
+
+
+class ModelTask(StrEnum):
+    """Known task categories for routing OpenAI calls."""
+
+    DEFAULT = "default"
+    EXTRACTION = "extraction"
+    COMPANY_INFO = "company_info"
+    FOLLOW_UP_QUESTIONS = "follow_up_questions"
+    RAG_SUGGESTIONS = "rag_suggestions"
+    SKILL_SUGGESTION = "skill_suggestion"
+    BENEFIT_SUGGESTION = "benefit_suggestion"
+    TASK_SUGGESTION = "task_suggestion"
+    JOB_AD = "job_ad"
+    INTERVIEW_GUIDE = "interview_guide"
+    DOCUMENT_REFINEMENT = "document_refinement"
+    EXPLANATION = "explanation"
+
+
+GPT5_MINI = "gpt-5-mini"
+GPT5_NANO = "gpt-5-nano"
+
+
+MODEL_ROUTING: Dict[str, str] = {
+    ModelTask.DEFAULT.value: OPENAI_MODEL,
+    ModelTask.EXTRACTION.value: GPT5_MINI,
+    ModelTask.COMPANY_INFO.value: GPT5_MINI,
+    ModelTask.FOLLOW_UP_QUESTIONS.value: GPT5_NANO,
+    ModelTask.RAG_SUGGESTIONS.value: GPT5_NANO,
+    ModelTask.SKILL_SUGGESTION.value: GPT5_NANO,
+    ModelTask.BENEFIT_SUGGESTION.value: GPT5_NANO,
+    ModelTask.TASK_SUGGESTION.value: GPT5_NANO,
+    ModelTask.JOB_AD.value: GPT5_MINI,
+    ModelTask.INTERVIEW_GUIDE.value: GPT5_MINI,
+    ModelTask.DOCUMENT_REFINEMENT.value: GPT5_MINI,
+    ModelTask.EXPLANATION.value: GPT5_MINI,
+    "embedding": EMBED_MODEL,
+}
+
+
+def _normalise_override(value: object) -> str | None:
+    """Normalize manual model override values."""
+
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    if candidate.lower() in {"auto", "automatic", "default"}:
+        return None
+    return candidate
+
+
+def _user_model_override() -> str | None:
+    """Return a manually selected model override, if present."""
+
+    try:
+        override = _normalise_override(st.session_state.get("model_override"))
+    except Exception:  # pragma: no cover - Streamlit session not initialised
+        override = None
+    if override:
+        return override
+    return None
+
+
+try:  # pragma: no cover - safe defaults when Streamlit session exists
+    if "model" not in st.session_state:
+        st.session_state["model"] = OPENAI_MODEL
+    if "model_override" not in st.session_state:
+        st.session_state["model_override"] = ""
+except Exception:
+    pass
+
+
+def get_model_for(task: ModelTask | str, *, override: str | None = None) -> str:
+    """Return the configured model for ``task`` respecting manual overrides."""
+
+    if override:
+        return override
+    user_override = _user_model_override()
+    if user_override:
+        return user_override
+    key = task.value if isinstance(task, ModelTask) else str(task)
+    return MODEL_ROUTING.get(key, GPT5_MINI)
+
 
 if OPENAI_API_KEY:
     try:

--- a/ingest/reader.py
+++ b/ingest/reader.py
@@ -189,7 +189,9 @@ _HEADERS = {"User-Agent": "CognitiveNeeds/1.0"}
 
 _EMAIL_RE = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.IGNORECASE)
 _PHONE_RE = re.compile(r"\+?\d[\d\s().\-/]{5,}\d")
-_CONTACT_LABEL_RE = re.compile(r"(kontakt|contact|homepage|telefon|phone|e-?mail)\s*[:–—-]")
+_CONTACT_LABEL_RE = re.compile(
+    r"(kontakt|contact|homepage|telefon|phone|e-?mail)\s*[:–—-]"
+)
 
 
 def _read_url(url: str) -> str:

--- a/llm/client.py
+++ b/llm/client.py
@@ -16,7 +16,13 @@ from openai_utils import model_supports_reasoning, model_supports_temperature
 from .context import build_extract_messages
 from .prompts import FIELDS_ORDER
 from core.errors import ExtractionError
-from config import OPENAI_API_KEY, OPENAI_BASE_URL, OPENAI_MODEL, REASONING_EFFORT
+from config import (
+    OPENAI_API_KEY,
+    OPENAI_BASE_URL,
+    REASONING_EFFORT,
+    ModelTask,
+    get_model_for,
+)
 
 logger = logging.getLogger("cognitive_needs.llm")
 
@@ -118,7 +124,7 @@ def extract_json(
         _minimal_messages(text) if minimal else build_extract_messages(text, title, url)
     )
     effort = st.session_state.get("reasoning_effort", REASONING_EFFORT)
-    model = st.session_state.get("model", OPENAI_MODEL)
+    model = get_model_for(ModelTask.EXTRACTION)
     try:
         request: dict[str, Any] = {
             "model": model,

--- a/openai_utils/api.py
+++ b/openai_utils/api.py
@@ -27,7 +27,13 @@ from openai import (
 )
 import streamlit as st
 
-from config import OPENAI_API_KEY, OPENAI_MODEL, OPENAI_BASE_URL, REASONING_EFFORT
+from config import (
+    OPENAI_API_KEY,
+    OPENAI_BASE_URL,
+    REASONING_EFFORT,
+    ModelTask,
+    get_model_for,
+)
 from constants.keys import StateKeys
 
 logger = logging.getLogger("cognitive_needs.openai")
@@ -177,7 +183,7 @@ def call_chat_api(
     from core import analysis_tools
 
     if model is None:
-        model = st.session_state.get("model", OPENAI_MODEL)
+        model = get_model_for(ModelTask.DEFAULT)
     if reasoning_effort is None:
         reasoning_effort = st.session_state.get("reasoning_effort", REASONING_EFFORT)
 

--- a/openai_utils/extraction.py
+++ b/openai_utils/extraction.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Mapping, Sequence
 
-import streamlit as st
-
-from config import OPENAI_MODEL
+from config import ModelTask, get_model_for
 from . import api
 from .api import _chat_content
 from .tools import build_extraction_tool
@@ -29,7 +27,7 @@ def extract_company_info(text: str, model: str | None = None) -> dict:
     if not text:
         return {}
     if model is None:
-        model = st.session_state.get("model", OPENAI_MODEL)
+        model = get_model_for(ModelTask.COMPANY_INFO)
 
     prompt = (
         "Analyze the following company website text and extract: the official "
@@ -159,7 +157,7 @@ def extract_with_function(
     """
 
     if model is None:
-        model = st.session_state.get("model", OPENAI_MODEL)
+        model = get_model_for(ModelTask.EXTRACTION)
 
     system_prompt = (
         "You are a vacancy extraction engine. Analyse the job advertisement "
@@ -244,7 +242,7 @@ def suggest_additional_skills(
     if not job_title:
         return {"technical": [], "soft": []}
     if model is None:
-        model = st.session_state.get("model", OPENAI_MODEL)
+        model = get_model_for(ModelTask.SKILL_SUGGESTION)
     half = num_suggestions // 2
     if lang.startswith("de"):
         prompt = (
@@ -371,7 +369,7 @@ def suggest_skills_for_role(
             "soft_skills": [],
         }
     if model is None:
-        model = st.session_state.get("model", OPENAI_MODEL)
+        model = get_model_for(ModelTask.SKILL_SUGGESTION)
 
     if lang.startswith("de"):
         prompt = (
@@ -488,7 +486,7 @@ def suggest_benefits(
     if not job_title:
         return []
     if model is None:
-        model = st.session_state.get("model", OPENAI_MODEL)
+        model = get_model_for(ModelTask.BENEFIT_SUGGESTION)
     if lang.startswith("de"):
         prompt = f"Nenne bis zu 5 Vorteile oder Zusatzleistungen, die für eine Stelle als {job_title} üblich sind"
         if industry:
@@ -590,7 +588,7 @@ def suggest_role_tasks(
     if not job_title:
         return []
     if model is None:
-        model = st.session_state.get("model", OPENAI_MODEL)
+        model = get_model_for(ModelTask.TASK_SUGGESTION)
     prompt = f"List {num_tasks} concise core responsibilities for a {job_title} role as a JSON array."
     messages = [{"role": "user", "content": prompt}]
     max_tokens = 180 if not model or "nano" in model else 250
@@ -665,7 +663,7 @@ def generate_interview_guide(
         num_questions + len(hard_list) + len(soft_list) + (1 if company_culture else 0)
     )
     if model is None:
-        model = st.session_state.get("model", OPENAI_MODEL)
+        model = get_model_for(ModelTask.INTERVIEW_GUIDE)
     job_title = job_title.strip() or "this position"
     if lang.startswith("de"):
         tone = tone or "professionell und hilfreich"
@@ -751,7 +749,7 @@ def generate_job_ad(
         data["compensation.benefits"] = deduped
     lang = data.get("lang", "en")
     if model is None:
-        model = st.session_state.get("model", OPENAI_MODEL)
+        model = get_model_for(ModelTask.JOB_AD)
     if tone is None:
         tone = (
             "klar, ansprechend und inklusiv"
@@ -952,7 +950,7 @@ def refine_document(original: str, feedback: str, model: str | None = None) -> s
         The revised document text.
     """
     if model is None:
-        model = st.session_state.get("model", OPENAI_MODEL)
+        model = get_model_for(ModelTask.DOCUMENT_REFINEMENT)
     prompt = (
         "Revise the following document based on the user instructions.\n"
         f"Document:\n{original}\n\n"
@@ -982,7 +980,7 @@ def what_happened(
         Explanation text summarizing the generation process.
     """
     if model is None:
-        model = st.session_state.get("model", OPENAI_MODEL)
+        model = get_model_for(ModelTask.EXPLANATION)
     keys_used = [k for k, v in session_data.items() if v]
     prompt = (
         f"Explain how the following {doc_type} was generated using the keys: {', '.join(keys_used)}.\n"

--- a/question_logic.py
+++ b/question_logic.py
@@ -32,7 +32,7 @@ from utils.i18n import tr
 from core.esco_utils import normalize_skills
 from core.suggestions import get_benefit_suggestions
 from integrations.esco import enrich_skills, search_occupation
-from config import OPENAI_API_KEY, OPENAI_MODEL, VECTOR_STORE_ID
+from config import OPENAI_API_KEY, VECTOR_STORE_ID, ModelTask, get_model_for
 
 # Optional OpenAI vector store ID for RAG suggestions; set via env/secrets.
 # If unset or blank, RAG lookups are skipped.
@@ -494,7 +494,7 @@ def _rag_suggestions(
     )
     if not vector_store_id:
         return {}
-    model = model or st.session_state.get("model", OPENAI_MODEL)
+    model = get_model_for(ModelTask.RAG_SUGGESTIONS, override=model)
     sys = (
         "You provide short, concrete suggestions to help complete a profile. "
         "Use retrieved context; if none, return empty arrays. Respond as a JSON object "
@@ -603,8 +603,7 @@ def ask_followups(
         parsing fails or the response is invalid.
     """
 
-    if model is None:
-        model = st.session_state.get("model", OPENAI_MODEL)
+    model = get_model_for(ModelTask.FOLLOW_UP_QUESTIONS, override=model)
     vector_store_id = (
         vector_store_id
         or st.session_state.get("vector_store_id")

--- a/state/ensure_state.py
+++ b/state/ensure_state.py
@@ -40,6 +40,8 @@ def ensure_state() -> None:
         st.session_state["lang"] = "de"
     if "model" not in st.session_state:
         st.session_state["model"] = OPENAI_MODEL
+    if "model_override" not in st.session_state:
+        st.session_state["model_override"] = ""
     if "vector_store_id" not in st.session_state:
         st.session_state["vector_store_id"] = os.getenv("VECTOR_STORE_ID", "")
     if "openai_api_key_missing" not in st.session_state:
@@ -84,7 +86,7 @@ def reset_state() -> None:
     reinitializes defaults via :func:`ensure_state`.
     """
 
-    preserve = {"lang", "model", "vector_store_id", "auto_reask"}
+    preserve = {"lang", "model", "model_override", "vector_store_id", "auto_reask"}
     for key in list(st.session_state.keys()):
         if key not in preserve:
             del st.session_state[key]

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -13,8 +13,8 @@ def test_suggest_additional_skills_model(monkeypatch):
 
     monkeypatch.setattr(openai_utils.api, "call_chat_api", fake_call_chat_api)
     monkeypatch.setattr(esco_utils, "normalize_skills", lambda skills, **_: skills)
-    out = openai_utils.suggest_additional_skills("Engineer", model="gpt-4.1-nano")
-    assert captured["model"] == "gpt-4.1-nano"
+    out = openai_utils.suggest_additional_skills("Engineer", model="gpt-5-mini")
+    assert captured["model"] == "gpt-5-mini"
     assert out["technical"] == ["Tech1", "Tech2"]
     assert out["soft"] == ["Communication"]
 
@@ -27,15 +27,14 @@ def test_suggest_benefits_model(monkeypatch):
         return ChatCallResult("- BenefitA\n- BenefitB", [], {})
 
     monkeypatch.setattr(openai_utils.api, "call_chat_api", fake_call_chat_api)
-    out = openai_utils.suggest_benefits("Engineer", lang="en", model="gpt-4.1-nano")
-    assert captured["model"] == "gpt-4.1-nano"
+    out = openai_utils.suggest_benefits("Engineer", lang="en", model="gpt-5-nano")
+    assert captured["model"] == "gpt-5-nano"
     assert out == ["BenefitA", "BenefitB"]
 
 
-def test_session_state_model_default(monkeypatch):
+def test_suggest_benefits_dispatch_default(monkeypatch):
     captured = {}
     st.session_state.clear()
-    st.session_state["model"] = "gpt-4.1-nano"
 
     def fake_call_chat_api(messages, model=None, **kwargs):
         captured["model"] = model
@@ -43,5 +42,20 @@ def test_session_state_model_default(monkeypatch):
 
     monkeypatch.setattr(openai_utils.api, "call_chat_api", fake_call_chat_api)
     out = openai_utils.suggest_benefits("Engineer")
-    assert captured["model"] == "gpt-4.1-nano"
+    assert captured["model"] == "gpt-5-nano"
+    assert out == ["BenefitA", "BenefitB"]
+
+
+def test_manual_override_reroutes_all_tasks(monkeypatch):
+    captured = {}
+    st.session_state.clear()
+    st.session_state["model_override"] = "gpt-5-mini"
+
+    def fake_call_chat_api(messages, model=None, **kwargs):
+        captured["model"] = model
+        return ChatCallResult("- BenefitA\n- BenefitB", [], {})
+
+    monkeypatch.setattr(openai_utils.api, "call_chat_api", fake_call_chat_api)
+    out = openai_utils.suggest_benefits("Engineer")
+    assert captured["model"] == "gpt-5-mini"
     assert out == ["BenefitA", "BenefitB"]

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -152,7 +152,7 @@ def test_call_chat_api_omits_reasoning_for_standard_models(monkeypatch):
     monkeypatch.setattr("openai_utils.api.client", _FakeClient(), raising=False)
     call_chat_api(
         [{"role": "user", "content": "hi"}],
-        model="gpt-4.1-nano",
+        model="gpt-5-nano",
         reasoning_effort="high",
     )
     assert "reasoning" not in captured
@@ -189,16 +189,16 @@ def test_model_supports_temperature_detection() -> None:
     """The helper should detect reasoning models and allow regular ones."""
 
     assert not model_supports_temperature("o1-mini")
-    assert not model_supports_temperature("gpt-4o-reasoning")
-    assert model_supports_temperature("gpt-4o-mini")
+    assert not model_supports_temperature("gpt-5-reasoning")
+    assert model_supports_temperature("gpt-5-mini")
 
 
 def test_model_supports_reasoning_detection() -> None:
     """The reasoning helper should match known reasoning model patterns."""
 
     assert model_supports_reasoning("o1-mini")
-    assert model_supports_reasoning("gpt-4o-reasoning")
-    assert not model_supports_reasoning("gpt-4.1-nano")
+    assert model_supports_reasoning("gpt-5-reasoning")
+    assert not model_supports_reasoning("gpt-5-nano")
 
 
 def test_extract_with_function(monkeypatch):

--- a/tests/test_refine_and_explain.py
+++ b/tests/test_refine_and_explain.py
@@ -11,10 +11,10 @@ def test_refine_document_passes_model(monkeypatch):
         return ChatCallResult("updated", [], {})
 
     monkeypatch.setattr(openai_utils.api, "call_chat_api", fake_call_chat_api)
-    out = openai_utils.refine_document("orig", "shorter", model="gpt-4.1-nano")
+    out = openai_utils.refine_document("orig", "shorter", model="gpt-5-mini")
     assert "orig" in captured["prompt"]
     assert "shorter" in captured["prompt"]
-    assert captured["model"] == "gpt-4.1-nano"
+    assert captured["model"] == "gpt-5-mini"
     assert out == "updated"
 
 
@@ -33,11 +33,11 @@ def test_what_happened_lists_keys(monkeypatch):
         "empty": "",
     }
     out = openai_utils.what_happened(
-        session, "doc", doc_type="job ad", model="gpt-4.1-nano"
+        session, "doc", doc_type="job ad", model="gpt-5-mini"
     )
     assert "job ad" in captured["prompt"]
     assert "position.job_title" in captured["prompt"]
     assert "location.primary_city" in captured["prompt"]
     assert "empty" not in captured["prompt"]
-    assert captured["model"] == "gpt-4.1-nano"
+    assert captured["model"] == "gpt-5-mini"
     assert out == "explanation"


### PR DESCRIPTION
## Summary
- add a central GPT-5-aware model dispatcher in `config.py` and expose task enums/helpers for reuse
- update UI session management and every OpenAI call site to consume the dispatcher, routing heavy jobs to gpt-5-mini and list suggestions to gpt-5-nano
- refresh documentation, agent notes, and tests to describe the new routing strategy and expectations

## Testing
- ruff check .
- black .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb2b2c3a7483209856ed8379d3a0ea