### PR TITLE
fix: require all company info fields

### DIFF
--- a/openai_utils/extraction.py
+++ b/openai_utils/extraction.py
@@ -55,6 +55,12 @@ def extract_company_info(text: str, model: str | None = None) -> dict:
                         "mission": {"type": "string"},
                         "culture": {"type": "string"},
                     },
+                    "required": [
+                        "name",
+                        "location",
+                        "mission",
+                        "culture",
+                    ],
                     "additionalProperties": False,
                 },
             },


### PR DESCRIPTION
## Summary
- enforce required company info fields in the extraction schema to ensure complete structured outputs

## Testing
- black .
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cc434c9c2c83209eb81e56ddb302f8