### PR TITLE
fix: adjust onboarding suggestions schema

### DIFF
--- a/openai_utils/extraction.py
+++ b/openai_utils/extraction.py
@@ -693,10 +693,17 @@ def suggest_onboarding_plans(
         json_schema={
             "name": "onboarding_suggestions",
             "schema": {
-                "type": "array",
-                "items": {"type": "string"},
-                "minItems": 5,
-                "maxItems": 5,
+                "type": "object",
+                "properties": {
+                    "suggestions": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 5,
+                        "maxItems": 5,
+                    }
+                },
+                "required": ["suggestions"],
+                "additionalProperties": False,
             },
         },
     )
@@ -704,8 +711,16 @@ def suggest_onboarding_plans(
     suggestions: list[str] = []
     try:
         data = json.loads(answer)
-        if isinstance(data, list):
-            suggestions = [str(item).strip() for item in data if str(item).strip()]
+        suggestions_payload: Sequence[Any]
+        if isinstance(data, dict):
+            suggestions_payload = data.get("suggestions", [])
+        elif isinstance(data, list):
+            suggestions_payload = data
+        else:
+            suggestions_payload = []
+        suggestions = [
+            str(item).strip() for item in suggestions_payload if str(item).strip()
+        ]
     except Exception:
         for line in answer.splitlines():
             item = line.strip("-•* \t")


### PR DESCRIPTION
## Summary
- enforce an object wrapper with a `suggestions` array in the onboarding suggestions schema
- update parsing logic to read the nested suggestions payload while keeping the fallback parsing path

## Testing
- `black openai_utils/extraction.py`
- `ruff check`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc43cdf9408320abd217497494b55b