### PR TITLE
Disable ESCO integration and hide wizard hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cognitive Needs — AI Recruitment Need Analysis (Streamlit)
 
-**Cognitive Needs** turns messy job ads into a **complete, structured profile**, then asks only the *minimal* follow‑ups. It enriches with **ESCO** (skills/occupations) and your **OpenAI Vector Store** to propose **missing skills, benefits, tools, and tasks**. Finally, it generates a polished **job ad**, **interview guide**, and **boolean search string**.
+**Cognitive Needs** turns messy job ads into a **complete, structured profile**, then asks only the *minimal* follow‑ups. It integrates with your **OpenAI Vector Store** to propose **missing skills, benefits, tools, and tasks**. ESCO-based occupation and skill enrichment is currently disabled and hidden in the wizard. Finally, the app generates a polished **job ad**, **interview guide**, and **boolean search string**.
 
 Cognitive Needs routes tasks across OpenAI’s GPT‑5 family to balance quality
 and cost. `gpt-5-mini` powers extraction, document generation and other
@@ -27,18 +27,14 @@ the base model if needed.
 - **Instant overview**: review extracted fields in a compact tabbed table before continuing
 - **API helper**: `call_chat_api` wraps the OpenAI Responses API with tool and JSON schema support, automatically executing mapped tools and returning a unified `ChatCallResult`
 - **Analysis tools**: built-in `get_salary_benchmark` and `get_skill_definition` functions can be invoked by the model for richer need analysis
-- **Smart follow‑ups**: priority-based questions enriched with ESCO & RAG that dynamically cap the number of questions by field importance (now up to 12 by default), shown inline in relevant steps. Required fields are consistently marked with a red asterisk.
+- **Smart follow‑ups**: priority-based questions that leverage RAG suggestions and dynamically cap the number of questions by field importance (now up to 12 by default), shown inline in relevant steps. Required fields are consistently marked with a red asterisk.
 - **Persistent follow-up tracking**: answered or skipped questions are remembered and won't reappear when navigating back through the wizard.
 - **Follow-up suggestion chips**: if the assistant proposes possible answers, they appear as one-click chips above the input field.
 - **AI-powered benefit suggestions**: fetch common perks for the role/industry and add them to the profile with a single click.
 - **Auto re‑ask loop**: optional toggle that keeps asking follow-up questions automatically until all critical fields are filled, with clear progress messages and a stop button for user control.
 - **Token usage tracker**: displays input/output token counts in the summary step.
 - **Reasoning effort control**: select low, medium, or high reasoning depth with an environment-variable default.
-- **Role-aware extras**: automatically adds occupation-specific questions (e.g., programming languages for developers, campaign types for marketers, board certification for doctors, grade levels for teachers, design tools for designers, shift schedules for nurses, project management methodologies for project managers, machine learning frameworks for data scientists, accounting software for financial analysts, HR software for human resource professionals, engineering tools for civil engineers, cuisine specialties for chefs).
-- **ESCO‑Power**: occupation classification + essential skill gaps
-- **Offline-ready ESCO**: set `VACAYSER_OFFLINE=1` to use cached occupations and skills without API calls; data comes from `integrations/esco_offline.json` and covers common roles. Unknown titles log a warning and skip enrichment—update the JSON or unset the env var to fall back to the live ESCO API
-- **Cached ESCO calls**: Streamlit caching avoids repeated API requests
-- **Auto-filled skills**: essential ESCO skills merge into required skills; generic entries like "Communication" are ignored so follow-ups stay relevant
+- **ESCO features disabled**: occupation classification, essential skill enrichment, and role-specific prompts are currently turned off and hidden in the wizard.
 - **RAG‑Assist**: use your vector store to fill/contextualize *(requires setting `VECTOR_STORE_ID` and a populated vector store)*
 - **Model routing**: automatically dispatches calls to `gpt-5-mini` for
   extraction, job ads, interview guides and refinements, and to `gpt-5-nano`
@@ -173,8 +169,8 @@ OPENAI_MODEL = "gpt-5-mini"
 
 Other environment flags:
 
-- `VACAYSER_OFFLINE=1` – use cached ESCO data from `integrations/esco_offline.json`
-  to run without internet access to the ESCO API.
+- `VACAYSER_OFFLINE` – legacy flag with no effect because ESCO integration is
+  currently disabled.
 - `VECTOR_STORE_ID=vs_…` – enable OpenAI File Search for RAG (leave unset to
   disable).
 

--- a/core/esco_utils.py
+++ b/core/esco_utils.py
@@ -1,225 +1,74 @@
-"""Helpers for interacting with the ESCO taxonomy.
+"""Legacy ESCO helpers now operating in offline-only mode.
 
-The helpers include lightweight caching and backoff-enabled HTTP
-requests for resilience. They provide occupation classification,
-essential skill lookup and skill normalization utilities.
+All ESCO-related functionality has been disabled. The public helper
+functions remain to avoid cascading import errors, but they now return
+empty results and perform simple normalization locally without performing
+any HTTP requests.
 """
 
 from __future__ import annotations
 
 import logging
-import re
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
-from difflib import SequenceMatcher
-
-import backoff
-import requests
-import streamlit as st
-
-_ESO = "https://ec.europa.eu/esco/api"
-_HEADERS = {"User-Agent": "CognitiveNeeds/1.0"}
 log = logging.getLogger("cognitive_needs.esco")
 
-_SKILL_CACHE: Dict[Tuple[str, str], Dict[str, str]] = {}
-_GROUP_CACHE: Dict[Tuple[str | None, str], str] = {}
 
-
-def _norm(s: str) -> str:
-    """Normalize whitespace and lowercase a string."""
-
-    return re.sub(r"\s+", " ", (s or "")).strip().lower()
-
-
-@backoff.on_exception(backoff.expo, requests.RequestException, max_time=60)
-def _get(path: str, **params) -> dict:
-    """Perform a GET request against the ESCO API."""
-
-    url = path if path.startswith("http") else f"{_ESO}/{path.lstrip('/')}"
-    resp = requests.get(url, params=params, timeout=20, headers=_HEADERS)
-    try:  # pragma: no cover - network failures/mocks without method
-        resp.raise_for_status()
-    except AttributeError:
-        pass
-    return resp.json()
-
-
-def _preferred_label(item: dict, lang: str) -> str:
-    """Return the preferred label of an ESCO item for ``lang``."""
-
-    label = item.get("preferredLabel") or item.get("label") or ""
-    if isinstance(label, dict):
-        return label.get(lang, "") or next(iter(label.values()), "")
-    return str(label)
-
-
-def _group_label(group_uri: str | None, lang: str) -> str:
-    """Resolve the human-readable label of an ISCO group."""
-
-    if not group_uri:
-        return ""
-    cache_key = (group_uri, lang)
-    if cache_key in _GROUP_CACHE:
-        return _GROUP_CACHE[cache_key]
-    try:
-        grp = _get("resource", uri=group_uri, language=lang)
-    except requests.RequestException as exc:  # pragma: no cover - network
-        log.warning("ESCO group lookup failed: %s", exc)
-        return ""
-    label = grp.get("title") or grp.get("preferredLabel") or grp.get("label") or ""
-    if isinstance(label, dict):
-        value = label.get(lang, "") or next(iter(label.values()), "")
-    else:
-        value = str(label)
-    value = value.strip()
-    _GROUP_CACHE[cache_key] = value
-    return value
-
-
-def _score_occupation(query_norm: str, item: dict, lang: str) -> float:
-    """Compute similarity score between query and occupation label."""
-
-    label = _norm(_preferred_label(item, lang))
-    score = SequenceMatcher(None, query_norm, label).ratio()
-    if query_norm in label:
-        score += 0.1
-    if query_norm == label:
-        score += 0.1
-    return score
-
-
-def _prepare_occupation_result(item: dict, lang: str) -> Dict[str, str]:
-    """Convert an ESCO search item into a compact dict."""
-
-    group_uri = (item.get("broaderIscoGroup") or [None])[0]
-    uri = item.get("uri") or item.get("_links", {}).get("self", {}).get("href")
-    return {
-        "preferredLabel": _preferred_label(item, lang).strip(),
-        "uri": uri,
-        "group": _group_label(group_uri, lang),
-    }
-
-
-@st.cache_data(show_spinner=False, max_entries=2048)
 def classify_occupation(title: str, lang: str = "en") -> Optional[Dict[str, str]]:
-    """Return best matching ESCO occupation for a job title."""
+    """Return ``None`` because ESCO classification has been disabled."""
 
-    if not title:
-        return None
-    try:
-        data = _get("search", text=title, type="occupation", language=lang)
-    except requests.RequestException as exc:  # pragma: no cover - network
-        log.warning("ESCO classify failed: %s", exc)
-        return None
-    items = data.get("_embedded", {}).get("results", []) or []
-    if not items and lang != "en":
-        return classify_occupation(title, "en")
-    if not items:
-        return None
-    query_norm = _norm(title)
-    best = max(items, key=lambda it: _score_occupation(query_norm, it, lang))
-    return _prepare_occupation_result(best, lang)
+    if title:
+        log.info("Skipping ESCO occupation classification for title '%s'", title)
+    return None
 
 
-@st.cache_data(show_spinner=False, max_entries=2048)
 def search_occupations(
     title: str,
     lang: str = "en",
     limit: int = 5,
 ) -> List[Dict[str, str]]:
-    """Return a ranked list of ESCO occupations for ``title``."""
+    """Return an empty list because ESCO lookups are disabled."""
 
-    if not title:
-        return []
-    try:
-        data = _get("search", text=title, type="occupation", language=lang)
-    except requests.RequestException as exc:  # pragma: no cover - network
-        log.warning("ESCO occupation search failed: %s", exc)
-        return []
-    items = data.get("_embedded", {}).get("results", []) or []
-    if not items and lang != "en":
-        return search_occupations(title, "en", limit=limit)
-    if not items:
-        return []
-    query_norm = _norm(title)
-    ranked = sorted(
-        items,
-        key=lambda it: _score_occupation(query_norm, it, lang),
-        reverse=True,
-    )
-    trimmed = ranked[: max(limit, 1)]
-    return [_prepare_occupation_result(item, lang) for item in trimmed]
+    if title:
+        log.info("Skipping ESCO occupation search for title '%s'", title)
+    return []
 
 
-@st.cache_data(show_spinner=False, max_entries=4096)
 def get_essential_skills(occupation_uri: str, lang: str = "en") -> List[str]:
-    """Return essential skill labels for a given occupation.
+    """Return an empty list because ESCO skill lookup is disabled."""
 
-    Args:
-        occupation_uri: ESCO URI of the occupation.
-        lang: Two-letter language code.
-
-    Returns:
-        Alphabetically sorted list of unique skill labels.
-    """
-
-    if not occupation_uri:
-        return []
-
-    try:
-        res = _get("resource", uri=occupation_uri, language=lang)
-    except requests.RequestException as exc:  # pragma: no cover - network
-        log.warning("ESCO essential skills failed: %s", exc)
-        return []
-    skills: List[str] = []
-    rels = (res.get("_links", {}) or {}).get("hasEssentialSkill", [])
-    for rel in rels:
-        lab = rel.get("title") or rel.get("preferredLabel") or ""
-        if isinstance(lab, dict):
-            lab = lab.get(lang, "") or next(iter(lab.values()), "")
-        label = str(lab).strip()
-        if label:
-            skills.append(label)
-
-    return sorted(set(skills))
+    if occupation_uri:
+        log.info(
+            "Skipping ESCO essential skill lookup for occupation '%s'", occupation_uri
+        )
+    return []
 
 
 def lookup_esco_skill(name: str, lang: str = "en") -> Dict[str, str]:
-    """Lookup a skill and return its ESCO metadata.
+    """Return an empty mapping because ESCO skill lookup is disabled."""
 
-    Results are cached in-memory to avoid repeated HTTP requests within a
-    process. Keys are normalized by lowercasing and collapsing whitespace.
-    """
-
-    if not name:
-        return {}
-    key = (_norm(name), lang)
-    if key in _SKILL_CACHE:
-        return _SKILL_CACHE[key]
-    try:
-        data = _get("search", text=name, type="skill", language=lang)
-    except requests.RequestException as exc:  # pragma: no cover - network
-        log.warning("ESCO lookup failed: %s", exc)
-        return {}
-    items = data.get("_embedded", {}).get("results", []) or []
-    res = items[0] if items else {}
-    _SKILL_CACHE[key] = res
-    return res
+    if name:
+        log.debug("Skipping ESCO skill lookup for '%s'", name)
+    return {}
 
 
 def normalize_skills(skills: List[str], lang: str = "en") -> List[str]:
-    """Normalize skill labels using ESCO preferred labels and dedupe."""
+    """Normalize skill labels locally without ESCO requests.
 
+    Args:
+        skills: Raw skill labels supplied by the user or extraction pipeline.
+        lang: Unused language hint retained for backwards compatibility.
+
+    Returns:
+        A list of trimmed, case-insensitive unique skill labels.
+    """
+
+    deduped: List[str] = []
     seen: set[str] = set()
-    out: List[str] = []
     for skill in skills:
-        if not skill:
-            continue
-        info = lookup_esco_skill(skill, lang=lang)
-        label = info.get("preferredLabel") or skill.strip()
-        label = label.strip()
-        key = label.lower()
+        label = str(skill or "").strip()
+        key = label.casefold()
         if label and key not in seen:
             seen.add(key)
-            out.append(label)
-    return out
+            deduped.append(label)
+    return deduped

--- a/integrations/esco.py
+++ b/integrations/esco.py
@@ -1,91 +1,36 @@
-"""ESCO integration wrapper with offline fallbacks."""
+"""Disabled ESCO integration wrapper."""
 
 from __future__ import annotations
 
-import json
 import logging
-import os
-from pathlib import Path
 from typing import Dict, List
-
-from core import esco_utils
 
 log = logging.getLogger("cognitive_needs.esco")
 
-# Environment flag intentionally named ``VACAYSER_OFFLINE`` (without an ``l``)
-# to match historical "Vacayser" naming used in earlier deployments.
-OFFLINE = bool(os.getenv("VACAYSER_OFFLINE", False))
 
-_OFFLINE_OCCUPATIONS: Dict[str, Dict[str, str]] = {}
-_OFFLINE_SKILLS: Dict[str, List[str]] = {}
+def search_occupation(title: str, lang: str = "en") -> Dict[str, str]:
+    """Return an empty mapping because ESCO features are disabled."""
 
-if OFFLINE:
-    data_file = Path(__file__).with_name("esco_offline.json")
-    try:
-        with data_file.open("r", encoding="utf-8") as fh:
-            data = json.load(fh)
-            _OFFLINE_OCCUPATIONS = {
-                k.lower(): v for k, v in data.get("occupations", {}).items()
-            }
-            _OFFLINE_SKILLS = data.get("skills", {})
-    except FileNotFoundError:
-        log.warning("Offline ESCO data file missing: %s", data_file)
-
-GENERIC_SKILLS = {"communication"}
-
-
-def search_occupation(title: str, lang: str = "en") -> dict[str, str]:
-    """Search ESCO occupation by title.
-
-    Args:
-        title: Job title to classify.
-        lang: Two-letter language code.
-
-    Returns:
-        Mapping with occupation metadata. Empty if not found.
-    """
-    if not title:
-        return {}
-    if OFFLINE:
-        title_key = title.strip().lower()
-        data = _OFFLINE_OCCUPATIONS.get(title_key) or {}
-        if not data:
-            log.warning("No offline ESCO match for '%s'", title)
-        return data
-    # Online mode: call actual ESCO API
-    return esco_utils.classify_occupation(title, lang) or {}
+    if title:
+        log.info("Skipping ESCO occupation lookup for '%s'", title)
+    return {}
 
 
 def search_occupation_options(
-    title: str, lang: str = "en", limit: int = 5
-) -> list[dict[str, str]]:
-    """Return multiple ESCO occupation candidates for a title."""
+    title: str,
+    lang: str = "en",
+    limit: int = 5,
+) -> List[Dict[str, str]]:
+    """Return an empty list of occupation options."""
 
-    if not title:
-        return []
-    if OFFLINE:
-        title_key = title.strip().lower()
-        match = _OFFLINE_OCCUPATIONS.get(title_key)
-        return [match] if match else []
-    return esco_utils.search_occupations(title, lang=lang, limit=limit) or []
+    if title:
+        log.info("Skipping ESCO occupation options lookup for '%s'", title)
+    return []
 
 
-def enrich_skills(occupation_uri: str, lang: str = "en") -> list[str]:
-    """Retrieve essential skills for an occupation.
+def enrich_skills(occupation_uri: str, lang: str = "en") -> List[str]:
+    """Return an empty list because ESCO enrichment is disabled."""
 
-    Args:
-        occupation_uri: ESCO URI of the occupation.
-        lang: Two-letter language code.
-
-    Returns:
-        List of essential skill labels.
-    """
-    if not occupation_uri:
-        return []
-    if OFFLINE:
-        skills = _OFFLINE_SKILLS.get(occupation_uri, [])
-        if not skills:
-            log.warning("No offline ESCO skills for '%s'", occupation_uri)
-    else:
-        skills = esco_utils.get_essential_skills(occupation_uri, lang)
-    return [s for s in skills if s.lower() not in GENERIC_SKILLS]
+    if occupation_uri:
+        log.info("Skipping ESCO skill enrichment for occupation '%s'", occupation_uri)
+    return []

--- a/openai_utils/extraction.py
+++ b/openai_utils/extraction.py
@@ -369,7 +369,7 @@ def suggest_additional_skills(
                 tech_skills.append(skill)
             else:
                 soft_skills.append(skill)
-    # Normalize skill labels via ESCO and drop duplicates against existing skills
+    # Normalize skill labels locally and drop duplicates against existing skills
     try:
         from core.esco_utils import normalize_skills
 
@@ -484,7 +484,7 @@ def suggest_skills_for_role(
     hard = _clean(data.get("hard_skills"))
     soft = _clean(data.get("soft_skills"))
 
-    try:  # Normalize via ESCO
+    try:  # Normalize skill labels locally
         from core.esco_utils import normalize_skills
 
         tools = normalize_skills(tools, lang=lang)

--- a/tests/test_esco_features.py
+++ b/tests/test_esco_features.py
@@ -1,60 +1,18 @@
-import os
-import sys
+"""Integration-level expectations for disabled ESCO features."""
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
-from core.esco_utils import classify_occupation, normalize_skills  # noqa: E402
+from core.esco_utils import normalize_skills
+from integrations import esco
 
 
-def test_classify_occupation(monkeypatch):
-    """Should return label, code and group from ESCO."""
+def test_search_occupation_returns_empty() -> None:
+    """Occupation search should return an empty mapping."""
 
-    def fake_get(url, params=None, timeout=5, headers=None):
-        class Resp:
-            status_code = 200
-
-            def __init__(self, data):
-                self._data = data
-
-            def json(self):
-                return self._data
-
-        if "search" in url:
-            data = {
-                "_embedded": {
-                    "results": [
-                        {
-                            "preferredLabel": {"en": "software developer"},
-                            "broaderIscoGroup": [
-                                "http://data.europa.eu/esco/isco/C2512"
-                            ],
-                            "uri": "http://example.com/occ",
-                        }
-                    ]
-                }
-            }
-            return Resp(data)
-        return Resp({"title": "Software developers"})
-
-    monkeypatch.setattr("core.esco_utils.requests.get", fake_get)
-    res = classify_occupation("Software engineer")
-    assert res == {
-        "preferredLabel": "software developer",
-        "group": "Software developers",
-        "uri": "http://example.com/occ",
-    }
+    assert esco.search_occupation("Engineer") == {}
+    assert esco.search_occupation_options("Engineer") == []
 
 
-def test_normalize_skills(monkeypatch):
-    """Skills are normalized to preferred labels and deduped."""
+def test_normalize_skills_dedupes_without_esco() -> None:
+    """Normalization should work locally without ESCO lookups."""
 
-    def fake_lookup(name, lang="en"):
-        mapping = {
-            "python": {"preferredLabel": "Python"},
-            "management": {"preferredLabel": "Project management"},
-        }
-        return mapping.get(name.lower(), {})
-
-    monkeypatch.setattr("core.esco_utils.lookup_esco_skill", fake_lookup)
-    out = normalize_skills(["Python", "python", "Management"])
-    assert out == ["Python", "Project management"]
+    out = normalize_skills(["Python", "python", "Management", ""])
+    assert out == ["Python", "Management"]

--- a/tests/test_esco_integration.py
+++ b/tests/test_esco_integration.py
@@ -1,90 +1,20 @@
-"""Tests for ESCO integration wrapper with offline support."""
+"""Tests for the disabled ESCO integration wrapper."""
 
-import importlib
-
-
-def test_offline_fallback(monkeypatch):
-    """search_occupation and enrich_skills use offline JSON when enabled."""
-    monkeypatch.setenv("VACAYSER_OFFLINE", "1")
-    module = importlib.import_module("integrations.esco")
-    importlib.reload(module)
-    occ = module.search_occupation("Software Engineer")
-    assert occ["uri"] == "http://data.europa.eu/esco/occupation/12345"
-    skills = module.enrich_skills(occ["uri"])
-    assert "Python" in skills
+from integrations import esco
 
 
-def test_offline_generic_skills_filtered(monkeypatch):
-    """Generic skills like 'Communication' are filtered out."""
-    monkeypatch.setenv("VACAYSER_OFFLINE", "1")
-    module = importlib.import_module("integrations.esco")
-    importlib.reload(module)
-    occ = module.search_occupation("Sales Representative")
-    skills = module.enrich_skills(occ["uri"])
-    assert "Communication" not in skills
+def test_search_returns_empty_results() -> None:
+    """Search helpers should return empty data structures."""
+
+    assert esco.search_occupation("Software Engineer") == {}
+    assert esco.search_occupation_options("Software Engineer") == []
 
 
-def test_offline_unknown_title(monkeypatch):
-    """Unknown titles return empty dict and no crash."""
-    monkeypatch.setenv("VACAYSER_OFFLINE", "1")
-    module = importlib.import_module("integrations.esco")
-    importlib.reload(module)
-    occ = module.search_occupation("Unknown Role")
-    assert occ == {}
+def test_enrich_skills_returns_empty(caplog) -> None:
+    """Skill enrichment should be disabled."""
 
-
-def test_offline_options(monkeypatch):
-    """Offline occupation option search returns at most one cached entry."""
-    monkeypatch.setenv("VACAYSER_OFFLINE", "1")
-    module = importlib.import_module("integrations.esco")
-    importlib.reload(module)
-    opts = module.search_occupation_options("Software Engineer")
-    assert isinstance(opts, list)
-    assert opts and opts[0]["uri"].startswith("http://data.europa.eu/esco/occupation/")
-
-
-def test_offline_missing_skills_warning(monkeypatch, caplog):
-    """Missing offline skills trigger a warning and return empty list."""
-    monkeypatch.setenv("VACAYSER_OFFLINE", "1")
-    module = importlib.import_module("integrations.esco")
-    importlib.reload(module)
-    with caplog.at_level("WARNING"):
-        skills = module.enrich_skills("unknown-uri")
-    assert skills == []
-    assert any("No offline ESCO skills" in r.message for r in caplog.records)
-
-
-def test_online_delegation(monkeypatch):
-    """Wrapper delegates to core.esco_utils when not offline."""
-    monkeypatch.delenv("VACAYSER_OFFLINE", raising=False)
-    module = importlib.import_module("integrations.esco")
-    importlib.reload(module)
-
-    calls = {}
-
-    def fake_classify(title: str, lang: str = "en") -> dict:
-        calls["classify"] = (title, lang)
-        return {"uri": "x"}
-
-    def fake_skills(uri: str, lang: str = "en") -> list[str]:
-        calls["skills"] = (uri, lang)
-        return ["A"]
-
-    def fake_options(title: str, lang: str = "en", limit: int = 5) -> list[dict]:
-        calls["options"] = (title, lang, limit)
-        return [{"uri": "y", "preferredLabel": "Dev", "group": "IT"}]
-
-    monkeypatch.setattr(module.esco_utils, "classify_occupation", fake_classify)
-    monkeypatch.setattr(module.esco_utils, "get_essential_skills", fake_skills)
-    monkeypatch.setattr(module.esco_utils, "search_occupations", fake_options)
-
-    occ = module.search_occupation("Dev", "de")
-    skills = module.enrich_skills("u", "de")
-    opts = module.search_occupation_options("Dev", "de", limit=7)
-
-    assert calls["classify"] == ("Dev", "de")
-    assert calls["skills"] == ("u", "de")
-    assert calls["options"] == ("Dev", "de", 7)
-    assert occ == {"uri": "x"}
-    assert skills == ["A"]
-    assert opts == [{"uri": "y", "preferredLabel": "Dev", "group": "IT"}]
+    with caplog.at_level("INFO"):
+        assert esco.enrich_skills("http://example.com/occ") == []
+        assert any(
+            "Skipping ESCO skill enrichment" in r.message for r in caplog.records
+        )

--- a/tests/test_summary_update.py
+++ b/tests/test_summary_update.py
@@ -31,7 +31,5 @@ def test_update_profile_ignores_semantic_empty() -> None:
 
     _update_profile("company.brand_keywords", "")
 
-    assert (
-        st.session_state[StateKeys.PROFILE]["company"]["brand_keywords"] is None
-    )
+    assert st.session_state[StateKeys.PROFILE]["company"]["brand_keywords"] is None
     assert st.session_state[StateKeys.JOB_AD_MD] == "cached"

--- a/tests/test_wizard_skip_and_reask.py
+++ b/tests/test_wizard_skip_and_reask.py
@@ -78,8 +78,6 @@ def test_extract_and_summarize_auto_reask(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr("wizard.extract_json", fake_extract)
     monkeypatch.setattr("wizard.coerce_and_fill", fake_coerce)
     monkeypatch.setattr("wizard.apply_basic_fallbacks", lambda p, t: p)
-    monkeypatch.setattr("wizard.search_occupation", lambda t, lang: None)
-    monkeypatch.setattr("wizard.enrich_skills", lambda u, lang: [])
     monkeypatch.setattr("wizard.ask_followups", fake_followups)
     monkeypatch.setattr(st, "spinner", lambda *a, **k: _DummySpinner())
 


### PR DESCRIPTION
## Summary
- disable the ESCO integration utilities and replace skill normalization with local deduplication
- remove ESCO-driven occupation/skill handling from the wizard and follow-up logic while updating dependent tests
- document that ESCO functionality is turned off and adjust test expectations accordingly

## Testing
- ruff check .
- black .
- mypy .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cd38d9f5808320ba7821ad123cfda7