### PR TITLE
feat: refresh sidebar settings layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,6 @@ for candidate in (APP_ROOT, APP_ROOT.parent):
     if candidate_str not in sys.path:
         sys.path.append(candidate_str)
 
-from components.model_selector import model_selector  # noqa: E402
 from constants.keys import UIKeys  # noqa: E402
 from config_loader import load_json  # noqa: E402
 from utils.i18n import tr  # noqa: E402
@@ -139,6 +138,11 @@ def render_primary_sidebar() -> None:
     def _on_theme_toggle() -> None:
         st.session_state["dark_mode"] = st.session_state["ui.dark_mode"]
 
+    def _on_lang_change() -> None:
+        st.session_state["lang"] = st.session_state[UIKeys.LANG_SELECT]
+
+    lang_options = {"de": "DE", "en": "EN"}
+
     hero_title = tr("Dein Recruiting-Co-Pilot", "Your recruiting co-pilot")
     hero_subtitle = tr(
         "Verwalte Einstellungen wie im vertrauten ATS – klar, fokussiert, jederzeit erreichbar.",
@@ -147,6 +151,17 @@ def render_primary_sidebar() -> None:
     status_label = tr("Wizard-Status", "Wizard status")
 
     with st.sidebar:
+        st.markdown(f"### ⚙️ {tr('Einstellungen', 'Settings')}")
+        st.toggle("Dark Mode 🌙", key="ui.dark_mode", on_change=_on_theme_toggle)
+        st.radio(
+            tr("Sprache", "Language"),
+            options=list(lang_options.keys()),
+            key=UIKeys.LANG_SELECT,
+            horizontal=True,
+            format_func=lambda key: lang_options[key],
+            on_change=_on_lang_change,
+        )
+
         st.markdown(
             f"""
             <div class="sidebar-hero">
@@ -161,18 +176,6 @@ def render_primary_sidebar() -> None:
             unsafe_allow_html=True,
         )
 
-        st.markdown(f"### ⚙️ {tr('Einstellungen', 'Settings')}")
-        st.toggle("Dark Mode 🌙", key="ui.dark_mode", on_change=_on_theme_toggle)
-
-        st.markdown(f"### 🤖 {tr('KI-Konfiguration', 'AI configuration')}")
-        model_selector()
-        st.caption(
-            tr(
-                "Passe das Modell flexibel an Extraktion, Analyse oder Generierung an.",
-                "Adjust the model flexibly for extraction, analysis or generation tasks.",
-            )
-        )
-
         st.divider()
         st.markdown(f"### 💡 {tr('Tipps aus der Praxis', 'Practical tips')}")
         st.markdown(
@@ -184,10 +187,6 @@ def render_primary_sidebar() -> None:
                 "- Use the salary outlook inside the detailed steps to validate budget decisions.\n"
                 "- Find every AI result again in the summary view.",
             )
-        )
-        st.markdown(
-            f"<div class='sidebar-note'>{tr('Hinweis: Änderungen werden automatisch gespeichert – nutze den Aktualisieren-Button in den Detail-Schritten für eine frische Prognose.', 'Note: Changes are saved automatically – use the refresh button in the detailed steps for an up-to-date salary estimate.')}</div>",
-            unsafe_allow_html=True,
         )
 
 

--- a/tests/test_wizard_intro.py
+++ b/tests/test_wizard_intro.py
@@ -16,18 +16,14 @@ class DummyContext:
 
 
 def test_onboarding_language_switch(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Selecting English updates ``st.session_state.lang`` via the onboarding UI."""
+    """Onboarding mirrors the sidebar language choice into ``st.session_state.lang``."""
 
     st.session_state.clear()
     st.session_state.lang = "de"
     st.session_state[UIKeys.INPUT_METHOD] = "text"
+    st.session_state[UIKeys.LANG_SELECT] = "en"
 
     def fake_radio(label, options, *, key, horizontal=False, on_change=None, **kwargs):
-        if key == UIKeys.LANG_SELECT:
-            st.session_state[key] = "en"
-            if on_change:
-                on_change()
-            return "en"
         if key == UIKeys.INPUT_METHOD:
             return st.session_state.get(UIKeys.INPUT_METHOD, options[0])
         return options[0]

--- a/wizard.py
+++ b/wizard.py
@@ -1411,24 +1411,10 @@ def _step_onboarding(schema: dict) -> None:
 
     _maybe_run_extraction(schema)
 
-    lang_options = {"de": "DE", "en": "EN"}
     if UIKeys.LANG_SELECT not in st.session_state:
         st.session_state[UIKeys.LANG_SELECT] = st.session_state.get("lang", "de")
 
-    def _on_lang_change() -> None:
-        st.session_state["lang"] = st.session_state[UIKeys.LANG_SELECT]
-
-    _, col_toggle = st.columns([5, 1])
-    with col_toggle:
-        st.radio(
-            tr("Sprache", "Language"),
-            options=list(lang_options.keys()),
-            key=UIKeys.LANG_SELECT,
-            horizontal=True,
-            label_visibility="collapsed",
-            format_func=lambda key: lang_options[key],
-            on_change=_on_lang_change,
-        )
+    st.session_state["lang"] = st.session_state[UIKeys.LANG_SELECT]
 
     welcome_headline = tr(
         "Willkommen zum Onboarding",


### PR DESCRIPTION
## Summary
- move the sidebar settings block above the wizard status and add the language toggle next to the dark mode control
- remove the obsolete AI configuration section and hint note from the sidebar
- mirror the sidebar language selection in the onboarding flow and update the related test

## Testing
- ruff check app.py wizard.py tests/test_wizard_intro.py
- black app.py wizard.py tests/test_wizard_intro.py
- mypy app.py wizard.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cbe98ba7fc8320824f69aaaedbad9c