### PR TITLE
Ensure company info schema required keys and add regression test

### DIFF
--- a/openai_utils/extraction.py
+++ b/openai_utils/extraction.py
@@ -38,6 +38,7 @@ def extract_company_info(text: str, model: str | None = None) -> dict:
         model = get_model_for(ModelTask.COMPANY_INFO)
 
     expected_fields = ("name", "location", "mission", "culture")
+    properties = {field: {"type": "string"} for field in expected_fields}
 
     prompt = (
         "Analyze the following company website text and extract: the official "
@@ -57,10 +58,8 @@ def extract_company_info(text: str, model: str | None = None) -> dict:
                 "name": "company_info",
                 "schema": {
                     "type": "object",
-                    "properties": {
-                        field: {"type": "string"} for field in expected_fields
-                    },
-                    "required": list(expected_fields),
+                    "properties": properties,
+                    "required": list(properties.keys()),
                     "additionalProperties": False,
                 },
             },

--- a/tests/test_extract_company_info.py
+++ b/tests/test_extract_company_info.py
@@ -29,3 +29,39 @@ def test_extract_company_info_parses_json(monkeypatch):
         "mission": "Make widgets greener",
         "culture": "Collaborative and inclusive",
     }
+
+
+def test_extract_company_info_required_keys(monkeypatch):
+    """Ensure all expected fields are marked as required in the schema."""
+
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_call_chat_api(messages, **kwargs):
+        captured_kwargs.update(kwargs)
+        payload = json.dumps(
+            {
+                "name": "Acme Corp",
+                "location": "Berlin, Germany",
+                "mission": "Make widgets greener",
+                "culture": "Collaborative and inclusive",
+            }
+        )
+        return ChatCallResult(payload, [], {})
+
+    monkeypatch.setattr(openai_utils.api, "call_chat_api", fake_call_chat_api)
+
+    openai_utils.extract_company_info("dummy text")
+
+    json_schema = captured_kwargs.get("json_schema")
+    assert isinstance(json_schema, dict)
+    schema = json_schema.get("schema")
+    assert isinstance(schema, dict)
+    properties = schema.get("properties")
+    assert isinstance(properties, dict)
+    required = schema.get("required")
+    assert required == list(properties.keys()) == [
+        "name",
+        "location",
+        "mission",
+        "culture",
+    ]


### PR DESCRIPTION
## Summary
- build the company info extraction schema properties once and derive the required list from those keys
- add a regression test to ensure the schema marks all four company info fields as required

## Testing
- PYTHONPATH=. pytest tests/test_extract_company_info.py

------
https://chatgpt.com/codex/tasks/task_e_68ccf96350c48320a4670e070d0808b9