### PR TITLE
fix: normalize summary profile updates

### DIFF
--- a/tests/test_summary_update.py
+++ b/tests/test_summary_update.py
@@ -20,3 +20,18 @@ def test_update_profile_clears_generated() -> None:
     assert StateKeys.JOB_AD_MD not in st.session_state
     assert StateKeys.BOOLEAN_STR not in st.session_state
     assert StateKeys.INTERVIEW_GUIDE_MD not in st.session_state
+
+
+def test_update_profile_ignores_semantic_empty() -> None:
+    """Setting empty values keeps cached outputs intact."""
+
+    st.session_state.clear()
+    st.session_state[StateKeys.PROFILE] = {"company": {"brand_keywords": None}}
+    st.session_state[StateKeys.JOB_AD_MD] = "cached"
+
+    _update_profile("company.brand_keywords", "")
+
+    assert (
+        st.session_state[StateKeys.PROFILE]["company"]["brand_keywords"] is None
+    )
+    assert st.session_state[StateKeys.JOB_AD_MD] == "cached"


### PR DESCRIPTION
## Summary
- normalize semantically empty values before applying profile updates so cached outputs only clear on real changes
- sanitize the summary brand keyword input to avoid empty submissions triggering updates
- add a regression test covering transitions from `None` to empty strings without clearing the job ad cache

## Testing
- PYTHONPATH=. pytest tests/test_summary_update.py
- ruff check wizard.py tests/test_summary_update.py

------
https://chatgpt.com/codex/tasks/task_e_68cd281e006083208c13a9d924ba786d