### PR TITLE
feat: highlight summary values overview

### DIFF
--- a/styles/cognitive_needs.css
+++ b/styles/cognitive_needs.css
@@ -130,6 +130,51 @@ a:hover { text-decoration: none; filter: drop-shadow(0 0 10px rgba(105,226,255,.
 }
 .stTabs [data-baseweb="tab-list"] button { border-radius: 10px; }
 
+/* Summary: values overview highlight */
+.values-overview-grid {
+  margin: 1rem 0 1.4rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+}
+
+.values-overview-card {
+  background: rgba(255,255,255,0.35);
+  border: 1px solid rgba(255,255,255,0.45);
+  border-radius: calc(var(--radius) - 2px);
+  padding: 1rem 1.2rem 1.1rem;
+  box-shadow: 0 18px 40px rgba(5,12,28,0.55);
+  backdrop-filter: blur(calc(var(--blur) + 6px)) saturate(160%);
+  -webkit-backdrop-filter: blur(calc(var(--blur) + 6px)) saturate(160%);
+  transition: transform .12s ease, box-shadow .12s ease;
+}
+
+.values-overview-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 46px rgba(5,12,28,0.65);
+}
+
+.values-overview-count {
+  font-family: 'Space Grotesk', Inter, system-ui;
+  font-size: 2.6rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: #0b1220;
+}
+
+.values-overview-label {
+  margin-top: .25rem;
+  font-weight: 600;
+  letter-spacing: .2px;
+  color: rgba(11,18,32,0.9);
+}
+
+.values-overview-subtitle {
+  margin-top: .35rem;
+  color: rgba(15,23,42,0.8);
+  font-size: .9rem;
+}
+
 /* Optional: hide default footer/menu; we minimize via config.toml */
 footer, #MainMenu { visibility: hidden; }
 

--- a/styles/cognitive_needs_light.css
+++ b/styles/cognitive_needs_light.css
@@ -116,6 +116,49 @@ a:hover { text-decoration: none; filter: drop-shadow(0 0 10px rgba(6,182,212,.25
 }
 .stTabs [data-baseweb="tab-list"] button { border-radius: 10px; }
 
+/* Summary: values overview highlight */
+.values-overview-grid {
+  margin: 1rem 0 1.4rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+}
+
+.values-overview-card {
+  background: rgba(255,255,255,0.96);
+  border: 1px solid rgba(15,23,42,0.08);
+  border-radius: calc(var(--radius) - 2px);
+  padding: 1rem 1.2rem 1.1rem;
+  box-shadow: 0 18px 40px rgba(15,23,42,0.16);
+  transition: transform .12s ease, box-shadow .12s ease;
+}
+
+.values-overview-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 46px rgba(15,23,42,0.22);
+}
+
+.values-overview-count {
+  font-family: 'Space Grotesk', Inter, system-ui;
+  font-size: 2.6rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: #0b1220;
+}
+
+.values-overview-label {
+  margin-top: .25rem;
+  font-weight: 600;
+  letter-spacing: .2px;
+  color: rgba(15,23,42,0.9);
+}
+
+.values-overview-subtitle {
+  margin-top: .35rem;
+  color: rgba(71,85,105,0.95);
+  font-size: .9rem;
+}
+
 footer, #MainMenu { visibility: hidden; }
 
 *::-webkit-scrollbar { height: 12px; width: 12px; }

--- a/wizard.py
+++ b/wizard.py
@@ -1,6 +1,7 @@
 # wizard.py — Cognitive Needs Wizard (clean flow, schema-aligned)
 from __future__ import annotations
 
+import html
 import hashlib
 import io
 import json
@@ -4166,15 +4167,27 @@ def _step_summary(schema: dict, _critical: list[str]):
     )
     st.markdown(f"### {overview_title}")
     entry_label = tr("Einträge", "Entries")
-    for chunk in _chunked(list(zip(group_keys, tab_labels)), 3):
-        cols = st.columns(len(chunk))
-        for col, (group, label) in zip(cols, chunk):
-            count = overview_counts.get(group, 0)
-            col.metric(label=label, value=count)
-            if count:
-                col.caption(f"{count} {entry_label}")
-            else:
-                col.caption(tr("Noch keine Angaben", "No entries yet"))
+    empty_label = tr("Noch keine Angaben", "No entries yet")
+    card_markup: list[str] = []
+    for group, label in zip(group_keys, tab_labels):
+        count = overview_counts.get(group, 0)
+        subtitle = f"{count} {entry_label}" if count else empty_label
+        card_markup.append(
+            "\n".join(
+                [
+                    '<div class="values-overview-card">',
+                    f'  <div class="values-overview-count">{count}</div>',
+                    f'  <div class="values-overview-label">{html.escape(label)}</div>',
+                    f'  <div class="values-overview-subtitle">{html.escape(subtitle)}</div>',
+                    "</div>",
+                ]
+            )
+        )
+
+    st.markdown(
+        '<div class="values-overview-grid">' + "".join(card_markup) + "</div>",
+        unsafe_allow_html=True,
+    )
 
     tabs = st.tabs(tab_labels)
     for tab, group in zip(tabs, group_keys):


### PR DESCRIPTION
## Summary
- replace the summary step metric row with a custom values overview grid that can be styled as a dedicated section
- add dark and light theme styles to brighten the values overview cards above the "Brand-Ton oder Keywords" field

## Testing
- ruff check .
- mypy .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cc1383047c83209719711c000321fc