### PR TITLE
fix: filter orphaned phase participants

### DIFF
--- a/tests/test_wizard_phases.py
+++ b/tests/test_wizard_phases.py
@@ -1,0 +1,31 @@
+"""Tests for phase participant filtering in the wizard."""
+
+from pathlib import Path
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from wizard import _filter_existing_participants  # noqa: E402
+
+
+def test_filter_existing_participants_preserves_known_entries() -> None:
+    """Previously saved participants should remain when still available."""
+
+    participants = ["Alice", "Bob"]
+    stakeholder_names = ["Alice", "Bob", "Charlie"]
+
+    assert (
+        _filter_existing_participants(participants, stakeholder_names) == participants
+    )
+
+
+def test_filter_existing_participants_removes_unknown_entries() -> None:
+    """Orphaned participant selections must be ignored."""
+
+    participants = ["Alice", "Bob", "Zoe"]
+    stakeholder_names = ["Alice", "Charlie"]
+
+    assert _filter_existing_participants(participants, stakeholder_names) == ["Alice"]

--- a/wizard.py
+++ b/wizard.py
@@ -1758,6 +1758,24 @@ def _render_stakeholders(process: dict, key_prefix: str) -> None:
         p["primary"] = i == primary_idx
 
 
+def _filter_existing_participants(
+    participants: Sequence[str],
+    stakeholder_names: Sequence[str],
+) -> list[str]:
+    """Return participants that still exist in ``stakeholder_names``.
+
+    Args:
+        participants: The participants saved for a phase.
+        stakeholder_names: Current list of available stakeholder names.
+
+    Returns:
+        Filtered list containing only participants still available for selection.
+    """
+
+    existing = {name for name in stakeholder_names if name}
+    return [participant for participant in participants if participant in existing]
+
+
 def _render_phases(process: dict, stakeholders: list[dict], key_prefix: str) -> None:
     """Render phase inputs based on ``interview_stages``."""
 
@@ -1813,10 +1831,13 @@ def _render_phases(process: dict, stakeholders: list[dict], key_prefix: str) -> 
                 format_func=dict(format_options).__getitem__,
                 key=f"{key_prefix}.{idx}.format",
             )
+            phase_participants = _filter_existing_participants(
+                phase.get("participants", []), stakeholder_names
+            )
             phase["participants"] = st.multiselect(
                 tr("Beteiligte", "Participants"),
                 stakeholder_names,
-                default=phase.get("participants", []),
+                default=phase_participants,
                 key=f"{key_prefix}.{idx}.participants",
             )
             phase["docs_required"] = st.text_input(


### PR DESCRIPTION
## Summary
- filter persisted phase participants to the currently available stakeholders before rendering
- add dedicated unit tests covering the participant filtering helper

## Testing
- ruff check wizard.py tests/test_wizard_phases.py
- black --check wizard.py tests/test_wizard_phases.py
- mypy .
- pytest tests/test_wizard_phases.py

------
https://chatgpt.com/codex/tasks/task_e_68cbdcd0b29c8320adc800d822084812