### PR TITLE
fix: restore final step outputs

### DIFF
--- a/constants/keys.py
+++ b/constants/keys.py
@@ -16,6 +16,8 @@ class UIKeys:
     TONE_SELECT = "ui.summary.tone"
     NUM_QUESTIONS = "ui.summary.num_questions"
     AUDIENCE_SELECT = "ui.summary.audience"
+    JOB_AD_OUTPUT = "ui.summary.job_ad_output"
+    INTERVIEW_OUTPUT = "ui.summary.interview_output"
     JOB_AD_FIELD_PREFIX = "ui.job_ad.field."
     JOB_AD_STEP_SELECT = "ui.job_ad.step_select"
     JOB_AD_STEP_FIELD_PREFIX = "ui.job_ad.step_field."

--- a/wizard.py
+++ b/wizard.py
@@ -4947,11 +4947,16 @@ def _step_summary(schema: dict, _critical: list[str]):
 
         job_ad_text = st.session_state.get(StateKeys.JOB_AD_MD, "")
         if job_ad_text:
+            output_key = UIKeys.JOB_AD_OUTPUT
+            if (
+                output_key not in st.session_state
+                or st.session_state.get(output_key) != job_ad_text
+            ):
+                st.session_state[output_key] = job_ad_text
             st.text_area(
                 tr("Generierte Stellenanzeige", "Generated job ad"),
-                value=job_ad_text,
                 height=_textarea_height(job_ad_text),
-                key="job_ad_output",
+                key=output_key,
             )
 
             seo_data = seo_optimize(job_ad_text)
@@ -5101,11 +5106,16 @@ def _step_summary(schema: dict, _critical: list[str]):
 
         guide_text = st.session_state.get(StateKeys.INTERVIEW_GUIDE_MD, "")
         if guide_text:
+            output_key = UIKeys.INTERVIEW_OUTPUT
+            if (
+                output_key not in st.session_state
+                or st.session_state.get(output_key) != guide_text
+            ):
+                st.session_state[output_key] = guide_text
             st.text_area(
                 tr("Generierter Leitfaden", "Generated guide"),
-                value=guide_text,
                 height=_textarea_height(guide_text),
-                key="interview_output",
+                key=output_key,
             )
             guide_format = st.session_state.get(UIKeys.JOB_AD_FORMAT, "docx")
             font_choice = st.session_state.get(StateKeys.JOB_AD_FONT_CHOICE)


### PR DESCRIPTION
## Summary
- ensure the generated job ad text area reflects the latest session state value
- keep the interview guide text area in sync with freshly generated content
- add dedicated UI keys for the generated document widgets

## Testing
- ruff check wizard.py constants/keys.py
- black wizard.py constants/keys.py
- mypy wizard.py --follow-imports=skip --ignore-missing-imports
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccf526232c83209134561be291d648