### PR TITLE
Normalize legacy intake/follow-up aliases to canonical profile paths and add regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Bei neuen oder geänderten Profilfeldern gilt ein **canonical path**-Workflow:
 3. JSON-Konfigurationen (`role_field_map.json`, `critical_fields.json`) dürfen String-Pfade enthalten, werden aber per Contract-Test gegen `ProfilePaths` abgesichert.
 4. Relevante Schema/Model/UI/Export-Stellen gemäß Datenvertrag mitziehen und Tests aktualisieren.
 
+**Migrationshinweis (Legacy Intake/Follow-ups):**
+- `position.context` wird bei Intake-Mapping/Folgefragen auf `position.role_summary` normalisiert.
+- `position.location` wird auf `location.primary_city` normalisiert.
+- Legacy-Felder bleiben nur als Input-Aliases erlaubt; in Wizard/Export/Follow-up-Contracts werden ausschließlich kanonische Keys verwendet.
+
 So bleibt `ProfilePaths` die Single Source of Truth für erlaubte Feldpfade in der Anwendung.
 
 ## LLM- und Responses-Policy

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2026-03-11
 
 ### Changed
+- Intake-/Follow-up-Migration ergänzt: Legacy-Felder `position.context` und `position.location` werden jetzt konsistent auf `position.role_summary` bzw. `location.primary_city` normalisiert; ergänzt durch Regression-Tests für Intake-Prefill, Follow-up-Key-Normalisierung sowie Export-/Generator-Weitergabe (JSON/Markdown/Boolean-Pipeline unverändert kanonisch).
 - Centralized intake-to-profile mapping in extraction orchestration (`wizard/flow.py`) and added robust list normalization (trim/dedup/empty filtering) for responsibilities, skills, tools, and benefits so downstream wizard steps consume clean prefilled values consistently.
 - Added a new `NeedAnalysisEnvelope` shadow contract (model + generated schema + profile→envelope adapter) and synced it into wizard session state as `profile_envelope_data` in parallel to the existing `NeedAnalysisProfile`; added contract tests for required structure and adapter backward-compatibility.
 - Added `ProfilePaths.all_values()` as canonical field-path helper and introduced contract coverage that validates path strings from `role_field_map.json`, `critical_fields.json`, and Python source references (including `question_logic.py`) against the `ProfilePaths` registry.

--- a/tests/test_followup_parsing.py
+++ b/tests/test_followup_parsing.py
@@ -93,6 +93,31 @@ def test_parse_followups_deduplicates_fields() -> None:
     assert questions[0]["question"] == "What is the company name?"
 
 
+def test_parse_followups_normalizes_legacy_field_aliases() -> None:
+    payload = {
+        "questions": [
+            {
+                "field": "position.location",
+                "question": "Where is the role located?",
+                "priority": "normal",
+                "suggestions": ["Berlin"],
+            },
+            {
+                "field": "position.context",
+                "question": "What is the role context?",
+                "priority": "normal",
+                "suggestions": ["Platform team"],
+            },
+        ]
+    }
+
+    result = followups_mod._parse_followup_response(json.dumps(payload))
+
+    assert result.fallback_reason is None
+    fields = [item["field"] for item in result.payload["questions"]]
+    assert fields == ["location.primary_city", "position.role_summary"]
+
+
 def test_prioritize_followups_prefers_low_confidence_critical_fields() -> None:
     profile = {
         "company": {"name": "ACME"},

--- a/tests/test_generator_v2_payload.py
+++ b/tests/test_generator_v2_payload.py
@@ -106,3 +106,46 @@ def test_interview_generator_adds_warning_for_blocking_proposed(monkeypatch) -> 
     user_message = captured["messages"][1]["content"]
     assert "d-int" in user_message
     assert "warnings" in user_message
+
+
+def test_job_ad_generator_uses_confirmed_location_decision_for_markdown_export(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_call(*_args: Any, **kwargs: Any) -> _FakeResult:
+        captured["messages"] = kwargs["messages"]
+        return _FakeResult(content=_job_ad_payload())
+
+    monkeypatch.setattr(job_ad_mod, "call_chat_api", fake_call)
+    monkeypatch.setattr(job_ad_mod, "get_model_for", lambda *_, **__: "model-job-ad")
+
+    job_ad_mod.generate_job_ad(
+        {
+            "role": {"work_location": "Berlin"},
+            "open_decisions": [
+                {
+                    "decision_id": "loc-proposed",
+                    "title": "Work location",
+                    "field_path": "role.work_location",
+                    "decision_state": "proposed",
+                    "proposed_value": "Munich",
+                    "rationale": "pending",
+                    "blocking_exports": ["job_ad_markdown"],
+                },
+                {
+                    "decision_id": "loc-confirmed",
+                    "title": "Work location",
+                    "field_path": "role.work_location",
+                    "decision_state": "confirmed",
+                    "proposed_value": "Hamburg",
+                    "rationale": "approved",
+                    "blocking_exports": ["job_ad_markdown"],
+                },
+            ],
+            "warnings": [],
+        },
+        "en",
+    )
+
+    user_message = captured["messages"][1]["content"]
+    assert "Hamburg" in user_message
+    assert "Munich" not in user_message

--- a/tests/test_v2_export_payload.py
+++ b/tests/test_v2_export_payload.py
@@ -50,3 +50,26 @@ def test_build_v2_export_payload_includes_confirmed_decision() -> None:
     assert len(export["open_decisions"]) == 1
     assert export["open_decisions"][0]["decision_state"] == "confirmed"
     assert export["warnings"] == []
+
+
+def test_build_v2_export_payload_applies_confirmed_location_for_markdown() -> None:
+    payload = {
+        "role": {"work_location": "Berlin"},
+        "open_decisions": [
+            {
+                "decision_id": "d-loc",
+                "title": "Work location",
+                "field_path": "role.work_location",
+                "decision_state": "confirmed",
+                "proposed_value": "Hamburg",
+                "rationale": "approved",
+                "blocking_exports": ["job_ad_markdown"],
+            }
+        ],
+        "warnings": [],
+    }
+
+    export = build_v2_export_payload(payload, artifact_key="job_ad_markdown")
+
+    assert export["role"]["work_location"] == "Hamburg"
+    assert export["warnings"] == []

--- a/tests/test_wizard_source.py
+++ b/tests/test_wizard_source.py
@@ -1337,6 +1337,10 @@ def test_apply_intake_profile_mapping_normalizes_target_paths() -> None:
     mapped = _apply_intake_profile_mapping(
         {
             "title": " Senior Data Engineer ",
+            "position": {
+                "context": " Build modern data products ",
+                "location": " Hamburg ",
+            },
             "company_name": " ACME GmbH ",
             "city": " Berlin ",
             "country": " Germany ",
@@ -1349,6 +1353,7 @@ def test_apply_intake_profile_mapping_normalizes_target_paths() -> None:
     )
 
     assert mapped["position"]["job_title"] == "Senior Data Engineer"
+    assert mapped["position"]["role_summary"] == "Build modern data products"
     assert mapped["company"]["name"] == "ACME GmbH"
     assert mapped["location"]["primary_city"] == "Berlin"
     assert mapped["location"]["country"] == "Germany"

--- a/wizard/flow.py
+++ b/wizard/flow.py
@@ -4621,6 +4621,16 @@ def _apply_intake_profile_mapping(extracted_data: Mapping[str, Any]) -> dict[str
     scalar_targets: tuple[tuple[str, tuple[str, ...]], ...] = (
         ("position.job_title", ("position.job_title", "position.title", "role.title", "job_title", "title")),
         (
+            "position.role_summary",
+            (
+                "position.role_summary",
+                "position.context",
+                "position.description",
+                "role.summary",
+                "context",
+            ),
+        ),
+        (
             "company.name",
             (
                 "company.name",
@@ -4634,6 +4644,8 @@ def _apply_intake_profile_mapping(extracted_data: Mapping[str, Any]) -> dict[str
             (
                 "location.primary_city",
                 "location.city",
+                "position.location",
+                "role.work_location",
                 "primary_city",
                 "city",
             ),


### PR DESCRIPTION
### Motivation

- Ensure legacy intake and follow-up alias fields are consistently mapped into the canonical profile contract so downstream UI, follow-ups and exports do not reference non-canonical keys.

### Description

- Extend intake canonicalization in `wizard/flow.py` to map legacy scalar sources into canonical targets, including `position.context` → `position.role_summary` and `position.location` / `role.work_location` → `location.primary_city`.
- Add regression tests covering intake prefill mapping, follow-up parser normalization, V2 export propagation and job-ad generator payload behavior via `tests/test_wizard_source.py`, `tests/test_followup_parsing.py`, `tests/test_v2_export_payload.py` and `tests/test_generator_v2_payload.py`.
- Document the migration/mapping decision in `README.md` and add a changelog note in `docs/CHANGELOG.md` to record the alias→canonical normalization policy.

### Testing

- Ran `ruff format .` and `ruff check .`, both passed.
- Ran `mypy --config-file pyproject.toml .`, which succeeded after invoking with the repository target.
- Executed targeted pytest assertions for the newly added/modified tests with `pytest -q tests/test_wizard_source.py::test_apply_intake_profile_mapping_normalizes_target_paths tests/test_followup_parsing.py::test_parse_followups_normalizes_legacy_field_aliases tests/test_v2_export_payload.py::test_build_v2_export_payload_applies_confirmed_location_for_markdown tests/test_generator_v2_payload.py::test_job_ad_generator_uses_confirmed_location_decision_for_markdown_export tests/test_boolean_search.py::test_build_boolean_search_applies_aliases`, and all targeted tests passed.
- A full non-integration `pytest -q -m "not integration"` run previously surfaced unrelated failures in other areas; to validate this change scope the above focused test set was used and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d57da9c883208b9a67bf535ab5c6)