### PR TITLE
fix: add esco occupation options key

### DIFF
--- a/constants/keys.py
+++ b/constants/keys.py
@@ -51,6 +51,7 @@ class StateKeys:
     EXTRACTION_MISSING = "extraction_missing"
     EXTRACTION_RAW_PROFILE = "extraction_raw_profile"
     ESCO_SKILLS = "extraction_esco_skills"
+    ESCO_OCCUPATION_OPTIONS = "extraction_esco_occupation_options"
     BIAS_FINDINGS = "data.bias_findings"
     SKILL_BUCKETS = "skill_buckets"
     COMPANY_PAGE_SUMMARIES = "company.page_summaries"


### PR DESCRIPTION
## Summary
- add the missing ESCO occupation options session state key constant
- ensure wizard and state initialization continue using the shared constant

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbf6b20eb48320be916549d5a464c2