### PR TITLE
feat: enrich hiring process step

### DIFF
--- a/config.py
+++ b/config.py
@@ -77,6 +77,7 @@ class ModelTask(StrEnum):
     SKILL_SUGGESTION = "skill_suggestion"
     BENEFIT_SUGGESTION = "benefit_suggestion"
     TASK_SUGGESTION = "task_suggestion"
+    ONBOARDING_SUGGESTION = "onboarding_suggestion"
     JOB_AD = "job_ad"
     INTERVIEW_GUIDE = "interview_guide"
     DOCUMENT_REFINEMENT = "document_refinement"
@@ -96,6 +97,7 @@ MODEL_ROUTING: Dict[str, str] = {
     ModelTask.SKILL_SUGGESTION.value: GPT5_NANO,
     ModelTask.BENEFIT_SUGGESTION.value: GPT5_NANO,
     ModelTask.TASK_SUGGESTION.value: GPT5_NANO,
+    ModelTask.ONBOARDING_SUGGESTION.value: GPT5_NANO,
     ModelTask.JOB_AD.value: GPT5_MINI,
     ModelTask.INTERVIEW_GUIDE.value: GPT5_MINI,
     ModelTask.DOCUMENT_REFINEMENT.value: GPT5_MINI,

--- a/constants/keys.py
+++ b/constants/keys.py
@@ -48,6 +48,7 @@ class StateKeys:
     INTERVIEW_GUIDE_MD = "data.interview_md"
     SKILL_SUGGESTIONS = "skill_suggestions"
     BENEFIT_SUGGESTIONS = "benefit_suggestions"
+    ONBOARDING_SUGGESTIONS = "onboarding_suggestions"
     EXTRACTION_SUMMARY = "extraction_summary"
     EXTRACTION_MISSING = "extraction_missing"
     EXTRACTION_RAW_PROFILE = "extraction_raw_profile"

--- a/core/suggestions.py
+++ b/core/suggestions.py
@@ -4,9 +4,17 @@ from __future__ import annotations
 
 from typing import Dict, List, Tuple
 
-from openai_utils import suggest_benefits, suggest_skills_for_role
+from openai_utils import (
+    suggest_benefits,
+    suggest_onboarding_plans,
+    suggest_skills_for_role,
+)
 
-__all__ = ["get_skill_suggestions", "get_benefit_suggestions"]
+__all__ = [
+    "get_skill_suggestions",
+    "get_benefit_suggestions",
+    "get_onboarding_suggestions",
+]
 
 
 def get_skill_suggestions(
@@ -55,4 +63,27 @@ def get_benefit_suggestions(
             None,
         )
     except Exception as err:  # pragma: no cover - error path is tested
+        return [], str(err)
+
+
+def get_onboarding_suggestions(
+    job_title: str,
+    *,
+    company_name: str = "",
+    industry: str = "",
+    culture: str = "",
+    lang: str = "en",
+) -> Tuple[List[str], str | None]:
+    """Fetch onboarding process suggestions for the given role context."""
+
+    try:
+        suggestions = suggest_onboarding_plans(
+            job_title,
+            company_name=company_name,
+            industry=industry,
+            culture=culture,
+            lang=lang,
+        )
+        return suggestions, None
+    except Exception as err:  # pragma: no cover - API failure path
         return [], str(err)

--- a/models/need_analysis.py
+++ b/models/need_analysis.py
@@ -131,6 +131,7 @@ class Stakeholder(BaseModel):
     role: str
     email: EmailStr | None = None
     primary: bool = False
+    information_loop_phases: List[int] = Field(default_factory=list)
 
     @field_validator("email", mode="before")
     @classmethod

--- a/schema/need_analysis.schema.json
+++ b/schema/need_analysis.schema.json
@@ -573,6 +573,12 @@
                                     "boolean",
                                     "null"
                                 ]
+                            },
+                            "information_loop_phases": {
+                                "type": "array",
+                                "items": {
+                                    "type": "integer"
+                                }
                             }
                         },
                         "required": [

--- a/tests/test_process_step.py
+++ b/tests/test_process_step.py
@@ -11,7 +11,11 @@ def test_process_model_supports_stakeholders_and_phases():
         interview_stages=2,
         stakeholders=[
             Stakeholder(
-                name="Alice", role="Recruiter", email="alice@example.com", primary=True
+                name="Alice",
+                role="Recruiter",
+                email="alice@example.com",
+                primary=True,
+                information_loop_phases=[0, 1],
             ),
             Stakeholder(name="Bob", role="Manager", email="bob@example.com"),
             Stakeholder(name="Carol", role="HR"),
@@ -43,6 +47,7 @@ def test_process_model_supports_stakeholders_and_phases():
     profile = NeedAnalysisProfile(process=process)
     assert profile.process.interview_stages == 2
     assert profile.process.stakeholders[0].primary is True
+    assert profile.process.stakeholders[0].information_loop_phases == [0, 1]
     assert profile.process.stakeholders[2].email is None
     assert profile.process.stakeholders[3].email is None
     assert profile.process.phases[1].participants == ["Bob"]


### PR DESCRIPTION
## Summary
- collapse interview phases by default, capture stakeholder information-loop phases, and capture the overall timeline via calendar inputs in the process step UI
- add an onboarding suggestion generator powered by the LLM, storing selectable proposals and wiring state/session handling for the wizard and summary views
- extend the model/schema to persist stakeholder phase selections and expose a new OpenAI task and helper for onboarding plans

## Testing
- black .
- ruff check .
- mypy .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbfd79965483208d6b8f8a72e663c3