### PR TITLE
fix: adjust rag pipeline client import

### DIFF
--- a/llm/rag_pipeline.py
+++ b/llm/rag_pipeline.py
@@ -9,7 +9,7 @@ from typing import Any, Iterable, Mapping, MutableMapping, Sequence
 from config import VECTOR_STORE_ID, ModelTask, get_model_for
 from openai import OpenAIError
 
-from openai_utils import get_client
+from openai_utils.api import get_client
 
 
 logger = logging.getLogger("cognitive_needs.rag")


### PR DESCRIPTION
## Summary
- update the RAG pipeline to import the OpenAI client from the api module

## Testing
- streamlit run app.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccfb2f2a9083209bf46a0ffdb73da6