### PR TITLE
feat: add structured ingest parsing

### DIFF
--- a/cli/extract.py
+++ b/cli/extract.py
@@ -25,7 +25,7 @@ def main() -> None:
     args = parser.parse_args()
 
     from ingest.extractors import extract_text_from_file
-    from ingest.reader import clean_job_text
+    from ingest.reader import clean_structured_document
     from config_loader import load_json
     from openai_utils import extract_with_function
     from config import OPENAI_MODEL
@@ -36,7 +36,8 @@ def main() -> None:
 
     with file_path.open("rb") as fh:
         try:
-            text = clean_job_text(extract_text_from_file(fh))
+            structured = clean_structured_document(extract_text_from_file(fh))
+            text = structured.text
         except ValueError as e:
             raise SystemExit(str(e))
     if not text:

--- a/constants/keys.py
+++ b/constants/keys.py
@@ -41,6 +41,7 @@ class StateKeys:
 
     PROFILE = "profile_data"
     RAW_TEXT = "profile_raw_text"
+    RAW_BLOCKS = "profile_raw_blocks"
     STEP = "current_step"
     FOLLOWUPS = "followup_questions"
     USAGE = "api_usage"

--- a/ingest/__init__.py
+++ b/ingest/__init__.py
@@ -1,11 +1,16 @@
 """Utilities for ingesting job posting text."""
 
 from .extractors import extract_text_from_file, extract_text_from_url
-from .reader import clean_job_text, read_job_text
+from .reader import clean_job_text, clean_structured_document, read_job_text
+from .types import ContentBlock, StructuredDocument, build_plain_text_document
 
 __all__ = [
     "read_job_text",
     "extract_text_from_file",
     "extract_text_from_url",
     "clean_job_text",
+    "clean_structured_document",
+    "ContentBlock",
+    "StructuredDocument",
+    "build_plain_text_document",
 ]

--- a/ingest/extractors.py
+++ b/ingest/extractors.py
@@ -2,10 +2,16 @@ import io
 import logging
 import re
 from pathlib import Path
+from typing import Any, Iterable
 
-import requests
-from requests import Response
 import chardet
+import requests
+from docx import Document
+from docx.table import Table
+from docx.text.paragraph import Paragraph
+from requests import Response
+
+from .types import ContentBlock, StructuredDocument, build_plain_text_document
 
 
 logger = logging.getLogger(__name__)
@@ -38,7 +44,7 @@ def _fetch_url(url: str, timeout: float = 15.0) -> str:
     return resp.text
 
 
-def extract_text_from_url(url: str) -> str:
+def extract_text_from_url(url: str) -> StructuredDocument:
     """Extract readable text content from ``url``.
 
     Args:
@@ -50,27 +56,36 @@ def extract_text_from_url(url: str) -> str:
     Raises:
         ValueError: If no text could be extracted.
     """
-    try:
-        import trafilatura
-    except ImportError:  # pragma: no cover - optional dependency
-        from bs4 import BeautifulSoup
-
-        html = _fetch_url(url)
-        soup = BeautifulSoup(html, "lxml")
-        text = soup.get_text("\n", strip=True)
-    else:
-        html = _fetch_url(url)
-        text = (
-            trafilatura.extract(html, include_comments=False, include_tables=False)
-            or ""
-        )
-    text = re.sub(r"\n{2,}", "\n\n", text.strip())
+    html = _fetch_url(url)
+    blocks = _parse_html_blocks(html)
+    text = ""
+    if blocks:
+        text = StructuredDocument.from_blocks(blocks, source=url).text
+    if not text:
+        try:
+            import trafilatura
+        except ImportError:  # pragma: no cover - optional dependency
+            text = ""
+        else:
+            text = (
+                trafilatura.extract(
+                    html,
+                    include_comments=False,
+                    include_tables=True,
+                )
+                or ""
+            )
     if not text:
         raise ValueError("URL contains no extractable text")
-    return text
+    if not blocks:
+        return build_plain_text_document(text, source=url)
+    doc = StructuredDocument.from_blocks(blocks, source=url)
+    if not doc.text:
+        return build_plain_text_document(text, source=url)
+    return doc
 
 
-def extract_text_from_file(file) -> str:
+def extract_text_from_file(file) -> StructuredDocument:
     """Extract text from an uploaded file.
 
     Supports PDF, DOCX and several common text formats. Unsupported binary
@@ -98,41 +113,9 @@ def extract_text_from_file(file) -> str:
 
     suffix = Path(name).suffix.lower()
     if suffix == ".pdf":
-        from pypdf import PdfReader
-        from pypdf.errors import PdfReadError
-
-        try:
-            reader = PdfReader(io.BytesIO(data))
-        except PdfReadError as exc:  # pragma: no cover - invalid PDFs
-            raise ValueError("invalid pdf") from exc
-
-        pages = []
-        for idx, page in enumerate(reader.pages, start=1):
-            page_text = page.extract_text() or ""
-            if not page_text.strip():
-                try:
-                    from pdf2image import convert_from_bytes
-                    import pytesseract
-                except ImportError as err:  # pragma: no cover - optional OCR
-                    raise RuntimeError("ocr dependencies missing") from err
-                try:
-                    images = convert_from_bytes(
-                        data, fmt="png", first_page=idx, last_page=idx
-                    )
-                    ocr_text = "\n".join(
-                        pytesseract.image_to_string(img) for img in images
-                    )
-                    page_text = (page_text + "\n" + ocr_text).strip()
-                except Exception as err:  # pragma: no cover - OCR failure
-                    raise RuntimeError("ocr failed") from err
-            page_text = page_text.strip()
-            pages.append(page_text)
-        return "\n".join(pages).strip()
+        return _extract_pdf(io.BytesIO(data), name)
     if suffix == ".docx":
-        import docx
-
-        doc = docx.Document(io.BytesIO(data))
-        return "\n".join([p.text for p in doc.paragraphs]).strip()
+        return _extract_docx(io.BytesIO(data), name)
     text_suffixes = {
         ".txt",
         ".md",
@@ -156,4 +139,271 @@ def extract_text_from_file(file) -> str:
             text = data.decode("utf-8", errors="ignore")
     text = re.sub(r"\r\n?", "\n", text)
     text = re.sub(r"\s+$", "", text, flags=re.MULTILINE)
-    return text
+    return build_plain_text_document(text, source=name)
+
+
+def _iter_block_items(doc: Any) -> Iterable[Paragraph | Table]:
+    """Yield paragraphs and tables in document order."""
+
+    body: Any = getattr(doc, "_body", None)
+    if body is None:
+        return []
+    iterator = getattr(body, "iter_inner_content", None)
+    if not callable(iterator):
+        return []
+    items: list[Paragraph | Table] = []
+    for child in iterator():  # pragma: no cover - exercised via docx parsing
+        if isinstance(child, (Paragraph, Table)):
+            items.append(child)
+        else:
+            tag = getattr(getattr(child, "_element", None), "tag", "")
+            if isinstance(tag, str) and tag.endswith("}p"):
+                items.append(Paragraph(child, doc))
+            elif isinstance(tag, str) and tag.endswith("}tbl"):
+                items.append(Table(child, doc))
+    return items
+
+
+def _paragraph_is_list(paragraph: Paragraph) -> bool:
+    props = getattr(paragraph._p, "pPr", None)
+    if props is None:
+        return False
+    return bool(getattr(props, "numPr", None))
+
+
+def _paragraph_list_level(paragraph: Paragraph) -> int:
+    props = getattr(paragraph._p, "pPr", None)
+    if props is None:
+        return 0
+    num_pr = getattr(props, "numPr", None)
+    if num_pr is None:
+        return 0
+    level = getattr(getattr(num_pr, "ilvl", None), "val", None)
+    try:
+        return int(level) if level is not None else 0
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return 0
+
+
+def _paragraph_list_type(paragraph: Paragraph) -> str:
+    style_name = (paragraph.style.name if paragraph.style else "").lower()
+    if "number" in style_name or "zähl" in style_name:
+        return "ordered"
+    if "bullet" in style_name or "aufzähl" in style_name:
+        return "unordered"
+    return "unordered"
+
+
+def _heading_level(paragraph: Paragraph) -> int | None:
+    style_name = paragraph.style.name if paragraph.style else ""
+    match = re.search(r"(Heading|Überschrift)\s*(\d)", style_name)
+    if match:
+        try:
+            return int(match.group(2))
+        except ValueError:  # pragma: no cover - defensive
+            return None
+    return None
+
+
+def _extract_docx(buf: io.BytesIO, name: str) -> StructuredDocument:
+    document = Document(buf)
+    blocks: list[ContentBlock] = []
+    position = 0
+    for item in _iter_block_items(document):
+        if isinstance(item, Paragraph):
+            text = item.text.strip()
+            if not text:
+                continue
+            heading_level = _heading_level(item)
+            if heading_level is not None:
+                blocks.append(
+                    ContentBlock(
+                        type="heading",
+                        text=text,
+                        level=heading_level,
+                        metadata={
+                            "position": position,
+                            "style": item.style.name if item.style else None,
+                        },
+                    )
+                )
+            elif _paragraph_is_list(item):
+                blocks.append(
+                    ContentBlock(
+                        type="list_item",
+                        text=text,
+                        level=_paragraph_list_level(item),
+                        metadata={
+                            "position": position,
+                            "style": item.style.name if item.style else None,
+                            "ordered": _paragraph_list_type(item) == "ordered",
+                            "marker": (
+                                "-"
+                                if _paragraph_list_type(item) == "unordered"
+                                else "1"
+                            ),
+                        },
+                    )
+                )
+            else:
+                blocks.append(
+                    ContentBlock(
+                        type="paragraph",
+                        text=text,
+                        metadata={
+                            "position": position,
+                            "style": item.style.name if item.style else None,
+                        },
+                    )
+                )
+        else:
+            rows: list[list[str]] = []
+            for row in item.rows:
+                values = [cell.text.strip() for cell in row.cells]
+                if any(values):
+                    rows.append(values)
+            if rows:
+                block_text = "\n".join(" | ".join(row) for row in rows)
+                blocks.append(
+                    ContentBlock(
+                        type="table",
+                        text=block_text,
+                        metadata={"position": position, "rows": rows},
+                    )
+                )
+        position += 1
+    return StructuredDocument.from_blocks(blocks, source=name)
+
+
+def _extract_pdf(buf: io.BytesIO, name: str) -> StructuredDocument:
+    from pypdf import PdfReader
+    from pypdf.errors import PdfReadError
+
+    try:
+        reader = PdfReader(buf)
+    except PdfReadError as exc:  # pragma: no cover - invalid PDFs
+        raise ValueError("invalid pdf") from exc
+
+    blocks: list[ContentBlock] = []
+    for idx, page in enumerate(reader.pages, start=1):
+        page_text = page.extract_text() or ""
+        if not page_text.strip():
+            try:
+                from pdf2image import convert_from_bytes
+                import pytesseract
+            except ImportError as err:  # pragma: no cover - optional OCR
+                raise RuntimeError("ocr dependencies missing") from err
+            try:
+                images = convert_from_bytes(
+                    buf.getvalue(), fmt="png", first_page=idx, last_page=idx
+                )
+                ocr_text = "\n".join(pytesseract.image_to_string(img) for img in images)
+                page_text = (page_text + "\n" + ocr_text).strip()
+            except Exception as err:  # pragma: no cover - OCR failure
+                raise RuntimeError("ocr failed") from err
+        page_text = page_text.strip()
+        if not page_text:
+            continue
+        segments = [
+            seg.strip() for seg in re.split(r"\n{2,}", page_text) if seg.strip()
+        ]
+        if not segments:
+            segments = [page_text]
+        for pos, segment in enumerate(segments):
+            blocks.append(
+                ContentBlock(
+                    type="paragraph",
+                    text=segment,
+                    metadata={"page": idx, "position": pos},
+                )
+            )
+    return StructuredDocument.from_blocks(blocks, source=name)
+
+
+def _parse_html_blocks(html: str) -> list[ContentBlock]:
+    from bs4 import BeautifulSoup
+    from bs4.element import Tag
+
+    soup = BeautifulSoup(html, "lxml")
+    for tag in soup(["script", "style", "noscript", "template"]):
+        tag.decompose()
+    body = soup.body or soup
+    blocks: list[ContentBlock] = []
+    position = 0
+    for element in body.find_all(
+        ["h1", "h2", "h3", "h4", "h5", "h6", "p", "li", "table"],
+        recursive=True,
+    ):
+        if not isinstance(element, Tag):
+            continue
+        text = element.get_text(" ", strip=True)
+        if not text or not element.name:
+            continue
+        if element.name.startswith("h"):
+            try:
+                level = int(element.name[1])
+            except (ValueError, IndexError):  # pragma: no cover - defensive
+                level = None
+            blocks.append(
+                ContentBlock(
+                    type="heading",
+                    text=text,
+                    level=level,
+                    metadata={"tag": element.name, "position": position},
+                )
+            )
+        elif element.name == "li":
+            ancestors = [
+                ancestor
+                for ancestor in element.parents
+                if isinstance(ancestor, Tag) and ancestor.name in {"ul", "ol"}
+            ]
+            list_level = max(len(ancestors) - 1, 0)
+            list_type = (
+                "ordered" if ancestors and ancestors[0].name == "ol" else "unordered"
+            )
+            marker = "-" if list_type == "unordered" else str(position + 1)
+            blocks.append(
+                ContentBlock(
+                    type="list_item",
+                    text=text,
+                    level=list_level,
+                    metadata={
+                        "position": position,
+                        "list_type": list_type,
+                        "ordered": list_type == "ordered",
+                        "marker": marker,
+                    },
+                )
+            )
+        elif element.name == "table":
+            rows: list[list[str]] = []
+            for tr in element.find_all("tr"):
+                if not isinstance(tr, Tag):
+                    continue
+                cells = [
+                    cell.get_text(" ", strip=True)
+                    for cell in tr.find_all(["td", "th"])
+                    if isinstance(cell, Tag)
+                ]
+                if any(cells):
+                    rows.append(cells)
+            if rows:
+                table_text = "\n".join(" | ".join(row) for row in rows)
+                blocks.append(
+                    ContentBlock(
+                        type="table",
+                        text=table_text,
+                        metadata={"position": position, "rows": rows},
+                    )
+                )
+        else:
+            blocks.append(
+                ContentBlock(
+                    type="paragraph",
+                    text=text,
+                    metadata={"tag": element.name, "position": position},
+                )
+            )
+        position += 1
+    return blocks

--- a/ingest/types.py
+++ b/ingest/types.py
@@ -1,0 +1,158 @@
+"""Structured content helpers for ingestion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, List
+import re
+
+
+@dataclass(slots=True)
+class ContentBlock:
+    """Container describing a chunk of extracted content."""
+
+    type: str
+    """Semantic type of the block (paragraph, heading, list_item, table, ...)."""
+
+    text: str
+    """Primary text associated with the block."""
+
+    level: int | None = None
+    """Optional hierarchical level (e.g. heading depth or list indentation)."""
+
+    metadata: dict[str, Any] | None = None
+    """Additional metadata such as page numbers or table rows."""
+
+    def render(self) -> str:
+        """Return a normalized string representation for downstream joins."""
+
+        if not self.text:
+            return ""
+        if self.type == "list_item":
+            meta = self.metadata or {}
+            marker = meta.get("marker", "-")
+            ordered = bool(meta.get("ordered"))
+            separator = ". " if ordered and not str(marker).endswith(".") else " "
+            return f"{marker}{separator}{self.text}".strip()
+        return self.text
+
+
+@dataclass(slots=True)
+class StructuredDocument:
+    """Representation of extracted content with semantic blocks."""
+
+    text: str
+    blocks: list[ContentBlock]
+    source: str | None = None
+
+    def __bool__(self) -> bool:  # pragma: no cover - convenience
+        return bool(self.text)
+
+    def __str__(self) -> str:  # pragma: no cover - convenience
+        return self.text
+
+    @classmethod
+    def from_blocks(
+        cls, blocks: Iterable[ContentBlock], *, source: str | None = None
+    ) -> "StructuredDocument":
+        """Create a structured document from ``blocks``.
+
+        Empty blocks are filtered and the resulting text is joined with blank
+        lines to mimic the previous plain-text behaviour.
+        """
+
+        block_list = [block for block in blocks if block.text and block.text.strip()]
+        text_parts = [block.render() for block in block_list if block.render().strip()]
+        text = "\n\n".join(text_parts).strip()
+        return cls(text=text, blocks=block_list, source=source)
+
+
+_BULLET_RE = re.compile(r"^([*\u2022\-\u2013\u2023])\s+(.*)")
+_ORDERED_RE = re.compile(r"^(\d+)[.)]\s+(.*)")
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)")
+
+
+def _list_level_from_indent(line: str) -> int:
+    """Return list nesting level based on indentation."""
+
+    indent = len(line) - len(line.lstrip(" \t"))
+    # Treat every two spaces (or a tab) as one additional level
+    return max(indent // 2, 0)
+
+
+def _flush_paragraph(buffer: List[str], blocks: List[ContentBlock]) -> None:
+    if not buffer:
+        return
+    paragraph = "\n".join(buffer).strip()
+    if paragraph:
+        blocks.append(ContentBlock(type="paragraph", text=paragraph))
+    buffer.clear()
+
+
+def build_plain_text_document(
+    text: str, *, source: str | None = None
+) -> StructuredDocument:
+    """Convert raw ``text`` into a :class:`StructuredDocument`.
+
+    Bullet points, ordered lists and Markdown headings are detected and mapped
+    to dedicated block types so downstream consumers can preserve structure.
+    """
+
+    if not text:
+        return StructuredDocument(text="", blocks=[], source=source)
+
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    lines = normalized.splitlines()
+    blocks: list[ContentBlock] = []
+    buffer: list[str] = []
+
+    for raw_line in lines:
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            _flush_paragraph(buffer, blocks)
+            continue
+        heading_match = _HEADING_RE.match(stripped)
+        if heading_match:
+            _flush_paragraph(buffer, blocks)
+            marker, content = heading_match.groups()
+            blocks.append(
+                ContentBlock(
+                    type="heading",
+                    text=content.strip(),
+                    level=len(marker),
+                    metadata={"marker": marker},
+                )
+            )
+            continue
+        bullet_match = _BULLET_RE.match(stripped)
+        if bullet_match:
+            _flush_paragraph(buffer, blocks)
+            marker, content = bullet_match.groups()
+            blocks.append(
+                ContentBlock(
+                    type="list_item",
+                    text=content.strip(),
+                    level=_list_level_from_indent(line),
+                    metadata={"marker": marker, "ordered": False},
+                )
+            )
+            continue
+        ordered_match = _ORDERED_RE.match(stripped)
+        if ordered_match:
+            _flush_paragraph(buffer, blocks)
+            marker, content = ordered_match.groups()
+            blocks.append(
+                ContentBlock(
+                    type="list_item",
+                    text=content.strip(),
+                    level=_list_level_from_indent(line),
+                    metadata={"marker": marker, "ordered": True},
+                )
+            )
+            continue
+        buffer.append(stripped)
+
+    _flush_paragraph(buffer, blocks)
+
+    return StructuredDocument.from_blocks(blocks, source=source)

--- a/state/ensure_state.py
+++ b/state/ensure_state.py
@@ -22,6 +22,8 @@ def ensure_state() -> None:
         st.session_state[StateKeys.PROFILE] = NeedAnalysisProfile().model_dump()
     if StateKeys.RAW_TEXT not in st.session_state:
         st.session_state[StateKeys.RAW_TEXT] = ""
+    if StateKeys.RAW_BLOCKS not in st.session_state:
+        st.session_state[StateKeys.RAW_BLOCKS] = []
     if StateKeys.STEP not in st.session_state:
         st.session_state[StateKeys.STEP] = 0
     if StateKeys.EXTRACTION_SUMMARY not in st.session_state:

--- a/tests/ingest/test_structured_blocks.py
+++ b/tests/ingest/test_structured_blocks.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from docx import Document  # noqa: E402
+
+from ingest.extractors import extract_text_from_file  # noqa: E402
+from ingest.reader import clean_structured_document, read_job_text  # noqa: E402
+
+
+def test_extract_docx_table_blocks() -> None:
+    doc = Document()
+    doc.add_paragraph("Overview")
+    table = doc.add_table(rows=2, cols=2)
+    table.cell(0, 0).text = "Col A"
+    table.cell(0, 1).text = "Col B"
+    table.cell(1, 0).text = "Row 1"
+    table.cell(1, 1).text = "Row 2"
+    buf = io.BytesIO()
+    doc.save(buf)
+    buf.seek(0)
+    setattr(buf, "name", "sample.docx")
+
+    result = clean_structured_document(extract_text_from_file(buf))
+
+    table_blocks = [block for block in result.blocks if block.type == "table"]
+    assert table_blocks, "table block should be detected"
+    assert table_blocks[0].metadata and table_blocks[0].metadata["rows"][0] == [
+        "Col A",
+        "Col B",
+    ]
+
+
+def test_read_job_text_detects_bullets() -> None:
+    pasted = "- First item\n- Second item"
+    doc = read_job_text([], pasted=pasted)
+    list_items = [block for block in doc.blocks if block.type == "list_item"]
+    assert len(list_items) == 2
+    assert [item.text for item in list_items] == ["First item", "Second item"]

--- a/tests/test_cli_extract.py
+++ b/tests/test_cli_extract.py
@@ -3,6 +3,7 @@ import sys
 
 import pytest
 
+from ingest.types import StructuredDocument
 import cli.extract as cli_extract
 
 
@@ -14,9 +15,9 @@ def test_cli_uses_ingest_extractor(
 
     called: dict[str, bool] = {"used": False}
 
-    def fake_extract_text_from_file(_fh) -> str:
+    def fake_extract_text_from_file(_fh) -> StructuredDocument:
         called["used"] = True
-        return "TEXT"
+        return StructuredDocument(text="TEXT", blocks=[])
 
     def fake_extract_with_function(text: str, schema: dict, model=None):
         assert text == "TEXT"

--- a/tests/test_company_research.py
+++ b/tests/test_company_research.py
@@ -7,6 +7,7 @@ import contextlib
 import streamlit as st
 
 from constants.keys import StateKeys
+from ingest.types import build_plain_text_document
 from wizard import (
     _candidate_company_page_urls,
     _enrich_company_profile_from_about,
@@ -49,10 +50,10 @@ def test_fetch_company_page_tries_candidates(monkeypatch) -> None:
 
     calls: list[str] = []
 
-    def fake_extract(url: str) -> str:
+    def fake_extract(url: str):
         calls.append(url)
         if url.endswith("ueber-uns"):
-            return "Über uns"
+            return build_plain_text_document("Über uns", source=url)
         raise ValueError("missing")
 
     monkeypatch.setattr("wizard.extract_text_from_url", fake_extract)
@@ -77,7 +78,10 @@ def test_load_company_page_section_updates_state(monkeypatch) -> None:
     st.session_state[StateKeys.COMPANY_PAGE_BASE] = ""
     st.session_state["lang"] = "de"
 
-    monkeypatch.setattr("wizard.extract_text_from_url", lambda url: "Inhalt")
+    monkeypatch.setattr(
+        "wizard.extract_text_from_url",
+        lambda url: build_plain_text_document("Inhalt", source=url),
+    )
     monkeypatch.setattr(
         "wizard.summarize_company_page",
         lambda text, label, lang="de": f"{label} :: {lang}",

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -11,14 +11,16 @@ from ingest.extractors import extract_text_from_file
 def test_extract_txt() -> None:
     f = io.BytesIO(b"Hello")
     f.name = "a.txt"
-    assert extract_text_from_file(f) == "Hello"
+    result = extract_text_from_file(f)
+    assert result.text == "Hello"
 
 
 def test_extract_txt_encoding_and_normalization() -> None:
     data = "Hällo\r\nWorld  ".encode("latin-1")
     f = io.BytesIO(data)
     f.name = "b.txt"
-    assert extract_text_from_file(f) == "Hällo\nWorld"
+    result = extract_text_from_file(f)
+    assert result.text == "Hällo\nWorld"
 
 
 def _blank_pdf() -> io.BytesIO:
@@ -37,7 +39,7 @@ def test_extract_pdf_with_ocr(monkeypatch) -> None:
     pytesseract = types.SimpleNamespace(image_to_string=lambda img: "OCR TEXT")
     monkeypatch.setitem(sys.modules, "pdf2image", pdf2image)
     monkeypatch.setitem(sys.modules, "pytesseract", pytesseract)
-    assert extract_text_from_file(f) == "OCR TEXT"
+    assert extract_text_from_file(f).text == "OCR TEXT"
 
 
 def test_extract_empty_file() -> None:

--- a/tests/test_extractors_url.py
+++ b/tests/test_extractors_url.py
@@ -26,8 +26,9 @@ def test_extract_text_from_url_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("ingest.extractors.requests.get", fake_get)
     monkeypatch.setitem(sys.modules, "trafilatura", fake_traf)
 
-    text = extract_text_from_url("http://example.com")
-    assert text == "Hello\n\nWorld"
+    doc = extract_text_from_url("http://example.com")
+    assert doc.text == "Hello URL"
+    assert doc.blocks and doc.blocks[0].type == "paragraph"
 
 
 def test_extract_text_from_url_http_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_ingest_reader.py
+++ b/tests/test_ingest_reader.py
@@ -5,7 +5,7 @@ def test_read_job_text_merges_and_cleans(tmp_path):
     txt = tmp_path / "a.txt"
     txt.write_text("Hello   world\n")
     result = read_job_text([str(txt)], pasted="Hello world")
-    assert result == "Hello world"
+    assert result.text == "Hello world"
 
 
 def test_clean_job_text_removes_boilerplate():


### PR DESCRIPTION
## Summary
- extend ingest extractors to build structured ContentBlock data for DOCX, PDF and HTML sources
- add StructuredDocument helpers and update the reader, CLI and wizard to propagate structured blocks through the flow
- expand ingest-related tests to cover DOCX tables, list handling and wizard/company page interactions

## Testing
- `ruff check`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc44b496b483209ca054ebe2a238a1