### PR TITLE
Fix summary value selection for job ad generation

### DIFF
--- a/constants/keys.py
+++ b/constants/keys.py
@@ -32,6 +32,7 @@ class UIKeys:
     JOB_AD_FONT = "ui.job_ad.font"
     JOB_AD_FORMAT = "ui.job_ad.format"
     JOB_AD_LOGO_UPLOAD = "ui.job_ad.logo_upload"
+    INTERVIEW_FORMAT = "ui.summary.interview_format"
 
 
 class StateKeys:
@@ -57,7 +58,9 @@ class StateKeys:
     COMPANY_PAGE_BASE = "company.page_base_url"
 
     JOB_AD_SELECTED_FIELDS = "data.job_ad.selected_fields"
+    JOB_AD_SELECTED_VALUES = "data.job_ad.selected_values"
     JOB_AD_MANUAL_ENTRIES = "data.job_ad.manual_entries"
     JOB_AD_SELECTED_AUDIENCE = "data.job_ad.selected_audience"
     JOB_AD_FONT_CHOICE = "data.job_ad.font"
     JOB_AD_LOGO_DATA = "data.job_ad.logo"
+    ESCO_OCCUPATION_OPTIONS = "data.esco_occupation_options"

--- a/state/ensure_state.py
+++ b/state/ensure_state.py
@@ -44,6 +44,8 @@ def ensure_state() -> None:
         st.session_state[StateKeys.COMPANY_PAGE_BASE] = ""
     if StateKeys.JOB_AD_SELECTED_FIELDS not in st.session_state:
         st.session_state[StateKeys.JOB_AD_SELECTED_FIELDS] = set()
+    if StateKeys.JOB_AD_SELECTED_VALUES not in st.session_state:
+        st.session_state[StateKeys.JOB_AD_SELECTED_VALUES] = {}
     if StateKeys.JOB_AD_MANUAL_ENTRIES not in st.session_state:
         st.session_state[StateKeys.JOB_AD_MANUAL_ENTRIES] = []
     if StateKeys.JOB_AD_SELECTED_AUDIENCE not in st.session_state:


### PR DESCRIPTION
## Summary
- add per-value checkboxes to the summary tabs and store the selection map in session state
- filter the profile payload before job-ad generation so only checked list items are forwarded
- seed the new summary selection state during setup to keep the job-ad flow consistent

## Testing
- black .
- ruff check .
- mypy .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cbf394baa0832095107de3c6ded2f9