### PR TITLE
fix: request ESCO resource endpoint for group labels

### DIFF
--- a/core/esco_utils.py
+++ b/core/esco_utils.py
@@ -82,10 +82,21 @@ def classify_occupation(title: str, lang: str = "en") -> Optional[Dict[str, str]
     group = ""
     if group_uri:
         try:
-            grp = _get(group_uri)
-            group = grp.get("title", "")
+            grp = _get("resource", uri=group_uri, language=lang)
         except requests.RequestException as exc:  # pragma: no cover - network
             log.warning("ESCO group lookup failed: %s", exc)
+        else:
+            label = (
+                grp.get("title")
+                or grp.get("preferredLabel")
+                or grp.get("label")
+                or ""
+            )
+            if isinstance(label, dict):
+                group = label.get(lang, "") or next(iter(label.values()), "")
+            else:
+                group = str(label)
+            group = group.strip()
     return {
         "preferredLabel": _lab(best),
         "uri": best.get("uri") or best.get("_links", {}).get("self", {}).get("href"),

--- a/tests/test_esco.py
+++ b/tests/test_esco.py
@@ -2,8 +2,11 @@ from core import esco_utils as esco
 
 
 def test_classify_occupation(monkeypatch) -> None:
+    calls = []
+
     def fake_get(path, **params):
-        if "search" in path:
+        calls.append((path, params))
+        if path == "search":
             return {
                 "_embedded": {
                     "results": [
@@ -15,7 +18,9 @@ def test_classify_occupation(monkeypatch) -> None:
                     ]
                 }
             }
-        return {"title": "Software developers"}
+        assert path == "resource"
+        assert params == {"uri": "http://example.com/group", "language": "en"}
+        return {"title": {"en": "Software developers"}}
 
     monkeypatch.setattr(esco, "_get", fake_get)
     res = esco.classify_occupation("Software engineer")
@@ -24,6 +29,8 @@ def test_classify_occupation(monkeypatch) -> None:
         "group": "Software developers",
         "uri": "http://example.com/occ",
     }
+    assert calls[0][0] == "search"
+    assert calls[1][0] == "resource"
 
 
 def test_get_essential_skills(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- update `classify_occupation` to fetch ISCO group metadata via the ESCO `resource` endpoint and parse localized titles
- keep error handling while ensuring blank-safe group labels
- extend the unit test to confirm the resource call and label extraction

## Testing
- PYTHONPATH=. pytest tests/test_esco.py

------
https://chatgpt.com/codex/tasks/task_e_68cbd68d80f88320b02967560c35bf8d